### PR TITLE
Updated xbmc-rbp and libcec-rpi to latest version

### DIFF
--- a/alarm/libcec-rpi/PKGBUILD
+++ b/alarm/libcec-rpi/PKGBUILD
@@ -5,7 +5,7 @@
 buildarch=16
 
 pkgname=libcec-rpi
-pkgver=2.0.5
+pkgver=2.1.1
 pkgrel=1
 pkgdesc="Pulse-Eight's libcec for the Pulse-Eight USB-CEC adapter with support for raspberry pi"
 arch=('armv6h')
@@ -14,16 +14,14 @@ license=('GPL')
 depends=('udev' 'lockdev' 'raspberrypi-firmware')
 conflicts=('libcec')
 provides=('libcec')
-source=("libcec-$pkgver.tar.gz::https://github.com/Pulse-Eight/libcec/tarball/libcec-$pkgver" "fix-boot_t.patch")
-sha256sums=('83d99cf759531d8c8a217f360f4748159cb9cedac98d77a4615450bad6d570c4'
+source=("https://github.com/Pulse-Eight/libcec/archive/libcec-$pkgver.tar.gz" "fix-boot_t.patch")
+sha256sums=('f61378798d900d496ed3a5ff7747b0bb35bdfec9b5c4168dcea38396e3569bf1'
             'ba9b4030f3c2aa092a7c513629b60e82eeca7daf044576fa89b117409a8e883f')
-_srcfolder=Pulse-Eight-libcec-e1599e0
 options=(!libtool)
 
 build() {
-  mv "$_srcfolder" "$pkgname-$pkgver"
 
-  cd "$pkgname-$pkgver"
+  cd "libcec-libcec-$pkgver"
   patch -p1 -i ../fix-boot_t.patch
   autoreconf -vif
   ./configure --prefix=/usr --enable-rpi \
@@ -33,7 +31,7 @@ build() {
 }
 
 package() {
-  cd "$pkgname-$pkgver"
+  cd "libcec-libcec-$pkgver"
   make DESTDIR="$pkgdir" install
 }
 

--- a/alarm/xbmc-rbp/PKGBUILD
+++ b/alarm/xbmc-rbp/PKGBUILD
@@ -1,8 +1,8 @@
 # Contributor tomasgroth at yahoo.dk
 # Contributor WarheadsSE <max@warheads.net>
 pkgname=xbmc-rbp
-pkgver=12.0
-pkgrel=3
+pkgver=12.1
+pkgrel=1
 buildarch=16
 
 pkgdesc="A software media player and entertainment hub for digital media for the Raspberry Pi"
@@ -11,7 +11,7 @@ url="http://xbmc.org"
 license=('GPL' 'custom')
 depends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio' 'yajl' 'libmysqlclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd' 'sdl_image' 'python2' 'libass' 'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray' 'libnfs' 'afpfs-ng' 'libshairport' 'avahi' 'bluez' 'tinyxml' 'raspberrypi-firmware' 'libcec-rpi' 'libplist' 'swig' 'taglib')
 
-makedepends=('boost' 'cmake' 'gperf' 'nasm' 'zip' 'udisks' 'upower' 'bluez' 'git' 'autoconf' 'openjdk6')
+makedepends=('boost' 'cmake' 'gperf' 'nasm' 'zip' 'udisks' 'upower' 'bluez' 'git' 'autoconf' 'jdk7-openjdk')
 optdepends=(
   'lirc: remote controller support'
   'udisks: automount external drives'
@@ -27,7 +27,7 @@ source=(http://mirrors.xbmc.org/releases/source/xbmc-${pkgver}.tar.gz
 	xbmc-ae04d99-321-texturepacker-hostflags-and-rework.patch
 	xbmc.service)
 
-md5sums=('a79128b9d094a046947bfd9bb4550809'
+md5sums=('8955473f84cb2a0513c0f3efd7e68843'
          'fc6a925a09ba1b13d84daf1121b42ab9'
          '76fae229ebc3bcfaab7e7f27e4fb51f5')
 


### PR DESCRIPTION
Because of the limited memory on my Pi, I'm not able to link some of the libs in xbmc, so I haven't completed the build of xbmc-rbp, but it configures ok...
