### PR TITLE
Made GCC v4.8.2 build on ARM using the patched PKGBUILD.

### DIFF
--- a/core/gcc/PKGBUILD
+++ b/core/gcc/PKGBUILD
@@ -19,7 +19,7 @@ pkgver=4.8.2
 pkgrel=4
 #_snapshot=4.8-20130725
 pkgdesc="The GNU Compiler Collection"
-arch=('i686' 'x86_64')
+arch=('i686' 'x86_64' 'armv7h')
 license=('GPL' 'LGPL' 'FDL' 'custom')
 url="http://gcc.gnu.org"
 makedepends=('binutils>=2.23' 'libmpc' 'cloog' 'doxygen')
@@ -30,7 +30,7 @@ source=(ftp://gcc.gnu.org/pub/gcc/releases/gcc-${pkgver}/gcc-${pkgver}.tar.bz2
         gcc-4.8-filename-output.patch
         gcc-4.8-lambda-ICE.patch)
 md5sums=('a3d7d63b9cb6b6ea049469a0c4a43c9d'
-         'bd7330bd41845929f1e0efb3b7d0a060'
+         #'bd7330bd41845929f1e0efb3b7d0a060'
          '40cb437805e2f7a006aa0d0c3098ab0f'
          '6eb6e080dbf7bc6825f53a0aaa6c4ef9')
 
@@ -61,7 +61,7 @@ prepare() {
   [[ $CARCH == "arm" ]] && CONFIGFLAG="--host=armv5tel-unknown-linux-gnueabi --build=armv5tel-unknown-linux-gnueabi"
   [[ $CARCH == "armv6h" ]] && CONFIGFLAG="--host=armv6l-unknown-linux-gnueabihf --build=armv6l-unknown-linux-gnueabihf --with-arch=armv6 --with-float=hard --with-fpu=vfp"
   [[ $CARCH == "armv7h" ]] && CONFIGFLAG="--host=armv7l-unknown-linux-gnueabihf --build=armv7l-unknown-linux-gnueabihf --with-arch=armv7-a --with-float=hard --with-fpu=vfpv3-d16"
-  [[ $CARCH == "armv6h" || $CARCH == "armv7h" ]] && patch -p1 -i "${srcdir}/armhf-triplet-trunk.diff"
+  #[[ $CARCH == "armv6h" || $CARCH == "armv7h" ]] && patch -p1 -i "${srcdir}/armhf-triplet-trunk.diff"
 
   mkdir ${srcdir}/gcc-build
 }
@@ -133,7 +133,7 @@ package_gcc-libs()
 
   # remove static libraries
   find ${pkgdir} -name *.a -delete
-  
+
   # Install Runtime Library Exception
   install -Dm644 ${srcdir}/${_basedir}/COPYING.RUNTIME \
     ${pkgdir}/usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION
@@ -148,7 +148,7 @@ package_gcc()
   install=gcc.install
 
   cd ${srcdir}/gcc-build
-  
+
   make -j1 DESTDIR=${pkgdir} install
 
   install -d $pkgdir/usr/share/gdb/auto-load/usr/lib
@@ -168,7 +168,7 @@ package_gcc()
   rm -f $pkgdir/usr/share/man/man1/{gccgo,gfortran}.1
 
   # remove static libraries - note libstdc++.a is needed for the binutils and glibc testsuite
-  rm $pkgdir/usr/lib/lib{asan,gomp,itm,mudflap{,th},quadmath}.a
+  rm $pkgdir/usr/lib/lib{gomp,itm,mudflap{,th}}.a
 
   # many packages expect this symlink
   #install -dm755 ${pkgdir}/lib
@@ -225,9 +225,9 @@ package_gcc-fortran()
   make -j1 -C $CHOST/libgomp DESTDIR=$pkgdir install-nodist_fincludeHEADERS
   make -j1 -C gcc DESTDIR=$pkgdir fortran.install-{common,man,info}
   install -Dm755 gcc/f951 $pkgdir/usr/lib/gcc/$CHOST/$pkgver/f951
-  
+
   ln -s gfortran ${pkgdir}/usr/bin/f95
-  
+
   # remove files included in gcc-libs or gcc and unnneeded static lib
   rm -f ${pkgdir}/usr/lib/lib{gfortran,gcc_s}.so*
   rm -f ${pkgdir}/usr/lib/libquadmath.{a,so*}


### PR DESCRIPTION
libtool needs to be uninstalled to install the new GCC v4.8.2.  I tried building libtool but it failed on a test.  I am talking to GNU about that and they say to 1) use http://alpha.gnu.org/gnu/libtool/libtool-2.4.2.418.tar.gz, 2) wait for the next release of Libtool, which is underway.
