### PR TITLE
alarm/raspberrypi-firmware: Split package.

### DIFF
--- a/alarm/raspberrypi-firmware/PKGBUILD
+++ b/alarm/raspberrypi-firmware/PKGBUILD
@@ -3,11 +3,12 @@ buildarch=18
 pkgbase=raspberrypi-firmware
 pkgname=('raspberrypi-firmware'
          'raspberrypi-firmware-bootloader'
+         'raspberrypi-firmware-bootloader-x'
          'raspberrypi-firmware-emergency-kernel'
          'raspberrypi-firmware-tools'
          'raspberrypi-firmware-examples')
 pkgver=20130308
-pkgrel=2
+pkgrel=3
 pkgdesc="Firmware files for Raspberry Pi"
 arch=('any')
 url="https://github.com/raspberrypi/firmware"
@@ -34,6 +35,7 @@ build() {
 
 package_raspberrypi-firmware() {
   depends=('raspberrypi-firmware-bootloader'
+           'raspberrypi-firmware-bootloader-x'
            'raspberrypi-firmware-emergency-kernel'
            'raspberrypi-firmware-tools'
            'raspberrypi-firmware-examples')
@@ -43,7 +45,15 @@ package_raspberrypi-firmware-bootloader() {
   pkgdesc="Bootloader files for Raspberry Pi"
 
   cp -R "${srcdir}"/firmware/boot "${pkgdir}"/boot
-  rm "${pkgdir}"/boot/{COPYING.linux,kernel*.img}
+  rm "${pkgdir}"/boot/{COPYING.linux,kernel*.img,start_x.elf,fixup_x.dat}
+}
+
+package_raspberrypi-firmware-bootloader-x() {
+  pkgdesc="Bootloader with extra codecs for Raspberry Pi"
+  depends=('raspberrypi-firmware-bootloader')
+
+  mkdir -p "${pkgdir}"/boot
+  cp "${srcdir}"/firmware/boot/{start_x.elf,fixup_x.dat} "${pkgdir}"/boot
 }
 
 package_raspberrypi-firmware-emergency-kernel() {


### PR DESCRIPTION
This commit splits the raspberrypi-firmware package in four parts (bootloader, emergency kernel, vc, examples) and a meta package which pulls in the other ones. (Issue #423.)
