### PR TITLE
Raspberry Pi patches for Qt5

### DIFF
--- a/extra/qt5/PKGBUILD
+++ b/extra/qt5/PKGBUILD
@@ -6,6 +6,7 @@
 #  - no x86/neon optimizations
 #  - disabled distcc, restricted makeflags to -j3
 #  - enabled opengl es2, mesa makedepend for headers
+#  - added Raspberry Pi patches for armv6h
 
 highmem=1
 
@@ -24,7 +25,7 @@ pkgname=('qt5-base'
          'qt5-webkit'
          'qt5-xmlpatterns')
 pkgver=5.0.2
-pkgrel=2
+pkgrel=3
 arch=('i686' 'x86_64')
 url='http://qt-project.org/'
 license=('GPL3' 'LGPL')
@@ -39,13 +40,17 @@ options=('!libtool' '!distcc')
 _pkgfqn="qt-everywhere-opensource-src-${pkgver}"
 source=("http://releases.qt-project.org/${pkgbase}/${pkgver}/single/${_pkgfqn}.tar.xz"
         'assistant.desktop' 'designer.desktop' 'linguist.desktop'
-        'use-python2.patch' 'gcc48.patch')
-md5sums=('00a577bd88e682d1b4d01d41d1d699cf'
+        'use-python2.patch' 'gcc48.patch' 
+        'deppath_gnu.patch' 'rpi.patch' 'undef_B0.patch')
+md5sums=('2cab3518d86fe8f0638c7faea8b46397'
          'f1837a03fd0ebbd2da58975845f278e3'
          '480fea1ed076992b688373c8db274be0'
          '5595c24d5bb942c21e3a4d299e6d0bf1'
          'd6ab43fb371be494e3bfd9b210c40bf1'
-         '7927028e2374321c78a76df858e723d6')
+         '7927028e2374321c78a76df858e723d6'
+         '27f2a06c6d363338ffe5e5dba96821d9'
+         '54ce1583d83f5e7e4b64bf89ea7cab99'
+         '3740dc700c9c43379b0da6c10d2f6c6e')
 
 build() {
   cd ${_pkgfqn}
@@ -68,6 +73,14 @@ build() {
   # GCC 4.8 fixes
   cd qtbase
   patch -p1 -i "${srcdir}"/gcc48.patch
+
+  # Raspberry Pi
+  if [ "$CARCH" == 'armv6h' ]; then
+    patch -p1 -i "${srcdir}"/deppath_gnu.patch
+    patch -p1 -i "${srcdir}"/rpi.patch
+    patch -p1 -i "${srcdir}"/undef_B0.patch
+    rbp_config="-device linux-rasp-pi-g++ -eglfs"
+  fi
   cd ../
 
   ./configure -confirm-license -opensource \
@@ -97,7 +110,8 @@ build() {
     -no-avx \
     -no-avx2 \
     -no-neon \
-    -opengl es2
+    -opengl es2 \
+    $rbp_config
 
   make
 

--- a/extra/qt5/deppath_gnu.patch
+++ b/extra/qt5/deppath_gnu.patch
@@ -1,0 +1,11 @@
+--- a/mkspecs/features/qt_functions.prf
++++ b/mkspecs/features/qt_functions.prf
+@@ -242,7 +242,7 @@ defineTest(qtAddTargetEnv) {
+             deppath += $$shell_path($$eval(QT.$${dep}.libs))
+         equals(QMAKE_HOST.os, Windows) {
+             deppath.name = PATH
+-        } else:contains(QMAKE_HOST.os, Linux|FreeBSD) {
++        } else:contains(QMAKE_HOST.os, Linux|FreeBSD|GNU) {
+             deppath.name = LD_LIBRARY_PATH
+         } else:equals(QMAKE_HOST.os, Darwin) {
+             contains(QT_CONFIG, qt_framework): \

--- a/extra/qt5/rpi.patch
+++ b/extra/qt5/rpi.patch
@@ -1,0 +1,77 @@
+--- a/configure
++++ b/configure
+@@ -2513,11 +2513,6 @@
+ else
+   XQMAKESPEC="$relpath/mkspecs/${XPLATFORM}"
+ fi
+-if [ "$PLATFORM" != "$XPLATFORM" ]; then
+-    QT_CROSS_COMPILE=yes
+-    QMAKE_CONFIG="$QMAKE_CONFIG cross_compile"
+-    QTCONFIG_CONFIG="$QTCONFIG_CONFIG cross_compile"
+-fi
+ 
+ if [ "$BUILD_ON_MAC" = "yes" ]; then
+    if [ `basename $QMAKESPEC` = "macx-xcode" ] || [ `basename $XQMAKESPEC` = "macx-xcode" ]; then
+@@ -2769,11 +2764,6 @@
+     if [ "$CFG_DEV" = "yes" ]; then
+         CFG_BUILD_PARTS="$CFG_BUILD_PARTS tests"
+     fi
+-
+-    # don't build tools by default when cross-compiling
+-    if [ "$PLATFORM" != "$XPLATFORM" ]; then
+-	CFG_BUILD_PARTS=`echo "$CFG_BUILD_PARTS" | sed "s, tools,,g"`
+-    fi
+ fi
+ for nobuild in $CFG_NOBUILD_PARTS; do
+     CFG_BUILD_PARTS=`echo "$CFG_BUILD_PARTS" | sed "s, $nobuild,,g"`
+diff --git a/mkspecs/devices/common/linux_device_post.conf b/mkspecs/devices/common/linux_device_post.conf
+index f8dbf76..b53c2a2 100644
+--- a/mkspecs/devices/common/linux_device_post.conf
++++ b/mkspecs/devices/common/linux_device_post.conf
+@@ -1,15 +1,3 @@
+-contains(DISTRO_OPTS, deb-multi-arch) {
+-    QMAKE_LFLAGS   += -Wl,-rpath-link,$$[QT_SYSROOT]/usr/lib/$${GCC_MACHINE_DUMP} \
+-                      -Wl,-rpath-link,$$[QT_SYSROOT]/lib/$${GCC_MACHINE_DUMP}
+-}
+-
+-contains(DISTRO_OPTS, hard-float) {
+-    COMPILER_FLAGS += -mfloat-abi=hard
+-} else {
+-    COMPILER_FLAGS += -mfloat-abi=softfp
+-}
+-
+ QMAKE_CFLAGS       += $$COMPILER_FLAGS
+ QMAKE_CXXFLAGS     += $$COMPILER_FLAGS
+ 
+-deviceSanityCheckCompiler()
+diff --git a/mkspecs/devices/common/linux_device_pre.conf b/mkspecs/devices/common/linux_device_pre.conf
+index 51f04d9..4794b1e 100644
+--- a/mkspecs/devices/common/linux_device_pre.conf
++++ b/mkspecs/devices/common/linux_device_pre.conf
+@@ -14,14 +14,3 @@ include(../../common/g++-unix.conf)
+ !load(device_config) {
+     error(Could not successfully load device configuration)
+ }
+-
+-# modifications to g++-unix.conf
+-QMAKE_CC                = $${CROSS_COMPILE}gcc
+-QMAKE_CXX               = $${CROSS_COMPILE}g++
+-QMAKE_LINK              = $${QMAKE_CXX}
+-QMAKE_LINK_SHLIB        = $${QMAKE_CXX}
+-
+-# modifications to linux.conf
+-QMAKE_AR                = $${CROSS_COMPILE}ar cqs
+-QMAKE_OBJCOPY           = $${CROSS_COMPILE}objcopy
+-QMAKE_STRIP             = $${CROSS_COMPILE}strip
+--- a/mkspecs/devices/linux-rasp-pi-g++/qmake.conf
++++ b/mkspecs/devices/linux-rasp-pi-g++/qmake.conf
+@@ -11,7 +11,7 @@
+ QMAKE_LIBDIR_OPENGL_ES2 = $$[QT_SYSROOT]/opt/vc/lib
+ QMAKE_LIBDIR_EGL        = $$QMAKE_LIBDIR_OPENGL_ES2
+ 
+-QMAKE_INCDIR_EGL        = $$[QT_SYSROOT]/opt/vc/include $$[QT_SYSROOT]/opt/vc/include/interface/vcos/pthreads
++QMAKE_INCDIR_EGL        = $$[QT_SYSROOT]/opt/vc/include $$[QT_SYSROOT]/opt/vc/include/interface/vcos/pthreads $$[QT_SYSROOT]/opt/vc/include/interface/vmcs_host/linux
+ QMAKE_INCDIR_OPENGL_ES2 = $${QMAKE_INCDIR_EGL}
+ 
+ QMAKE_LIBS_EGL          = -lEGL -lGLESv2
+ 

--- a/extra/qt5/undef_B0.patch
+++ b/extra/qt5/undef_B0.patch
@@ -1,0 +1,13 @@
+--- qtbase-opensource-src-5.0.1+dfsg.orig/src/gui/painting/qpagedpaintdevice.h	2013-01-29 12:03:00.000000000 -0700
++++ qtbase-opensource-src-5.0.1+dfsg/src/gui/painting/qpagedpaintdevice.h	2013-02-18 13:21:01.000000000 -0700
+@@ -44,6 +44,10 @@
+ 
+ #include <QtGui/qpaintdevice.h>
+ 
++#if defined(B0)
++#undef B0 // Terminal hang-up.  We assume that you do not want that.
++#endif
++
+ QT_BEGIN_HEADER
+ 
+ QT_BEGIN_NAMESPACE


### PR DESCRIPTION
I have added 3 patches from twolife's Raspbian scripts. Patches are used only for armv6h architecture and they require raspberry headers and libs for successful compilation and linking.

There are two more flags for ./configure script for enabling eglfs using Raspberry Pi libs.
