### PR TITLE
bump libbcm2835 version to 1.32 + remove useless/empty parameters

### DIFF
--- a/alarm/libbcm2835/PKGBUILD
+++ b/alarm/libbcm2835/PKGBUILD
@@ -4,19 +4,14 @@ buildarch=16
 
 _pkgbasename=bcm2835
 pkgname=libbcm2835
-pkgver=1.26
+pkgver=1.32
 pkgrel=1 
 pkgdesc="C library for Broadcom BCM 2835 as used in Raspberry Pi"
 url="http://www.airspayce.com/mikem/bcm2835/"
 arch=('armv6h')
 license=('GPL')
-depends=()
-makedepends=()
-conflicts=()
-replaces=()
-backup=()
 source=(http://www.airspayce.com/mikem/${_pkgbasename}/${_pkgbasename}-${pkgver}.tar.gz)
-md5sums=('bd378a905fc3287694a27a5fcef9db9c')
+md5sums=('085239569554de5ee6649fe8bb123379')
 
 build() {
   cd ${srcdir}/${_pkgbasename}-${pkgver}


### PR DESCRIPTION
There is a new version with these changes according to the [website](http://www.airspayce.com/mikem/bcm2835/index.html):

```
1.27 bcm2835_gpio_set_pad() no longer needs BCM2835_PAD_PASSWRD: it is now automatically included. Added suport for PWM mode with bcm2835_pwm_* functions. 
1.28 Fixed a problem where bcm2835_spi_writenb() would have problems with transfers of more than 64 bytes dues to read buffer filling. Patched by Peter Würtz. 
1.29 Further fix to SPI from Peter Würtz. 
1.30 10 microsecond delays from bcm2835_spi_transfer and bcm2835_spi_transfern for significant performance improvements, Patch by Alan Watson. 
1.31 Fix a GCC warning about dummy variable, patched by Alan Watson. Thanks. 
1.32 Added option I2C_V1 definition to compile for version 1 RPi. By default I2C code is generated for the V2 RPi which has SDA1 and SCL1 connected. Contributed by Malcolm Wiles.
```
