### PR TITLE
core/glibc: move /lib to /usr/lib

### DIFF
--- a/core/glibc/PKGBUILD
+++ b/core/glibc/PKGBUILD
@@ -15,7 +15,7 @@ noautobuild=1
 
 pkgname=glibc
 pkgver=2.16.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU C Library"
 arch=('i686' 'x86_64')
 url="http://www.gnu.org/software/libc"
@@ -117,6 +117,8 @@ check() {
 package() {
   cd ${srcdir}/glibc-build
 
+  ln -s usr/lib ${pkgdir}/lib
+
   install -dm755 ${pkgdir}/etc
   touch ${pkgdir}/etc/ld.so.conf
 
@@ -144,11 +146,11 @@ package() {
   if [[ ${CARCH} = "x86_64" ]]; then
     # fix paths and compliance with binary blobs...
     sed -i '/RTLDLIST/s%lib64%lib%' ${pkgdir}/usr/bin/ldd
-    ln -s /lib ${pkgdir}/lib64
+    ln -s usr/lib ${pkgdir}/lib64
   fi
 
   # ALARM: symlink ld-linux.so.3 for hard-float
-  [[ $CARCH == "armv7h" ]] && ln -s /lib/ld-2.16.so ${pkgdir}/lib/ld-linux.so.3
+  [[ $CARCH == "armv7h" ]] && ln -s /usr/lib/ld-2.16.so ${pkgdir}/usr/lib/ld-linux.so.3
 
   # Do not strip the following files for improved debugging support
   # ("improved" as in not breaking gdb and valgrind...):
@@ -167,9 +169,9 @@ package() {
 
   strip $STRIP_STATIC usr/lib/*.a
 
-  strip $STRIP_SHARED lib/{libanl,libBrokenLocale,libcidn,libcrypt}-*.so \
-                      lib/libnss_{compat,db,dns,files,hesiod,nis,nisplus}-*.so \
-                      lib/{libdl,libm,libnsl,libresolv,librt,libutil}-*.so \
-                      lib/{libmemusage,libpcprofile,libSegFault}.so \
+  strip $STRIP_SHARED usr/lib/{libanl,libBrokenLocale,libcidn,libcrypt}-*.so \
+                      usr/lib/libnss_{compat,db,dns,files,hesiod,nis,nisplus}-*.so \
+                      usr/lib/{libdl,libm,libnsl,libresolv,librt,libutil}-*.so \
+                      usr/lib/{libmemusage,libpcprofile,libSegFault}.so \
                       usr/lib/{pt_chown,{audit,gconv}/*.so}
 }


### PR DESCRIPTION
This makes the /lib -> /usr/lib move.

See this upstream commit: https://projects.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/glibc&id=32282350aa2759b8b9a7ce89266d0c36382be5e0
