### PR TITLE
core/linux-raspberrypi: we don't use mkinitcpio

### DIFF
--- a/core/linux-raspberrypi/PKGBUILD
+++ b/core/linux-raspberrypi/PKGBUILD
@@ -88,12 +88,11 @@ build() {
 
 package_linux-raspberrypi() {
   pkgdesc="The Linux Kernel and modules for Raspberry Pi"
-  depends=('coreutils' 'linux-firmware' 'module-init-tools>=3.16' 'mkinitcpio>=0.7')
+  depends=('coreutils' 'linux-firmware' 'module-init-tools>=3.16')
   optdepends=('crda: to set the correct wireless channels of your country')
   provides=('kernel26-raspberrypi' 'linux=${pkgver}')
   conflicts=('kernel26' 'linux')
   replaces=('kernel26')
-  backup=("etc/mkinitcpio.d/${pkgname}.preset")
   install=${pkgname}.install
 
   cd "${srcdir}/linux"


### PR DESCRIPTION
We don't use mkinitcpio. It's just wasted space.
