### PR TITLE
Added xf86-video-fbturbo.

### DIFF
--- a/alarm/xf86-video-fbturbo/PKGBUILD
+++ b/alarm/xf86-video-fbturbo/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer: Martin Wimpress <code@flexion.org>
+
+pkgname=xf86-video-fbturbo-git
+pkgver=0.r189.9808a58
+pkgrel=1
+pkgdesc="X.org frame buffer driver for Allwinner A10/A13, Raspberry Pi and other ARM devices"
+arch=(armv6h armv7h)
+license=('custom')
+url="https://github.com/ssvb/xf86-video-fbturbo"
+depends=('glibc')
+makedepends=('git' 'xorg-server-devel' 'X-ABI-VIDEODRV_VERSION=14' 'resourceproto' 'scrnsaverproto')
+conflicts=('xorg-server<1.14.0' 'X-ABI-VIDEODRV_VERSION<14' 'X-ABI-VIDEODRV_VERSION>=15')
+groups=('xorg-drivers' 'xorg')
+source=("${pkgname%-*}::git+https://github.com/ssvb/xf86-video-fbturbo")
+md5sums=('SKIP')
+
+pkgver() {
+    cd ${pkgname%-*}
+    printf "0.r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+    cd ${pkgname%-*}
+    autoreconf -vi
+    ./configure --prefix=/usr
+    make
+}
+
+package() {
+    cd ${pkgname%-*}
+    make DESTDIR="${pkgdir}" install
+    install -m755 -d "${pkgdir}/usr/share/licenses/${pkgname}"
+    install -m644 COPYING "${pkgdir}/usr/share/licenses/${pkgname}/"
+    install -m755 -d "${pkgdir}/usr/share/doc/${pkgname}"
+    install -m644 xorg.conf "${pkgdir}/usr/share/doc/${pkgname}/"
+    install -m644 README "${pkgdir}/usr/share/doc/${pkgname}/"
+}


### PR DESCRIPTION
Hi,

I discovered the `xf86-video-fbturbo` DDX for Xorg yesterday.
- https://github.com/ssvb/xf86-video-fbturbo

I've packaged it, primarily for use on the Raspberry Pi, but it may be useful for others.

Regards, Martin.
