### PR TITLE
linux-raspberrypi: allow to autoinstall modules via dkms

### DIFF
--- a/core/linux-raspberrypi/linux-raspberrypi.install
+++ b/core/linux-raspberrypi/linux-raspberrypi.install
@@ -8,6 +8,11 @@ post_install () {
   # updating module dependencies
   echo ">>> Updating module dependencies. Please wait ..."
   depmod ${KERNEL_VERSION}
+  # give use the ability to automatically and install modules via dkms
+  if [ -x /usr/sbin/dkms ]; then
+    echo ">>> Found DKMS. Running dkms autoinstall. Please wait ..."
+    dkms autoinstall -k ${KERNEL_VERSION}
+  fi
 }
 
 post_upgrade() {
@@ -21,4 +26,9 @@ post_upgrade() {
   # updating module dependencies
   echo ">>> Updating module dependencies. Please wait ..."
   depmod ${KERNEL_VERSION}
+  # give use the ability to automatically and install modules via dkms
+  if [ -x /usr/sbin/dkms ]; then
+    echo ">>> Found DKMS. Running dkms autoinstall. Please wait ..."
+    dkms autoinstall -k ${KERNEL_VERSION}
+  fi
 }


### PR DESCRIPTION
This would allow us to automatically build and install modules via dkms autoinstall during kernel updates. Much more comfortable than doing it manually.

Normally I would recommend to use a mkinitcpio hook for this but we don't use it. So I think this is the best solution.
