### PR TITLE
Additional includes in rpi.patch

### DIFF
--- a/extra/qt5/PKGBUILD
+++ b/extra/qt5/PKGBUILD
@@ -50,7 +50,7 @@ md5sums=('2cab3518d86fe8f0638c7faea8b46397'
          'd6ab43fb371be494e3bfd9b210c40bf1'
          '7927028e2374321c78a76df858e723d6'
          '27f2a06c6d363338ffe5e5dba96821d9'
-         '54ce1583d83f5e7e4b64bf89ea7cab99'
+         'b7a0d68183b822899834eb1dd08c1f67'
          '3740dc700c9c43379b0da6c10d2f6c6e')
 
 build() {

--- a/extra/qt5/rpi.patch
+++ b/extra/qt5/rpi.patch
@@ -65,12 +65,13 @@ index 51f04d9..4794b1e 100644
 -QMAKE_STRIP             = $${CROSS_COMPILE}strip
 --- a/mkspecs/devices/linux-rasp-pi-g++/qmake.conf
 +++ b/mkspecs/devices/linux-rasp-pi-g++/qmake.conf
-@@ -11,7 +11,7 @@
+@@ -11,7 +11,8 @@
  QMAKE_LIBDIR_OPENGL_ES2 = $$[QT_SYSROOT]/opt/vc/lib
  QMAKE_LIBDIR_EGL        = $$QMAKE_LIBDIR_OPENGL_ES2
  
 -QMAKE_INCDIR_EGL        = $$[QT_SYSROOT]/opt/vc/include $$[QT_SYSROOT]/opt/vc/include/interface/vcos/pthreads
 +QMAKE_INCDIR_EGL        = $$[QT_SYSROOT]/opt/vc/include $$[QT_SYSROOT]/opt/vc/include/interface/vcos/pthreads $$[QT_SYSROOT]/opt/vc/include/interface/vmcs_host/linux
++QMAKE_CFLAGS            += -I$$[QT_SYSROOT]/opt/vc/include -I$$[QT_SYSROOT]/opt/vc/include/interface/vcos/pthreads -I$$[QT_SYSROOT]/opt/vc/include/interface/vmcs_host/linux
  QMAKE_INCDIR_OPENGL_ES2 = $${QMAKE_INCDIR_EGL}
  
  QMAKE_LIBS_EGL          = -lEGL -lGLESv2


### PR DESCRIPTION
Added missing includes for Raspberry Pi headers. If it still doesn't compile, cancel all changes until I test package on clean image.
