### PR TITLE
reuse existing git clone

### DIFF
--- a/core/linux-raspberrypi/PKGBUILD
+++ b/core/linux-raspberrypi/PKGBUILD
@@ -24,10 +24,27 @@ source=('config'
         'https://raspy-juice.googlecode.com/svn/trunk/linux-rtc/0001-rtc-pcf8523.patch'
         'https://raspy-juice.googlecode.com/svn/trunk/linux-rtc/0002-pcf8523-i2c-register-dt.patch')
 
-build() {
-  git clone --depth 1 git://github.com/raspberrypi/linux.git
+_gitroot=git://github.com/raspberrypi/linux.git
+_gitname=linux
 
-  cd "${srcdir}/linux"
+build() {
+  cd "$srcdir"
+  msg "Connecting to GIT server...."
+
+  if [[ -d "$_gitname" ]]; then
+    cd "$_gitname"
+    git pull origin
+    git reset --hard
+    git clean -fqd
+    msg "The local files are updated."
+  else
+    git clone --depth 1 "$_gitroot" "$_gitname"
+  fi
+
+  msg "GIT checkout done or server timeout"
+  msg "Starting build..."
+
+  cd "$srcdir/$_gitname"
 
   # add upstream patch
   #patch -p1 -i "${srcdir}/patch-${pkgver}"


### PR DESCRIPTION
This is almost identical to the ABS suggested way of dealing with git, but
keeping the option "--depth 1" to speed up cloning.

Without this change, a subsequent run will fail on git clone because the target
directory already exists.
