### PR TITLE
Add aur/advancemame, aur/advancemenu

### DIFF
--- a/aur/advancemame/PKGBUILD
+++ b/aur/advancemame/PKGBUILD
@@ -1,0 +1,38 @@
+# Contributor: Sebastian Wolf <fatmike303 at googlemail dot com>
+
+pkgname=advancemame
+pkgver=1.2
+pkgrel=1
+pkgdesc="A port of the MAME emulator for video hardware like TVs, Arcade monitors, PC monitors and LCD screens"
+arch=('i686' 'x86_64')
+url="http://advancemame.sourceforge.net"
+depends=('sdl' 'alsa-lib' 'expat' 'zlib' 'ncurses')
+makedepends=('nasm')
+license=('GPL')
+source=(http://downloads.sourceforge.net/sourceforge/$pkgname/$pkgname-$pkgver.tar.gz)
+md5sums=('ef0cfd38e7c8859bc03ada60f51295c6')
+
+build() {
+	cd $startdir/src/$pkgname-$pkgver
+	./configure --prefix=/usr || return 1
+	make || return 1
+
+	# Binaries
+	install -D -m755 obj/cfg/linux/blend/advcfg $startdir/pkg/usr/bin/advcfg
+	install -D -m755 obj/j/linux/blend/advj $startdir/pkg/usr/bin/advj
+	install -D -m755 obj/k/linux/blend/advk $startdir/pkg/usr/bin/advk
+	install -D -m755 obj/m/linux/blend/advm $startdir/pkg/usr/bin/advm
+	install -D -m755 obj/mame/linux/blend/advmame $startdir/pkg/usr/bin/advmame
+	install -D -m755 obj/s/linux/blend/advs $startdir/pkg/usr/bin/advs
+	install -D -m755 obj/v/linux/blend/advv $startdir/pkg/usr/bin/advv
+
+	# Documentation
+	install -D -m644 doc/advcfg.1 $startdir/pkg/usr/man/man1/advcfg.1
+	install -D -m644 doc/advj.1 $startdir/pkg/usr/man/man1/advj.1
+	install -D -m644 doc/advk.1 $startdir/pkg/usr/man/man1/advk.1
+	install -D -m644 doc/advm.1 $startdir/pkg/usr/man/man1/advm.1
+	install -D -m644 doc/advmame.1 $startdir/pkg/usr/man/man1/advmame.1
+	install -D -m644 doc/advs.1 $startdir/pkg/usr/man/man1/advs.1
+	install -D -m644 doc/advv.1 $startdir/pkg/usr/man/man1/advv.1
+}
+

--- a/aur/advancemenu/PKGBUILD
+++ b/aur/advancemenu/PKGBUILD
@@ -1,0 +1,25 @@
+# Contributor: Sebastian Wolf <fatmike303 at googlemail dot com>
+
+pkgname=advancemenu
+pkgver=2.5.0
+pkgrel=1
+pkgdesc="A frontend for AdvanceMAME emulator"
+arch=('i686' 'x86_64')
+url="http://advancemame.sourceforge.net"
+depends=('advancemame')
+license=('GPL')
+source=(http://downloads.sourceforge.net/sourceforge/advancemame/$pkgname-$pkgver.tar.gz)
+md5sums=('3df294eaf76dc404fcb628a2267400e9')
+
+build() {
+	cd $startdir/src/$pkgname-$pkgver
+	./configure --prefix=/usr || return 1
+	make || return 1
+
+	# Binaries
+	install -D -m755 obj/menu/linux/blend/advmenu $startdir/pkg/usr/bin/advmenu
+
+	# Documentation
+	install -D -m644 doc/advmenu.1 $startdir/pkg/usr/man/man1/advmenu.1
+}
+


### PR DESCRIPTION
Add unchanged PKGBUILDs from [aur/advancemame](https://aur.archlinux.org/packages/advancemame/) and [aur/advancemenu](https://aur.archlinux.org/packages/advancemenu/). These compile for me without changes on my Raspberry Pi (ARMv6). #421
