### PR TITLE
core/linux-wandboard fix pkgver in provides array

### DIFF
--- a/core/linux-wandboard/PKGBUILD
+++ b/core/linux-wandboard/PKGBUILD
@@ -70,7 +70,7 @@ _package() {
   pkgdesc="The Linux Kernel and modules - ${_desc}"
   depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
   optdepends=('crda: to set the correct wireless channels of your country')
-  provides=('kernel26' 'linux=${pkgver}' 'aufs_friendly')
+  provides=('kernel26' "linux=${pkgver}" 'aufs_friendly')
   conflicts=('linux-omap' 'linux-imx6' 'linux-armada370')
   install=${pkgname}.install
 
@@ -115,7 +115,7 @@ _package() {
 
 _package-headers() {
   pkgdesc="Header files and scripts for building modules for linux kernel - ${_desc}"
-  provides=('linux-headers=${pkgver}')
+  provides=("linux-headers=${pkgver}")
   conflicts=('linux-headers-omap' 'linux-headers-imx6')
 
   install -dm755 "${pkgdir}/usr/lib/modules/${_kernver}"


### PR DESCRIPTION
This fixes the linux and linux-headers version in the provides array. Strings within ' do not get evaluated, so use " instead.
