### PR TITLE
Update core/linux-kirkwood to 3.7.3

### DIFF
--- a/core/linux-kirkwood/PKGBUILD
+++ b/core/linux-kirkwood/PKGBUILD
@@ -7,7 +7,7 @@ pkgbase=linux-kirkwood
 pkgname=('linux-kirkwood' 'linux-headers-kirkwood')
 #pkgname=linux-test       # Build kernel with a different name
 _kernelname=${pkgname#linux}
-_basekernel=3.7.2
+_basekernel=3.7.3
 pkgver=${_basekernel}
 pkgrel=0
 cryptover=1.5
@@ -28,10 +28,10 @@ source=("ftp://ftp.kernel.org/pub/linux/kernel/v3.x/linux-${_basekernel}.tar.bz2
 	"http://algo.ing.unimo.it/people/paolo/disk_sched/patches/3.7.0-v5r1/0002-block-introduce-the-BFQ-v5r1-I-O-sched-for-3.7.patch"
 	'aufs3-3.7.patch.xz')
 
-md5sums=('4ca51d06144cc31bac8468cc8129c734'
+md5sums=('8fb7330345d0e0e3681e928ab334a942'
          '17c0496b7f3031c864f49894702b8911'
          'f5d3635da03cb45904bedd69b47133de'
-         'ce89674fb4e888f5fffb41d5015f9693'
+         '556536312778a6569d2d53de26101d8e'
          '1f8103abb9c79b0745926acddec6ec85'
          '9d3c56a4b999c8bfbd4018089a62f662'
          'd00814b57448895e65fbbc800e8a58ba'
@@ -43,20 +43,21 @@ md5sums=('4ca51d06144cc31bac8468cc8129c734'
 build() {
   cd "${srcdir}/linux-${_basekernel}"
 
-msg "Add the USB_QUIRK_RESET_RESUME for several webcams"
+msg "Patches:"
+msg2 "Add the USB_QUIRK_RESET_RESUME for several webcams"
   # FS#26528
   patch -Np1 -i "${srcdir}/usb-add-reset-resume-quirk-for-several-webcams.patch"
 
-  msg "Add Arch Linux ARM patch for ARMv5te plug computers," 
-msg "requested additional support, mach-types"
+msg2 "Add Arch Linux ARM patch for ARMv5te plug computers," 
+msg2 "requested additional support, mach-types"
   patch -Np1 -i "${srcdir}/archlinuxarm.patch"
   patch -Np1 -i "${srcdir}/support.patch"
   cp "${srcdir}/mach-types" arch/arm/tools
 
-msg "Add AUFS3 patches"
+msg2 "Add AUFS3 patches"
   patch -Np1 -i "${srcdir}/aufs3-3.7.patch"
 
-msg "Add BFQ patches"
+msg2 "Add BFQ patches"
   patch -Np1 -i "${srcdir}/0001-block-cgroups-kconfig-build-bits-for-BFQ-v5r1-3.7.patch"
   patch -Np1 -i "${srcdir}/0002-block-introduce-the-BFQ-v5r1-I-O-sched-for-3.7.patch"
 
@@ -66,6 +67,7 @@ msg "Add BFQ patches"
   # set DEFAULT_CONSOLE_LOGLEVEL to 4 (same value as the 'quiet' kernel param)
   # remove this when a Kconfig knob is made available by upstream
   # (relevant patch sent upstream: https://lkml.org/lkml/2011/7/26/227)
+msg2 "Change default loglevel"
   patch -Np1 -i "${srcdir}/change-default-console-loglevel.patch"
 
   cat "${srcdir}/config" > ./.config
@@ -99,10 +101,10 @@ msg "Add BFQ patches"
 
   #yes "" | make config
 
-msg "building!"
+msg "Building!"
   make ${MAKEFLAGS} uImage modules
 
-msg "build cryptodev module"
+msg "Build cryptodev module"
   cd "${srcdir}/cryptodev-linux-${cryptover}"
   make KERNEL_DIR="${srcdir}/linux-${_basekernel}"
 }

--- a/core/linux-kirkwood/config
+++ b/core/linux-kirkwood/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 3.7.2-0 Kernel Configuration
+# Linux/arm 3.7.3-0 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_SYS_SUPPORTS_APM_EMULATION=y

--- a/core/linux-kirkwood/linux-kirkwood.install
+++ b/core/linux-kirkwood/linux-kirkwood.install
@@ -2,7 +2,7 @@
 # arg 2:  the old package version
 
 KERNEL_NAME=-kirkwood
-KERNEL_VERSION=3.7.2-0-ARCH
+KERNEL_VERSION=3.7.3-0-ARCH
 
 post_install () {
   # updating module dependencies


### PR DESCRIPTION
Many fixes for ext4, usb, ath9, ath5
