### PR TITLE
Bump alarm/libbcm2835 to version 1.17

### DIFF
--- a/alarm/libbcm2835/PKGBUILD
+++ b/alarm/libbcm2835/PKGBUILD
@@ -4,7 +4,7 @@ buildarch=16
 
 _pkgbasename=bcm2835
 pkgname=libbcm2835
-pkgver=1.16
+pkgver=1.17
 pkgrel=1 
 pkgdesc="C library for Broadcom BCM 2835 as used in Raspberry Pi"
 url="http://www.open.com.au/mikem/bcm2835/"
@@ -16,7 +16,7 @@ conflicts=()
 replaces=()
 backup=()
 source=(http://www.open.com.au/mikem/${_pkgbasename}/${_pkgbasename}-${pkgver}.tar.gz)
-md5sums=('0c90dcf51cbcd64981179eaf998299b5')
+md5sums=('5a910d7680edf3ac9358f23e8ee4b353')
 
 build() {
   cd ${srcdir}/${_pkgbasename}-${pkgver}


### PR DESCRIPTION
Built and installed on a raspberry pi today.
