### PR TITLE
core/linux-omap: added VIDEO_OMAP3 driver

### DIFF
--- a/core/linux-omap/PKGBUILD
+++ b/core/linux-omap/PKGBUILD
@@ -12,7 +12,7 @@ pkgname=('linux-omap' 'linux-headers-omap')
 _kernelname=${pkgname#linux}
 _basekernel=3.7
 pkgver=${_basekernel}.10
-pkgrel=2
+pkgrel=3
 rcnrel=x9
 arch=('arm')
 url="http://www.kernel.org/"
@@ -28,7 +28,7 @@ source=("http://www.kernel.org/pub/linux/kernel/v3.0/linux-${_basekernel}.tar.xz
 md5sums=('21223369d682bcf44bcdfe1521095983'
          '5545033e0ce84a7f343f79530ebe94ab'
          'fad15afe55984ea11cdd900e718083f8'
-         '9f3c21b8ce7800694db753fd467630da'
+         '960f202a6867746f3b28e6ecd003131b'
          '9d3c56a4b999c8bfbd4018089a62f662'
          '961e19a119443158f104a68ea4d0d9f1')
 

--- a/core/linux-omap/config
+++ b/core/linux-omap/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 3.7.10 Kernel Configuration
+# Linux/arm 3.7.10-3 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_SYS_SUPPORTS_APM_EMULATION=y
@@ -2820,7 +2820,8 @@ CONFIG_V4L_PLATFORM_DRIVERS=y
 CONFIG_VIDEO_OMAP2_VOUT_VRFB=y
 CONFIG_VIDEO_OMAP2_VOUT=m
 # CONFIG_VIDEO_TIMBERDALE is not set
-# CONFIG_VIDEO_OMAP3 is not set
+CONFIG_VIDEO_OMAP3=m
+# CONFIG_VIDEO_OMAP3_DEBUG is not set
 # CONFIG_SOC_CAMERA is not set
 # CONFIG_V4L_MEM2MEM_DRIVERS is not set
 # CONFIG_V4L_TEST_DRIVERS is not set


### PR DESCRIPTION
I need this for the mt9p031 camera to work on the beagleboard.
