### PR TITLE
Fix for alarm/marvell-libgfx conflicts 

### DIFF
--- a/alarm/marvell-libgfx/PKGBUILD
+++ b/alarm/marvell-libgfx/PKGBUILD
@@ -6,16 +6,16 @@ buildarch=4
 
 pkgname="marvell-libgfx"
 pkgver=0.2.0
-pkgrel=5
+pkgrel=6
 arch=('armv7h')
 url="http://archlinuxarm.org"
 license=('Proprietary')
 source=("http://archlinuxarm.org/builder/src/marvell-libgfx-0.2.0.tar.gz"
   "http://download.solid-run.com/pub/solidrun/cubox/packages/marvell-opengl/marvell-opengl-hardfp-debug.zip"
   "http://download.solid-run.com/pub/solidrun/cubox/packages/marvell-libgfx/marvell-libgfx-headers-20120713.tar.bz2"
+  "profile.sh"
 )
 provides=('libegl' 'libgles' 'khrplatform-devel')
-conflicts=('libegl' 'libgles' 'khrplatform-devel')
 
 package() {
   pkgdesc="Armada 510/Dove graphics Libraries"
@@ -24,23 +24,26 @@ package() {
     "${pkgdir}/usr/lib/udev/rules.d/99-galcore.rules"
 
   find include -type f -exec \
-    install -Dm644 {} "${pkgdir}/usr/{}" \;
-  ln -s gc_hal.h "${pkgdir}/usr/include/HAL/aqHal.h"
-
-  # cd "${pkgname}-${pkgver}/include"
-  # install -m644 {vdkTypes.h,vdk.h,gcu.h,VG/vgext.h,VG/openvg.h,EGL/eglvivante.h} \
-    # "${pkgdir}/usr/include"
+    install -Dm644 {} "${pkgdir}/opt/${pkgname}/{}" \;
+  ln -s gc_hal.h "${pkgdir}/opt/${pkgname}/include/HAL/aqHal.h"
 
   cd gc3184-1-mgcc462hd-d
   find -name "*.so" -not -path "*libdirectfb_gal.so" \
-    -exec install -Dm755 {} "${pkgdir}/usr/lib/{}.1" \; \
-    -exec ln -s {}.1 "${pkgdir}/usr/lib/{}" \;
-  ln -s libGLES_CM.so.1 "${pkgdir}/usr/lib/libGLESv1_CM.so"
-  ln -s libGLES_CM.so.1 "${pkgdir}/usr/lib/libGLESv1_CM.so.1"
-  ln -s libGLESv2x.so.1 "${pkgdir}/usr/lib/libGLESv2.so"
-  ln -s libGLESv2x.so.1 "${pkgdir}/usr/lib/libGLESv2.so.1"
+    -exec install -Dm755 {} "${pkgdir}/opt/${pkgname}/lib/{}.1" \; \
+    -exec ln -s {}.1 "${pkgdir}/opt/${pkgname}/lib/{}" \;
+  ln -s libGLES_CM.so.1 "${pkgdir}/opt/${pkgname}/lib/libGLESv1_CM.so"
+  ln -s libGLES_CM.so.1 "${pkgdir}/opt/${pkgname}/lib/libGLESv1_CM.so.1"
+  ln -s libGLESv2x.so.1 "${pkgdir}/opt/${pkgname}/lib/libGLESv2.so"
+  ln -s libGLESv2x.so.1 "${pkgdir}/opt/${pkgname}/lib/libGLESv2.so.1"
+  ln -s libGLESv2x.so.1 "${pkgdir}/opt/${pkgname}/lib/libGLESv2.so.2"
+
+  install -d "${pkgdir}"/etc/ld.so.conf.d/
+  echo "/opt/${pkgname}/lib" > "${pkgdir}"/etc/ld.so.conf.d/${pkgname}.conf
+
+  install -Dm755 "${srcdir}/profile.sh" "${pkgdir}/etc/profile.d/${pkgname}.sh"
 }
 
 md5sums=('6cd584e6feb6a8605662bb2280676f65'
   'd21429fa2d4296f1f4238faff6cca6ca'
-  'a381d9d6d0c5beda781a23dea2c3e0ea')
+  'a381d9d6d0c5beda781a23dea2c3e0ea'
+  '9a210fbfad0e13d775800b06946d8abd')

--- a/alarm/marvell-libgfx/profile.sh
+++ b/alarm/marvell-libgfx/profile.sh
@@ -1,0 +1,1 @@
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/marvell-libgfx/lib"

--- a/alarm/xf86-video-dove/PKGBUILD
+++ b/alarm/xf86-video-dove/PKGBUILD
@@ -10,7 +10,7 @@ pkgrel=7
 arch=('armv7h')
 url="http://www.solid-run.com/mw/index.php/CuBox_Drivers#GPU_Drivers"
 license=('GPL2')
