### PR TITLE
Fix node.js segfault on pogoplug e02

### DIFF
--- a/community/nodejs/PKGBUILD
+++ b/community/nodejs/PKGBUILD
@@ -21,6 +21,31 @@ options=('!emptydirs !strip')
 source=("http://nodejs.org/dist/v${pkgver}/node-v${pkgver}.tar.gz")
 sha1sums=('b780f58f0e3bc43d2380d4a935f2b45350783b37')
 
+set_flags_for_arm() {
+  if [ "$CARCH" == "arm" ]; then
+    # CXXFLAGS is here to bash it over the head. It has a bad habit.
+    EABI=soft
+    CXXFLAGS="$CXXFLAGS -march=armv5t -mno-unaligned-access" ;
+    GYPFLAGS="-Darmeabi=soft -Dv8_can_use_vfp_instructions=false -Dv8_can_use_unaligned_accesses=false -Darmv7=0"
+    VFP3=off
+    VFP2=off
+  fi
+  if [ "$CARCH" == "armv6h" ]; then
+    EABI=hard
+    GYPFLAGS="-Darmeabi=hard -Dv8_use_arm_eabi_hardfloat=true -Dv8_can_use_vfp3_instructions=false -Dv8_can_use_vfp2_instructions=true -Darm7=0 -Darm_vfp=vfp"
+    VFP3=off
+    VFP2=on
+  fi
+  if [ "$CARCH" == "armv7h" ]; then
+    EABI=hard
+    GYPFLAGS="-Darmeabi=hard -Dv8_use_arm_eabi_hardfloat=true -Dv8_can_use_vfp3_instructions=true -Dv8_can_use_vfp2_instructions=true -Darm7=1"  
+    VFP3=on
+    VFP2=on
+  fi
+  export CXXFLAGS
+  export GYPFLAGS
+}
+
 build() {
   cd node-v${pkgver}
 
@@ -31,28 +56,7 @@ build() {
 
   export PYTHON=python2
 
-if [ "$CARCH" == "arm" ]; then
-  # CXXFLAGS is here to bash it over the head. It has a bad habit.
-  EABI=soft
-  CXXFLAGS="$CXXFLAGS -march=armv5t -mno-unaligned-access" ;
-  GYPFLAGS="-Darmeabi=soft -Dv8_can_use_vfp_instructions=false -Dv8_can_use_unaligned_accesses=false -Darmv7=0"
-  VFP3=off
-  VFP2=off
-fi
-if [ "$CARCH" == "armv6h" ]; then
-  EABI=hard
-  GYPFLAGS="-Darmeabi=hard -Dv8_use_arm_eabi_hardfloat=true -Dv8_can_use_vfp3_instructions=false -Dv8_can_use_vfp2_instructions=true -Darm7=0 -Darm_vfp=vfp"
-  VFP3=off
-  VFP2=on
-fi
-if [ "$CARCH" == "armv7h" ]; then
-  EABI=hard
-  GYPFLAGS="-Darmeabi=hard -Dv8_use_arm_eabi_hardfloat=true -Dv8_can_use_vfp3_instructions=true -Dv8_can_use_vfp2_instructions=true -Darm7=1"  
-  VFP3=on
-  VFP2=on
-fi
-  export CXXFLAGS
-  export GYPFLAGS
+  set_flags_for_arm
 
  # short-cutting python=python2 for GYP, as it will only be used here.
   export PYTHON=python2
@@ -87,6 +91,9 @@ check() {
 
 package() {
   cd node-v${pkgver}
+
+  # suppress re-compile(with out customized flags) by 'make install'.
+  set_flags_for_arm
 
   make DESTDIR=${pkgdir} install
 


### PR DESCRIPTION
Customized CXXFLAGS(`-march=armv5t`) for arm was not effective in the package function.
And then, re-compiled with enabled `-march=armv5te` by `make install`
(`CXXFLAGS` of default's makepkg.conf was included `-march=armv5te` on pogoplug e02)

Therefore, set flags in package function.
