### PR TITLE
raspberrypi-firmware: New version available and made it compatible with the ArchLinux VCS PKGBUILD Guidelines

### DIFF
--- a/alarm/raspberrypi-firmware/PKGBUILD
+++ b/alarm/raspberrypi-firmware/PKGBUILD
@@ -11,8 +11,24 @@ makedepends=('git')
 license=('custom')
 options=(!strip)
 
+_gitroot=git://github.com/raspberrypi/firmware.git
+_gitname=firmware
+
+build() {
+  msg "Connecting to GIT server...."
+
+  if [[ -d "$_gitname" ]]; then
+    cd "$_gitname" && git pull origin
+    msg "The local files are updated."
+  else
+    git clone --depth 1 "$_gitroot" "$_gitname"
+  fi
+
+  msg "GIT checkout done or server timeout"
+
+  rm -f "${srcdir}"/firmware/boot/kernel.img
+}
+
 package() {
-  git clone --depth 1 git://github.com/raspberrypi/firmware.git
-  rm "${srcdir}"/firmware/boot/kernel.img
   cp -R "${srcdir}"/firmware/{boot,opt} "${pkgdir}"
 }


### PR DESCRIPTION
As the title says: They updated the firmware files yesterday and I made the package compatible with the ArchLinux VCS PKGBUILD Guidelines

https://github.com/raspberrypi/firmware/commits/master
https://wiki.archlinux.org/index.php/VCS_PKGBUILD_Guidelines
