### PR TITLE
packman-mirrorlist: don't just overwrite but backup mirrorlist file

### DIFF
--- a/core/pacman-mirrorlist/PKGBUILD
+++ b/core/pacman-mirrorlist/PKGBUILD
@@ -9,6 +9,7 @@ arch=('arm' 'armv7h')
 url="http://www.archlinux.org/pacman/"
 license=('GPL')
 groups=('base')
+backup=(etc/pacman.d/mirrorlist)
 source=(mirrorlist)
 md5sums=('9c41e9500145567e64db78a77abbee43')
 


### PR DESCRIPTION
People can have their own settings, if they don't want to use
the GeoIP-decided servers. Don't just lose those, but back up
properly if need.
