### PR TITLE
Updated and fixed libbcm2835

### DIFF
--- a/alarm/libbcm2835/PKGBUILD
+++ b/alarm/libbcm2835/PKGBUILD
@@ -4,7 +4,7 @@ buildarch=16
 
 _pkgbasename=bcm2835
 pkgname=libbcm2835
-pkgver=1.32
+pkgver=1.33
 pkgrel=1 
 pkgdesc="C library for Broadcom BCM 2835 as used in Raspberry Pi"
 url="http://www.airspayce.com/mikem/bcm2835/"
@@ -12,7 +12,7 @@ arch=('armv6h')
 license=('GPL')
 options=('staticlibs')
 source=(http://www.airspayce.com/mikem/${_pkgbasename}/${_pkgbasename}-${pkgver}.tar.gz)
-md5sums=('085239569554de5ee6649fe8bb123379')
+md5sums=('afc449e32c955bd8dbd98ddaafd72d35')
 
 build() {
   cd ${srcdir}/${_pkgbasename}-${pkgver}


### PR DESCRIPTION
The version was outdated and the PKGBUILD was missing the staticlibs option, so the .a file was stripped by makepkg making this package useless.
