### PR TITLE
Change from mysql to mariadb like upstream PKGBUILD

### DIFF
--- a/alarm/xbmc-rbp/PKGBUILD
+++ b/alarm/xbmc-rbp/PKGBUILD
@@ -2,14 +2,14 @@
 # Contributor WarheadsSE <max@warheads.net>
 pkgname=xbmc-rbp
 pkgver=12.1
-pkgrel=1
+pkgrel=2
 buildarch=16
 
 pkgdesc="A software media player and entertainment hub for digital media for the Raspberry Pi"
 arch=('armv6h')
 url="http://xbmc.org"
 license=('GPL' 'custom')
-depends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio' 'yajl' 'libmysqlclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd' 'sdl_image' 'python2' 'libass' 'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray' 'libnfs' 'afpfs-ng' 'libshairport' 'avahi' 'bluez' 'tinyxml' 'raspberrypi-firmware' 'libcec-rpi' 'libplist' 'swig' 'taglib')
+depends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio' 'yajl' 'libmariadbclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd' 'sdl_image' 'python2' 'libass' 'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray' 'libnfs' 'afpfs-ng' 'libshairport' 'avahi' 'bluez' 'tinyxml' 'raspberrypi-firmware' 'libcec-rpi' 'libplist' 'swig' 'taglib')
 
 makedepends=('boost' 'cmake' 'gperf' 'nasm' 'zip' 'udisks' 'upower' 'bluez' 'git' 'autoconf' 'jdk7-openjdk')
 optdepends=(

--- a/aur/xbmc-rbp-git/PKGBUILD
+++ b/aur/xbmc-rbp-git/PKGBUILD
@@ -17,7 +17,7 @@ pkgdesc="A software media player and entertainment hub for digital media for the
 arch=('armv6h')
 url="http://xbmc.org"
 license=('GPL' 'custom')
-depends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio' 'yajl' 'libmysqlclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd' 'sdl_image' 'python2' 'libass' 'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray' 'libnfs' 'afpfs-ng' 'libshairport' 'avahi' 'bluez' 'tinyxml' 'raspberrypi-firmware' 'libcec-rpi' 'libplist' 'swig' 'taglib')
+depends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio' 'yajl' 'libmariadbclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd' 'sdl_image' 'python2' 'libass' 'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray' 'libnfs' 'afpfs-ng' 'libshairport' 'avahi' 'bluez' 'tinyxml' 'raspberrypi-firmware' 'libcec-rpi' 'libplist' 'swig' 'taglib')
 
 makedepends=('boost' 'cmake' 'gperf' 'nasm' 'zip' 'udisks' 'upower' 'bluez' 'git' 'autoconf' 'java-environment')
 optdepends=(


### PR DESCRIPTION
Also Xbmc needs a recompile to pick up the new version of libshairport (libshairport.so.2 instead oflibshairport.so.1). I didn't update the pkgrel on xbmc-rbp-git, since it doesn't seem to have been build yet.
