### PR TITLE
Added module usblp to linux-sun4i

### DIFF
--- a/core/linux-sun4i/PKGBUILD
+++ b/core/linux-sun4i/PKGBUILD
@@ -13,7 +13,7 @@ pkgname=("linux-${_mach}" "linux-headers-${_mach}")
 _kernelname=${pkgname#linux}
 _basekernel=3.0
 pkgver=${_basekernel}.57
-pkgrel=2
+pkgrel=3
 arch=('armv7h')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -22,7 +22,7 @@ options=('!strip')
 source=('config'
         'change-default-console-loglevel.patch'
         "linux.tar.gz::https://github.com/${_github_user}/${_github_repo}/tarball/${_github_commitID}")
-md5sums=('4bed917577fd5be8fbaefba38f99036b'
+md5sums=('491bb0d9bd64df02c052720f76e91b07'
          '9d3c56a4b999c8bfbd4018089a62f662'
          '1d57b811237d5447bedacf74be15808e')
 

--- a/core/linux-sun4i/config
+++ b/core/linux-sun4i/config
@@ -2191,7 +2191,7 @@ CONFIG_USB_SW_SUN4I_HCD0=y
 # USB Device Class drivers
 #
 CONFIG_USB_ACM=m
-# CONFIG_USB_PRINTER is not set
+CONFIG_USB_PRINTER=m 
 # CONFIG_USB_WDM is not set
 # CONFIG_USB_TMC is not set
 


### PR DESCRIPTION
Added usblp as module (CONFIG_USB_PRINTER=m) to allow sharing your old non-network Printer with your A10 board over network.
