### PR TITLE
PKGBUILD for xbmc-rbp-git and raspberrypi-firmware update

### DIFF
--- a/alarm/raspberrypi-firmware/PKGBUILD
+++ b/alarm/raspberrypi-firmware/PKGBUILD
@@ -1,7 +1,7 @@
 buildarch=2
 
 pkgname=raspberrypi-firmware
-pkgver=20120531
+pkgver=20120606
 pkgrel=1
 pkgdesc="Firmware files for Raspberry Pi"
 arch=('any')
@@ -9,6 +9,7 @@ url="https://github.com/raspberrypi/firmware"
 makedepends=('git')
 license=('custom')
 options=(!strip)
+provides=('libegl' 'libgles')
 
 _gitroot=git://github.com/raspberrypi/firmware.git
 _gitname=firmware
@@ -29,5 +30,7 @@ build() {
 }
 
 package() {
+  mkdir -p "${pkgdir}"/etc/ld.so.conf.d/
+  echo "/opt/vc/lib/" > "${pkgdir}"/etc/ld.so.conf.d/raspberrypi-firmware.conf
   cp -R "${srcdir}"/firmware/{boot,opt} "${pkgdir}"
 }

--- a/alarm/xbmc-rbp-git/PKGBUILD
+++ b/alarm/xbmc-rbp-git/PKGBUILD
@@ -1,0 +1,91 @@
+# Contributor: tgc <tomasgroth AT yahoo dk>
+#
+pkgname=xbmc-rbp-git
+pkgver=20120606
+pkgrel=1
+pkgdesc="A software media player and entertainment hub for digital media"
+arch=('arm')
+url="http://xbmc.org"
+license=('GPL' 'custom')
+depends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libpng' 'libcdio' 'yajl' 'libmysqlclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd' 'python2' 'libass' 'libmpeg2' 'libmad' 'libmodplug' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray' 'libnfs' 'afpfs-ng' 'libshairport' 'avahi' 'bluez' 'jasper' 'tinyxml')
+makedepends=('boost' 'cmake' 'gperf' 'nasm' 'zip' 'libcec' 'udisks' 'upower' 'bluez')
+optdepends=(
+  'libcec: support for Pulse-Eight USB-CEC adapter'
+  'lirc: remote controller support'
+  'udisks: automount external drives'
+  'upower: used to trigger suspend functionality'
+  'unrar: access compressed files without unpacking them'
+)
+source=()
+
+sha256sums=()
+
+_gitroot="git://github.com/xbmc"
+_gitname="xbmc-rbp"
+
+_prefix=/usr
+
+build() {
+  cd "${srcdir}"
+
+  msg2 "Connecting to GIT server..."
+  if [[ -d "${_gitname}" ]]; then
+    cd "${_gitname}" && git pull origin
+    msg2 "The local files are updated."
+  else
+    git clone "${_gitroot}/${_gitname}"
+  fi
+  msg2 "GIT checkout done or server timeout."
+
+  cd "${srcdir}/${_gitname}"
+
+  # fix lsb_release dependency
+  sed -i -e 's:/usr/bin/lsb_release -d:cat /etc/arch-release:' xbmc/utils/SystemInfo.cpp
+
+  # fix sse2 compiler flags
+  sed -i -e 's/-DSQUISH_USE_SSE=2 -msse2//g' lib/libsquish/Makefile.in
+
+  # Bootstrapping XBMC
+  ./bootstrap
+
+  # Configuring XBMC
+  export PYTHON_VERSION=2  # external python v2
+  export CFLAGS="$CFLAGS -I/opt/vc/include/ -I/opt/vc/include/IL"
+  export CXXFLAGS="$CXXFLAGS -I/opt/vc/include/ -I/opt/vc/include/IL"
+  export LDFLAGS="$LDFLAGS -L/opt/vc/lib"
+  export MAKEFLAGS="-j1"
+  ./configure --prefix=$_prefix --exec-prefix=$_prefix  \
+  --enable-gles --disable-sdl --disable-x11 --disable-xrandr --disable-openmax \
+  --disable-optical-drive --disable-dvdcss --disable-joystick --disable-debug \
+  --disable-crystalhd --disable-vtbdecoder --disable-vaapi --disable-vdpau \
+  --disable-pulse --disable-projectm --with-platform=raspberry-pi --disable-optimizations
+
+  make
+}
+
+package() {
+  cd "${srcdir}/${_gitname}"
+  # Running make install
+  make DESTDIR="${pkgdir}" install
+
+  # run feh with python2
+  sed -i -e 's/python/python2/g' ${pkgdir}${_prefix}/bin/xbmc
+
+  # Remove checks that doesn't apply to the raspberry pi
+  head -n 171 "${pkgdir}${_prefix}/share/xbmc/FEH.py" > "${pkgdir}${_prefix}/share/xbmc/FEH.py.new"
+  mv "${pkgdir}${_prefix}/share/xbmc/FEH.py.new"  "${pkgdir}${_prefix}/share/xbmc/FEH.py"
+
+  # lsb_release fix
+  sed -i -e 's/which lsb_release > \/dev\/null/\[ -f \/etc\/arch-release ]/g' "${pkgdir}${_prefix}/bin/xbmc"
+  sed -i -e "s/lsb_release -a 2> \/dev\/null | sed -e 's\/\^\/    \/'/cat \/etc\/arch-release/g" "${pkgdir}${_prefix}/bin/xbmc"
+
+  # Tools
+  install -D -m 0755 "${srcdir}/${_gitname}/tools/TexturePacker/TexturePacker" "${pkgdir}${_prefix}/share/xbmc/"
+
+  # Licenses
+  install -d -m 0755 "${pkgdir}${_prefix}/share/licenses/${pkgname}"
+  for licensef in LICENSE.GPL copying.txt; do
+    mv "${pkgdir}${_prefix}/share/doc/xbmc/${licensef}" "${pkgdir}${_prefix}/share/licenses/${pkgname}"
+  done
+}
+# vim:set ts=2 sw=2 et:


### PR DESCRIPTION
- Added libegl and libgles as provides for raspberry pi firmware PKGBUILD
- Also added raspberry pi firmware path to lib path file (/etc/ld.so.conf.d/raspberrypi-firmware.conf).
- Added PKGBUILD for xbmc-rbp-git
