### PR TITLE
Copy mach-bcm2708 headers, not mach-kirkwood

### DIFF
--- a/core/linux-raspberrypi/PKGBUILD
+++ b/core/linux-raspberrypi/PKGBUILD
@@ -164,8 +164,8 @@ package_linux-headers-raspberrypi() {
    # copy arch includes for external modules
   mkdir -p ${pkgdir}/usr/src/linux-${_kernver}/arch/$KARCH
   cp -a arch/$KARCH/include ${pkgdir}/usr/src/linux-${_kernver}/arch/$KARCH/
-  mkdir -p ${pkgdir}/usr/src/linux-${_kernver}/arch/$KARCH/mach-kirkwood   
-  cp -a arch/$KARCH/mach-kirkwood/include ${pkgdir}/usr/src/linux-${_kernver}/arch/$KARCH/mach-kirkwood/
+  mkdir -p ${pkgdir}/usr/src/linux-${_kernver}/arch/$KARCH/mach-bcm2708   
+  cp -a arch/$KARCH/mach-bcm2708/include ${pkgdir}/usr/src/linux-${_kernver}/arch/$KARCH/mach-bcm2708/
 
   # copy files necessary for later builds, like nvidia and vmware
   cp Module.symvers "${pkgdir}/usr/src/linux-${_kernver}"


### PR DESCRIPTION
The Raspberry Pi uses mach-bcm2708 that's why mach-kirkwood is useless.
