### PR TITLE
Dont use external ffmpeg in xbmc-rbp-git.

### DIFF
--- a/aur/xbmc-rbp-git/PKGBUILD
+++ b/aur/xbmc-rbp-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Contributor tomasgroth at yahoo.dk
 # Contributor WarheadsSE <max@warheads.net>
 pkgname=xbmc-rbp-git
-pkgver=20121221
+pkgver=20121230
 pkgrel=1
 buildarch=16
 


### PR DESCRIPTION
Now with bumped pkgver.
