### PR TITLE
Disable shared-v8 in community/nodejs/PKGBUILD

### DIFF
--- a/community/nodejs/PKGBUILD
+++ b/community/nodejs/PKGBUILD
@@ -10,7 +10,7 @@ pkgname=nodejs
 pkgver=0.8.18
 pkgrel=1
 pkgdesc='Evented I/O for V8 javascript'
-arch=('i686' 'x86_64' 'arm')
+arch=('i686' 'x86_64' 'arm' 'armv6h')
 url='http://nodejs.org/'
 license=('MIT')
 makedepends=('v8' 'python2')
@@ -70,9 +70,9 @@ fi
     --prefix=/usr \
     --without-snapshot \
     --with-arm-float-abi=$EABI \
-    --shared-v8 \
-    --shared-v8-libpath=/usr/lib \
-    --shared-v8-includes=/usr/include 
+#    --shared-v8 \
+#    --shared-v8-libpath=/usr/lib \
+#    --shared-v8-includes=/usr/include 
 #    --shared-openssl \
 
 


### PR DESCRIPTION
Not using a shared v8 [fixes **this issue**](https://github.com/archlinuxarm/PKGBUILDs/issues/362) (the segmentation faults I get on a Rasberry Pi / ARMv6).
