### PR TITLE
Go 1.1 beta 2

### DIFF
--- a/community/go/PKGBUILD
+++ b/community/go/PKGBUILD
@@ -10,10 +10,10 @@
 # ALARM: Kevin Mihelich <kevin@archlinuxarm.org>
 #  - added switches for our architectures
 # ALARM: Alexander Rødseth <rodseth@gmail.com>
-#  - Go 1.1beta1 support
+#  - Go 1.1beta2 support
 
 pkgname=go
-pkgver=1.1beta1
+pkgver=1.1beta2
 pkgrel=1
 epoch=2
 pkgdesc='Google Go compiler and tools'
@@ -26,7 +26,7 @@ install="$pkgname.install"
 backup=('usr/lib/go/bin')
 source=("http://go.googlecode.com/files/${pkgname}$pkgver.src.tar.gz"
         "$pkgname.sh")
-sha256sums=('feb5af0f73ee8d377577ac7c250919e911139821fae8e0ce365d235f87297f84'
+sha256sums=('7437a922cdbaad92f902d7a883edbdb8ea15ffeb04ff9960193a24632fcde3f0'
             'a03db71d323ed2794123bb31b5c8ad5febd551c490b5c0b341052c8e5f0ba892')
 
 build() {
@@ -61,6 +61,8 @@ check() {
 
 package() {
   cd "$srcdir/$pkgname"
+
+  export GOROOT="$srcdir/$pkgname"
 
   install -Dm644 LICENSE \
     $pkgdir/usr/share/licenses/go/LICENSE


### PR DESCRIPTION
New version of Go. This one, like beta1, also works on the RPI. Compiling and running Go applications work just fine.
