### PR TITLE
aur/dfc update to 3.0.3

### DIFF
--- a/aur/dfc/PKGBUILD
+++ b/aur/dfc/PKGBUILD
@@ -1,31 +1,30 @@
 # Maintainer: Rolinh <robinDOThahlingATgw-computingDOTnet>
-
 pkgname=dfc
-pkgver=3.0.2
-pkgrel=1
+pkgver=3.0.3
+pkgrel=3
 pkgdesc="Display file system space usage using graphs and colors"
 arch=('x86_64' 'i686')
 url="http://projects.gw-computing.net/projects/dfc"
 license=('BSD')
 depends=('glibc')
-makedepends=('cmake')
+makedepends=('cmake' 'gettext')
 provides=('dfc')
 conflicts=('dfc-git')
-source=(http://projects.gw-computing.net/attachments/download/68/${pkgname}-${pkgver}.tar.gz)
+source=(http://projects.gw-computing.net/attachments/download/78/${pkgname}-${pkgver}.tar.gz)
 install='dfc.install'
-md5sums=('ec26dba0a4efdbe8c520c045a9a05258')
+md5sums=('c4b2d554f6739502dd6d809966f8c616')
 
 build() {
-  cd ${pkgname}-${pkgver}
+  cd "${srcdir}/${pkgname}-${pkgver}"
 
   cmake . -DPREFIX=/usr -DSYSCONFDIR=/etc -DCMAKE_BUILD_TYPE=RELEASE
   make
 }
 
 package() {
-  cd ${pkgname}-${pkgver}
+  cd "${srcdir}/${pkgname}-${pkgver}"
 
-  make DESTDIR=${pkgdir} install
+  make DESTDIR="${pkgdir}" install
 
   install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/aur/dfc/dfc.install
+++ b/aur/dfc/dfc.install
@@ -2,6 +2,3 @@ post_install() {
 	echo 'Optional configuration file is located in /etc/xdg/dfc/'
 	echo 'Copy it to ~/.config/dfc/ (create this folder if necessary) if you want to use it.'
 }
-post_upgrade() {
-	post_install
-}


### PR DESCRIPTION
This updates dfc to bugfix version 3.0.3.
This PKGBUILD also now includes gettext as a build dependency (it was missing previously) and removed the post-upgrade message.
