### PR TITLE
libcec-rpi - libcec with support for raspberry pi

### DIFF
--- a/alarm/libcec-rpi/PKGBUILD
+++ b/alarm/libcec-rpi/PKGBUILD
@@ -1,0 +1,33 @@
+# Contributor: tomasgroth at yahoo.dk
+
+pkgname=libcec-rpi
+pkgver=1.9.0
+pkgrel=1
+pkgdesc="Pulse-Eight's libcec for the Pulse-Eight USB-CEC adapter with support for raspberry pi"
+arch=('armv6h')
+url="https://github.com/Pulse-Eight/libcec"
+license=('GPL')
+depends=('udev' 'lockdev' 'raspberrypi-firmware')
+conflicts=('libcec')
+provides=('libcec')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Pulse-Eight/libcec/tarball/libcec-$pkgver")
+_srcfolder=Pulse-Eight-libcec-217b236
+sha256sums=('93c0c56b446f82ef71499fd88186c7212a92b037cb8a19516140216cc0aae68f')
+options=(!libtool)
+
+build() {
+  mv "$_srcfolder" "$pkgname-$pkgver"
+
+  cd "$pkgname-$pkgver"
+  autoreconf -vif
+  ./configure --prefix=/usr --enable-rpi \
+   --with-rpi-include-path="/opt/vc/include" \
+   --with-rpi-lib-path="/opt/vc/lib" 
+  make
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+  make DESTDIR="$pkgdir" install
+}
+

--- a/aur/xbmc-rbp-git/PKGBUILD
+++ b/aur/xbmc-rbp-git/PKGBUILD
@@ -10,7 +10,7 @@ arch=('armv6h')
 url="http://xbmc.org"
 license=('GPL' 'custom')
 depends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libpng' 'libcdio' 'yajl' 'libmysqlclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd' 'python2' 'libass' 'libmpeg2' 'libmad' 'libmodplug' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray' 'libnfs' 'afpfs-ng' 'libshairport' 'avahi' 'bluez' 'jasper' 'tinyxml' 'raspberrypi-firmware' 'sdl_image' 'libcec' 'libplist')
-makedepends=('boost' 'cmake' 'gperf' 'nasm' 'zip' 'libcec' 'udisks' 'upower' 'bluez' 'git' 'autoconf')
+makedepends=('boost' 'cmake' 'gperf' 'nasm' 'zip' 'libcec-rpi' 'udisks' 'upower' 'bluez' 'git' 'autoconf')
 optdepends=(
   'lirc: remote controller support'
   'udisks: automount external drives'


### PR DESCRIPTION
Added libcec-rpi, which has support for Raspberry Pi compiled in, and added the package as dependency for xbmc-rbp-git.