-depends=('marvell-libgfx')
+#depends=('marvell-libgfx')
 makedepends=('pkgconfig' 'xorg-server-devel' 'resourceproto' 'scrnsaverproto')
 options=('!libtool' '!strip')
 source=("http://archlinuxarm.org/builder/src/xf86-video-dove-0.3.4.tar.gz"
@@ -20,7 +20,11 @@ source=("http://archlinuxarm.org/builder/src/xf86-video-dove-0.3.4.tar.gz"
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
   patch -p1 -i "${srcdir}/dovefb-port-to-compat-api-for-new-server.patch"
-  CFLAGS="${CFLAGS} -I/usr/include/HAL -g -DMRVL_SUPPORT_RANDR=1 -DMRVL_SUPPORT_EXA=1 -DDUMP_RAW_VIDEO=0 -DMRVL_USE_OFFSCREEN_HEAP=0 -DMRVL_EXA_MODE=2 -DMRVL_EXA_ENABLE_UP_DOWNLOAD=2 -DMRVL_EXA_FORCE_HW_LOAD=0 -DMRVL_EXA_ALLOC_PIXMAP_FROM_SYSTEM=0 -DMRVL_EXA_PERF_PROFILING=0 -DMRVL_EXA_TRACE_FALLBACK=0 -DMRVL_EXA_XBGR_SUPPORT=1 -DMRVL_XV_SUPPORT_RGB_FORMAT=1 -DMRVL_XV_TEX_VIDEO=1 -DMRVL_XV_OVERLAY_VIDEO=1 -DMRVL_XV_DEFERRED_STALL_GPU=1 -DMRVL_XV_USE_FAKE_FENCE_STALL=1 -DMRVL_RANDR_EDID_MODES=1  -DMRVL_CRTC_SUPPORT_ROTATION=1 -DMRVL_PLATFORM_INFO=1"
+  CFLAGS="${CFLAGS} -I/opt/marvell-libgfx/include/HAL -g -DMRVL_SUPPORT_RANDR=1 -DMRVL_SUPPORT_EXA=1 -DDUMP_RAW_VIDEO=0 -DMRVL_USE_OFFSCREEN_HEAP=0 -DMRVL_EXA_MODE=2 -DMRVL_EXA_ENABLE_UP_DOWNLOAD=2 -DMRVL_EXA_FORCE_HW_LOAD=0 -DMRVL_EXA_ALLOC_PIXMAP_FROM_SYSTEM=0 -DMRVL_EXA_PERF_PROFILING=0 -DMRVL_EXA_TRACE_FALLBACK=0 -DMRVL_EXA_XBGR_SUPPORT=1 -DMRVL_XV_SUPPORT_RGB_FORMAT=1 -DMRVL_XV_TEX_VIDEO=1 -DMRVL_XV_OVERLAY_VIDEO=1 -DMRVL_XV_DEFERRED_STALL_GPU=1 -DMRVL_XV_USE_FAKE_FENCE_STALL=1 -DMRVL_RANDR_EDID_MODES=1  -DMRVL_CRTC_SUPPORT_ROTATION=1 -DMRVL_PLATFORM_INFO=1"
+  LDFLAGS="$LDFLAGS -L/opt/marvell-libgfx/lib"
+
+  # autotools fix.
+  sed "s/^AM_CONFIG_HEADER/AC_CONFIG_HEADERS/" -i configure.ac
 
   autoreconf -i
   ./configure --prefix=/usr CFLAGS="${CFLAGS}"

--- a/extra/mesa/PKGBUILD
+++ b/extra/mesa/PKGBUILD
@@ -5,11 +5,12 @@
 # ALARM: Kevin Mihelich <kevin@archlinuxarm.org>
 #  - Removed DRI and Gallium3D drivers/packages for chipsets that don't exist in our ARM devices (intel, radeon, VMware svga).
 #  - Build v7h with -O1 instead of -O2
+#  - Removed libgles, libegl and khrplatform-devel from conflicts for marvell-libgfx compatibility.
 
 pkgbase=mesa
 pkgname=('mesa' 'mesa-libgl')
 pkgver=9.1
-pkgrel=2
+pkgrel=3
 arch=('i686' 'x86_64')
 makedepends=('python2' 'libxml2' 'libx11' 'glproto' 'libdrm' 'dri2proto' 'libxxf86vm' 'libxdamage'
              'libvdpau' 'wayland')
@@ -60,7 +61,7 @@ package_mesa() {
   depends=('libdrm' 'libvdpau' 'wayland' 'libxxf86vm' 'libxdamage' 'systemd')
   optdepends=('opengl-man-pages: for the OpenGL API man pages')
   provides=('libglapi' 'osmesa' 'libgbm' 'libgles' 'libegl' 'khrplatform-devel')
-  conflicts=('libglapi' 'osmesa' 'libgbm' 'libgles' 'libegl' 'khrplatform-devel')
+  conflicts=('libglapi' 'osmesa' 'libgbm')
   replaces=('libglapi' 'osmesa' 'libgbm' 'libgles' 'libegl' 'khrplatform-devel')
 
   mv -v ${srcdir}/fakeinstall/* ${pkgdir}


### PR DESCRIPTION
Merging libgles, libegl and khrplatform-devel into the mesa 9.1-2 package created conflict problems for marvell-libgfx.
