### PR TITLE
alarm/xbmc-cubox-git: build fix.

### DIFF
--- a/alarm/xbmc-cubox-git/PKGBUILD
+++ b/alarm/xbmc-cubox-git/PKGBUILD
@@ -2,9 +2,9 @@
 buildarch=4
 
 pkgname="xbmc-cubox-git"
-pkgver=20121106
+pkgver=20121112
 pkgrel=1
-pkgdesc="A software media player and entertainment hub for digital media"
+pkgdesc="A software media player and entertainment hub for digital media for the Cubox"
 arch=("armv7h")
 url="http://xbmc.org"
 license=("GPL" "LGPL")
@@ -28,13 +28,11 @@ replaces=("marvell-xbmc-git")
 source=("https://dl.dropbox.com/u/38673799/XbmcCuBoxPatches-Rev10.tar.xz" \
 	"http://alunamation.com/archlinux/arm/AdditionalXbmcCuBoxPatches-Rev10.1.tar.xz" \
 	"xbmc.service" \
-	"xbmc.install" \
-	"https://archvdr.svn.sourceforge.net/svnroot/archvdr/trunk/archvdr/xbmc-git/pulse_fix.patch")
+	"xbmc.install")
 md5sums=("55813f68e1ab05405451f9791e59e68b" \
 	"966deb0b02155153d72445b461b3e952" \
 	"f5d227faaac16d08035e0dc849649cb5" \
-	"46db2069b75b23809bd7c760650618dd" \
-	"b09721b962e591abb3f4b39a641ded15")
+	"46db2069b75b23809bd7c760650618dd")
 install="xbmc.install"
 
 _gitroot="git://github.com/xbmc/xbmc.git"
@@ -135,7 +133,7 @@ build() {
 		patch -p1 -i "${srcdir}/XbmcCuBoxPatches-Rev10/${_patch}"
 	done
 
-	for _patch in "${srcdir}"/AdditionalXbmcCuBoxPatches-Rev10.1/* "${srcdir}/pulse_fix.patch"; do
+	for _patch in "${srcdir}"/AdditionalXbmcCuBoxPatches-Rev10.1/*; do
 		patch -p1 -i "${_patch}"
 	done
 


### PR DESCRIPTION
I've removed the patch (that's no longer needed and was) causing the build to fail (reported in #298).
