### PR TITLE
Apply upsteam patch for musb usb host oopse

### DIFF
--- a/core/linux-am33x/PKGBUILD
+++ b/core/linux-am33x/PKGBUILD
@@ -13,7 +13,7 @@ pkgname=('linux-am33x' 'linux-headers-am33x')
 _kernelname=${pkgname#linux}
 _basekernel=3.2
 pkgver=${_basekernel}.32
-pkgrel=1
+pkgrel=2
 arch=('arm')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -24,12 +24,14 @@ source=("ftp://ftp.kernel.org/pub/linux/kernel/v3.x/linux-${_basekernel}.tar.xz"
         "rcn-ee.diff.gz::http://rcn-ee.net/deb/sid-armhf/v3.2.32-psp25/patch-3.2-psp25.diff.gz"
         'config'
         'change-default-console-loglevel.patch'
-        'aufs3-3.2.patch.gz')
+        'aufs3-3.2.patch.gz'
+        'musb_start_urb-oopse.patch')
 md5sums=('364066fa18767ec0ae5f4e4abcf9dc51'
          'db000f54f7c3d1598416cacf770b3f18'
          '3b039b51889e43bd410d596bda3f0d9b'
          '9d3c56a4b999c8bfbd4018089a62f662'
-         '6ea7b005a74be27abb072c934ef15a2c')
+         '6ea7b005a74be27abb072c934ef15a2c'
+         'd57e095fd462f0b915e5f4f7086a67d1')
 
 build() {
   cd "${srcdir}/linux-${_basekernel}"
@@ -47,6 +49,7 @@ build() {
   # ALARM patches
   patch -Np1 -i "${srcdir}/rcn-ee.diff"
   patch -Np1 -i "${srcdir}/aufs3-3.2.patch"
+  patch -Np1 -i "${srcdir}/musb_start_urb-oopse.patch"
 
   cat "${srcdir}/config" > ./.config
 

--- a/core/linux-am33x/musb_start_urb-oopse.patch
+++ b/core/linux-am33x/musb_start_urb-oopse.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/usb/musb/musb_host.c b/drivers/usb/musb/musb_host.c
+index 4bb717d..1ae378d 100644
+--- a/drivers/usb/musb/musb_host.c
++++ b/drivers/usb/musb/musb_host.c
+@@ -2049,7 +2049,7 @@ static int musb_urb_enqueue(
+ 	 * we only have work to do in the former case.
+ 	 */
+ 	spin_lock_irqsave(&musb->lock, flags);
+-	if (hep->hcpriv) {
++	if (hep->hcpriv || !next_urb(qh)) {
+ 		/* some concurrent activity submitted another urb to hep...
+ 		 * odd, rare, error prone, but legal.
+ 		 */


### PR DESCRIPTION
Upsteam patch information:

```
https://github.com/torvalds/linux/commit/3067779b1566ae5fb6af40f03ae874ac47035523
```
