### PR TITLE
bump up community/docker to 0.7.6

### DIFF
--- a/community/docker/PKGBUILD
+++ b/community/docker/PKGBUILD
@@ -4,7 +4,7 @@
 # Add patch for ARM being a supported platform. 
 
 pkgname=docker
-pkgver=0.7.3
+pkgver=0.7.6
 pkgrel=1
 epoch=1
 pkgdesc='Pack, ship and run any application as a lightweight container'


### PR DESCRIPTION
builds fine on my raspberry pi, once I add the architecture there - haven't changed because the other packages don't have armv6h too.
