### PR TITLE
linux-omap: add MT9P031 driver

### DIFF
--- a/core/linux-omap/PKGBUILD
+++ b/core/linux-omap/PKGBUILD
@@ -28,7 +28,7 @@ source=("http://www.kernel.org/pub/linux/kernel/v3.0/linux-${_basekernel}.tar.xz
 md5sums=('21223369d682bcf44bcdfe1521095983'
          '0bb3a5b1c5ee7ae694e3db58b2b69a8d'
          '57e0c3c53f9c6a412e880a526b6766d4'
-         'dcec77aa65fda11fab38bcca033bc89a'
+         '7ec9137703971b621744a0fcd232bfef'
          '9d3c56a4b999c8bfbd4018089a62f662'
          '961e19a119443158f104a68ea4d0d9f1')
 

--- a/core/linux-omap/config
+++ b/core/linux-omap/config
@@ -2850,6 +2850,7 @@ CONFIG_VIDEO_CX2341X=m
 # Camera sensor devices
 #
 CONFIG_VIDEO_MT9V011=m
+CONFIG_VIDEO_MT9P031=m
 
 #
 # Flash devices


### PR DESCRIPTION
The driver is used on the leopard imaging LI-5M03 cameras that plugin the beagleboards.
