### PR TITLE
core/linux-raspberrypi: fix "linux=${pkgver}" in pkginfo

### DIFF
--- a/core/linux-raspberrypi/PKGBUILD
+++ b/core/linux-raspberrypi/PKGBUILD
@@ -90,7 +90,7 @@ package_linux-raspberrypi() {
   pkgdesc="The Linux Kernel and modules for Raspberry Pi"
   depends=('coreutils' 'linux-firmware' 'module-init-tools>=3.16' 'mkinitcpio>=0.7')
   optdepends=('crda: to set the correct wireless channels of your country')
-  provides=('kernel26-raspberrypi' 'linux=${pkgver}')
+  provides=('kernel26-raspberrypi' "linux=${pkgver}")
   conflicts=('kernel26' 'linux')
   replaces=('kernel26')
   backup=("etc/mkinitcpio.d/${pkgname}.preset")
@@ -139,7 +139,7 @@ package_linux-raspberrypi() {
 
 package_linux-headers-raspberrypi() {
   pkgdesc="Header files and scripts for building modules for linux kernel for Raspberry Pi"
-  provides=('kernel26-headers' 'linux-headers=${pkgver}')
+  provides=('kernel26-headers' "linux-headers=${pkgver}")
   conflicts=('kernel26-headers')
   replaces=('kernel26-headers')
 


### PR DESCRIPTION
Using variables within '' was never a good idea :)

raspberrypi ~ # pacman -Qi linux-raspberrypi
[...]
Provides       : kernel26-raspberrypi  linux=${pkgver}

raspberrypi ~ # pacman -Qi linux-headers-raspberrypi
[...]
Provides       : kernel26-headers  linux-headers=${pkgver}
