### PR TITLE
core/linux-cubox: install SPDIF conf fix

### DIFF
--- a/core/linux-cubox/PKGBUILD
+++ b/core/linux-cubox/PKGBUILD
@@ -151,7 +151,7 @@ package_linux-cubox() {
   mkdir -p "${pkgdir}/usr"
   mv "$pkgdir/lib" "$pkgdir/usr"
 
-  install -Dm644 cp "${srcdir}/Kirkwood_SPDIF.conf" \
+  install -Dm644 "${srcdir}/Kirkwood_SPDIF.conf" \
     "${pkgdir}/usr/share/alsa/cards/Kirkwood_SPDIF.conf"
 }
 


### PR DESCRIPTION
Sorry about that. Thanks for putting up with me kmihelich.
