### PR TITLE
Add package alarm/libbcm2835 for armv6h

### DIFF
--- a/alarm/libbcm2835/PKGBUILD
+++ b/alarm/libbcm2835/PKGBUILD
@@ -1,0 +1,30 @@
+# Maintainer: <nico.nell@gmail.com>
+
+buildarch=16
+
+_pkgbasename=bcm2835
+pkgname=libbcm2835
+pkgver=1.15
+pkgrel=1 
+pkgdesc="C library for Broadcom BCM 2835 as used in Raspberry Pi"
+url="http://www.open.com.au/mikem/bcm2835/"
+arch=('armv6h')
+license=('GPL')
+depends=()
+makedepends=()
+conflicts=()
+replaces=()
+backup=()
+source=(http://www.open.com.au/mikem/${_pkgbasename}/${_pkgbasename}-${pkgver}.tar.gz)
+md5sums=('49bd399cf085111fd894635ccea060bc')
+
+build() {
+  cd ${srcdir}/${_pkgbasename}-${pkgver}
+  ./configure --prefix=/usr
+  make
+}
+
+package() {
+  cd ${srcdir}/${_pkgbasename}-${pkgver} 
+  make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
I've added a C library specific to the Raspberry Pi that allows users to access GPIO and SPI functionality. I built and installed this package on a raspberry pi today using the PKGBUILD that I include in this commit.

I've added buildarch=16 so that the package should only build for armv6h. 

I have tried to copy the style of PKGBUILDs I've seen throughout this repo. If there is anything I can do to improve it let me know and I'll make another commit.
