### PR TITLE
Cubox: vmeta 667clk service

### DIFF
--- a/alarm/marvell-libvmeta/PKGBUILD
+++ b/alarm/marvell-libvmeta/PKGBUILD
@@ -6,13 +6,15 @@ buildarch=4
 
 pkgname="marvell-libvmeta"
 pkgver=1.0
-pkgrel=2
+pkgrel=3
 arch=('armv7h')
 url="http://archlinuxarm.org"
 depends=('marvell-libbmm')
 license=('Proprietary')
 source=("http://archlinuxarm.org/builder/src/marvell-libvmeta-1.0.tar.gz"
-        "http://archlinuxarm.org/builder/src/vmeta-hardfp.tar.xz")
+        "http://archlinuxarm.org/builder/src/vmeta-hardfp.tar.xz"
+        "vmeta-clk@667.service")
+optdepends=("systemd: autostart vmeta-clk@667")
 
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
@@ -28,7 +30,11 @@ package() {
   cp *.h "${pkgdir}/usr/include"
 
   cp "${srcdir}"/vmeta-hardfp/* "${pkgdir}/usr/lib"
+
+  install -Dm0644 "${srcdir}/vmeta-clk@667.service" \
+    "${pkgdir}/usr/lib/systemd/system/vmeta-clk@667.service"
 }
 
 md5sums=('a42e3d010a3fd4936aea1224e2778b3d'
-         '30eb47cd675c81c4e6ee0858d1fbc3a7')
+         '30eb47cd675c81c4e6ee0858d1fbc3a7'
+         'b0ed087d03ffb157441eab331acd4397')

--- a/alarm/marvell-libvmeta/vmeta-clk@667.service
+++ b/alarm/marvell-libvmeta/vmeta-clk@667.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Set vmeta clock to %I
+ConditionFileIsExecutable=/bin/sh
+ConditionPathIsReadWrite=/sys/devices/platform/dove_clocks_sysfs.0/vmeta
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c "echo %I000000 > /sys/devices/platform/dove_clocks_sysfs.0/vmeta"
+ExecStop=/bin/sh -c "echo 500000000 > /sys/devices/platform/dove_clocks_sysfs.0/vmeta"
+RemainAfterExit=yes


### PR DESCRIPTION
The added service make it easy to run vmeta at 667clk which gives a little performance boost. The cubox engineers (rabeeh) say is safe and has requested users test (before it becomes the new default).
