### PR TITLE
core/linux-odroid to 3.8.13.12-2

### DIFF
--- a/core/linux-odroid/PKGBUILD
+++ b/core/linux-odroid/PKGBUILD
@@ -8,18 +8,18 @@ pkgname=('linux-odroid-x' 'linux-odroid-x2' 'linux-odroid-u2' 'linux-headers-odr
 _kernelname=${pkgname#linux}
 _basekernel=3.8
 pkgver=${_basekernel}.13.12
-pkgrel=1
+pkgrel=2
 arch=('armv7h')
 url="http://github.com/hardkernel/linux/"
 license=('GPL2')
 makedepends=('xmlto' 'docbook-xsl' 'git' 'inetutils' 'bc')
 options=('!strip')
-_commit=aac36947a409c6f9e9b38294d417609aa02fded0
+_commit=60b28ac59f16f476423ab29840dcdeae1e2c0919
 source=("https://github.com/hardkernel/linux/archive/${_commit}.tar.gz"
         'config_x'
         'config_x2'
         'config_u2')
-md5sums=('f0e356fd700d26c67b7a2256bbef85c5'
+md5sums=('c554ae931c078fbecd5b364ca32d6b0e'
          '5ef6f99f905b60ca1f1cc617ebeba81b'
          '9eb48e5e5850c95a2cc6031244afc5b7'
          '7839311a96f772cde300b0493c1b7914')


### PR DESCRIPTION
This fixed the coloring issue on HDMI
Temperature messages
And enables the MCT for fine clocking
