### PR TITLE
libcec-cubox fix

### DIFF
--- a/alarm/libcec-cubox/PKGBUILD
+++ b/alarm/libcec-cubox/PKGBUILD
@@ -23,7 +23,7 @@ options=(!libtool)
 build() {
   mv "$_srcfolder" "$pkgname-$pkgver"
 
-  _kernel_release="$(pacman -Q linux-headers-cubox | grep -Eo "[^\ ]+$")-ARCH"
+  _kernel_release="$(pacman -Q linux-headers-cubox | grep -Eo "[^\ ]+$")-ARCH+"
 
   cd "$pkgname-$pkgver"
   patch -p1 -i "${srcdir}/${source[1]}"


### PR DESCRIPTION
Just notice libcec-cubox never made it into the repos. Fixed the path, builds fine now.
