### PR TITLE
alarm/fake-hwclock: Correct suggested cron job.

### DIFF
--- a/alarm/fake-hwclock/fake-hwclock.install
+++ b/alarm/fake-hwclock/fake-hwclock.install
@@ -2,7 +2,7 @@ post_install () {
   echo "**********************************************************************"
   echo "To keep fake-hwclock up to date in case of a power failure, add the"
   echo "following job to root crontab: "
-  echo "*/15 * * * * /usr/lib/systemd/scripts/fake-hwclock.sh set"
+  echo "*/15 * * * * /usr/lib/systemd/scripts/fake-hwclock.sh save"
   echo "**********************************************************************"
 }
 


### PR DESCRIPTION
The cron job should save the current time to disk every 15 minutes, not reset the time to what it originally was.
