### PR TITLE
also copy includes for plat-orion (see commit 9eac6d0a in linux-stable) 

### DIFF
--- a/core/linux/PKGBUILD
+++ b/core/linux/PKGBUILD
@@ -184,6 +184,8 @@ package_linux-headers() {
   cp -a arch/$KARCH/include ${pkgdir}/usr/src/linux-${_kernver}/arch/$KARCH/
   mkdir -p ${pkgdir}/usr/src/linux-${_kernver}/arch/$KARCH/mach-kirkwood   
   cp -a arch/$KARCH/mach-kirkwood/include ${pkgdir}/usr/src/linux-${_kernver}/arch/$KARCH/mach-kirkwood/
+  cp -a arch/$KARCH/plat-orion/include ${pkgdir}/usr/src/linux-${_kernver}/arch/$KARCH/plat-orion/
+
 
   # copy files necessary for later builds, like nvidia and vmware
   cp Module.symvers "${pkgdir}/usr/src/linux-${_kernver}"


### PR DESCRIPTION
otherwise there are build errors because of missing plat/gpio.h when you try to build e.g. v4l modules
