### PR TITLE
core/linux-raspberrypi: corrected md5sums

### DIFF
--- a/core/linux-raspberrypi/PKGBUILD
+++ b/core/linux-raspberrypi/PKGBUILD
@@ -23,7 +23,6 @@ source=('config'
 md5sums=('7679418d6e4e3f3276132b30a5be851f'
          '9d3c56a4b999c8bfbd4018089a62f662'
          'd00814b57448895e65fbbc800e8a58ba'
-         '6e7667c6c6348bfeca22eaaa05462d62'
          '9335d1263fd426215db69841a380ea26'
          'a00e424e2fbb8c5a5f77ba2c4871bed4'
          '2f82dbe5752af65ff409d737caf11954')


### PR DESCRIPTION
It's bad when integrity checks fail :)
