### PR TITLE
don't apply 0001-rtc-pcf8523.patch

### DIFF
--- a/core/linux-raspberrypi/PKGBUILD
+++ b/core/linux-raspberrypi/PKGBUILD
@@ -21,7 +21,6 @@ source=('config'
         'args-uncompressed.txt'
         'boot-uncompressed.txt'
         'imagetool-uncompressed.py'
-        'https://raspy-juice.googlecode.com/svn/trunk/linux-rtc/0001-rtc-pcf8523.patch'
         'https://raspy-juice.googlecode.com/svn/trunk/linux-rtc/0002-pcf8523-i2c-register-dt.patch')
 
 build() {
@@ -34,7 +33,6 @@ build() {
 
   # Add the USB_QUIRK_RESET_RESUME for several webcams
   # FS#26528
-  patch -Np1 -i "${srcdir}/0001-rtc-pcf8523.patch"
   patch -Np1 -i "${srcdir}/0002-pcf8523-i2c-register-dt.patch"
 
   #nxp-pcf8523 RTC patch
@@ -270,5 +268,4 @@ md5sums=('04120f0656f3fa1b98cb058b1cbb8a76'
          '9335d1263fd426215db69841a380ea26'
          'a00e424e2fbb8c5a5f77ba2c4871bed4'
          '2f82dbe5752af65ff409d737caf11954'
-         'ca74031c9e9bfc9f4a668924dcb37f4c'
          '1e46f207dcf2dd9392a099a437bb9b3e')


### PR DESCRIPTION
The linux-raspberrypi PKGBUILD is currently not building. It still includes a patch to add the PCF8523 RTC driver (0001-rtc-pcf8523.patch), however this patch appears to have now been applied upstream. So the build fails due to the skipped patch.

This pull request is to remove the redundant patch.
