### PR TITLE
Update linux-kirkwood to 3.4.6

### DIFF
--- a/core/linux-kirkwood/PKGBUILD
+++ b/core/linux-kirkwood/PKGBUILD
@@ -7,7 +7,7 @@ pkgbase=linux-kirkwood
 pkgname=('linux-kirkwood' 'linux-headers-kirkwood')
 #pkgname=linux-test       # Build kernel with a different name
 _kernelname=${pkgname#linux}
-_basekernel=3.4.5
+_basekernel=3.4.6
 pkgver=${_basekernel}
 pkgrel=0
 cryptover=1.4
@@ -25,12 +25,12 @@ source=("ftp://ftp.kernel.org/pub/linux/kernel/v3.x/linux-${_basekernel}.tar.bz2
         'change-default-console-loglevel.patch'
         'usb-add-reset-resume-quirk-for-several-webcams.patch'
         "http://download.gna.org/cryptodev-linux/cryptodev-linux-${cryptover}.tar.gz")
-md5sums=('59a21893b7a410a83328d38e094cd386'
+md5sums=('e81d235d91289e612f48718b459b9039'
          'cb59c253388108d0a1d4ab33167847e1'
          'f5d3635da03cb45904bedd69b47133de'
          '852ba24ebd20ca85f8bbee03243ccf91'
          '4cf4bf5db2acb94a5b73fb7e2047c369'
-         'c4cec78edaae21d7faab6fc75b1101dd'
+         '22b65429bf6ee4862d4b91f0c0fbfe8a'
          '9d3c56a4b999c8bfbd4018089a62f662'
          'd00814b57448895e65fbbc800e8a58ba'
          '7b0ac1c0a88d8fbe7316db02f21666e6')

--- a/core/linux-kirkwood/linux-kirkwood.install
+++ b/core/linux-kirkwood/linux-kirkwood.install
@@ -2,7 +2,7 @@
 # arg 2:  the old package version
 
 KERNEL_NAME=-kirkwood
-KERNEL_VERSION=3.4.5-0-ARCH
+KERNEL_VERSION=3.4.6-0-ARCH
 
 post_install () {
   # updating module dependencies


### PR DESCRIPTION
Now builds off linux-stable which is at 3.4.6
Corrects md5sum of mach-types
