### PR TITLE
Dont use external ffmpeg in xbmc-rbp-git.

### DIFF
--- a/aur/xbmc-rbp-git/PKGBUILD
+++ b/aur/xbmc-rbp-git/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc="A software media player and entertainment hub for digital media for the
 arch=('armv6h')
 url="http://xbmc.org"
 license=('GPL' 'custom')
-depends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio' 'yajl' 'libmysqlclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd' 'sdl_image' 'python2' 'libass' 'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray' 'libnfs' 'afpfs-ng' 'libshairport' 'avahi' 'bluez' 'tinyxml' 'raspberrypi-firmware' 'libcec-rpi' 'libplist' 'swig' 'taglib' 'ffmpeg')
+depends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio' 'yajl' 'libmysqlclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd' 'sdl_image' 'python2' 'libass' 'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray' 'libnfs' 'afpfs-ng' 'libshairport' 'avahi' 'bluez' 'tinyxml' 'raspberrypi-firmware' 'libcec-rpi' 'libplist' 'swig' 'taglib')
 
 makedepends=('boost' 'cmake' 'gperf' 'nasm' 'zip' 'udisks' 'upower' 'bluez' 'git' 'autoconf' 'openjdk6')
 optdepends=(
@@ -62,7 +62,7 @@ build() {
   --disable-optical-drive --disable-dvdcss --disable-joystick --disable-debug \
   --disable-crystalhd --disable-vtbdecoder --disable-vaapi --disable-vdpau \
   --disable-pulse --disable-projectm --with-platform=raspberry-pi --enable-optimizations \
-  --enable-libcec --enable-player=omxplayer --enable-external-ffmpeg
+  --enable-libcec --enable-player=omxplayer 
 
   make
 }


### PR DESCRIPTION
Since linking ffmpeg takes more memory than is available on my Pi, I haven't been able to complete building this pkg myself, but I expect it to build since there is no other change.
