### PR TITLE
Update docker to 0.8.0

### DIFF
--- a/community/docker/PKGBUILD
+++ b/community/docker/PKGBUILD
@@ -4,22 +4,24 @@
 # Add patch for ARM being a supported platform. 
 
 pkgname=docker
-pkgver=0.7.6
+_truever=0.8.0
+pkgver=${_truever%.*}
 pkgrel=1
 epoch=1
 pkgdesc='Pack, ship and run any application as a lightweight container'
-arch=('x86_64')
+arch=('x86_64' 'armv7h')
 url='http://www.docker.io/'
 license=('Apache')
 depends=('bridge-utils' 'iproute2' 'device-mapper' 'lxc' 'sqlite' 'systemd')
-makedepends=('git' 'go')
+makedepends=('git' 'go' 'btrfs-progs')
+optdepends=('btrfs-progs: btrfs backend support')
 # don't strip binaries! A sha1 is used to check binary consistency.
 options=('!strip')
 install=$pkgname.install
-source=("git+https://github.com/dotcloud/docker.git#tag=v$pkgver"
+source=("git+https://github.com/dotcloud/docker.git#tag=v$_truever"
         'docker-arm.patch')
 md5sums=('SKIP'
-         '47cc1cdf900af66660bfa3402012ea71')
+         'e7bf65454c5deb3d682c7927896583a9')
 # magic harcoded path
 _magic=src/github.com/dotcloud
 
@@ -44,8 +46,8 @@ check() {
 
 package() {
   cd "$_magic/docker"
-  install -Dm755 "bundles/$pkgver/dynbinary/docker-$pkgver" "$pkgdir/usr/bin/docker"
-  install -Dm755 "bundles/$pkgver/dynbinary/dockerinit-$pkgver" "$pkgdir/usr/lib/docker/dockerinit"
+  install -Dm755 "bundles/$_truever/dynbinary/docker-$_truever" "$pkgdir/usr/bin/docker"
+  install -Dm755 "bundles/$_truever/dynbinary/dockerinit-$_truever" "$pkgdir/usr/lib/docker/dockerinit"
   # completion
   install -Dm644 "contrib/completion/bash/docker" "$pkgdir/usr/share/bash-completion/completions/docker"
   install -Dm644 "contrib/completion/zsh/_docker" "$pkgdir/usr/share/zsh/site-functions/_docker"

--- a/community/docker/docker-arm.patch
+++ b/community/docker/docker-arm.patch
@@ -1,5 +1,5 @@
 diff --git a/engine/engine.go b/engine/engine.go
-index 5da0a97..f468a59 100644
+index ec880b9..f03d657 100644
 --- a/engine/engine.go
 +++ b/engine/engine.go
 @@ -60,7 +60,7 @@ func (eng *Engine) Register(name string, handler Handler) error {
@@ -11,3 +11,172 @@ index 5da0a97..f468a59 100644
  		return nil, fmt.Errorf("The docker runtime currently only supports amd64 (not %s). This will change in the future. Aborting.", runtime.GOARCH)
  	}
  	// Check for unsupported kernel versions
+diff --git a/execdriver/lxc/lxc_init_linux.go b/execdriver/lxc/lxc_init_linux.go
+index 7288f58..66871cd 100644
+--- a/execdriver/lxc/lxc_init_linux.go
++++ b/execdriver/lxc/lxc_init_linux.go
+@@ -1,4 +1,4 @@
+-// +build amd64
++// +build amd64 arm
+ 
+ package lxc
+ 
+diff --git a/execdriver/lxc/lxc_init_unsupported.go b/execdriver/lxc/lxc_init_unsupported.go
+index d68cb91..47a40c0 100644
+--- a/execdriver/lxc/lxc_init_unsupported.go
++++ b/execdriver/lxc/lxc_init_unsupported.go
+@@ -1,4 +1,4 @@
+-// +build !linux !amd64
++// +build !linux !amd64,!arm
+ 
+ package lxc
+ 
+diff --git a/graphdriver/btrfs/btrfs.go b/graphdriver/btrfs/btrfs.go
+index 592e058..e6570b0 100644
+--- a/graphdriver/btrfs/btrfs.go
++++ b/graphdriver/btrfs/btrfs.go
+@@ -1,4 +1,5 @@
+-// +build linux,amd64
++// +build linux
++// +build amd64 arm
+ 
+ package btrfs
+ 
+@@ -30,7 +31,7 @@ func Init(home string) (graphdriver.Driver, error) {
+ 		return nil, err
+ 	}
+ 
+-	if buf.Type != 0x9123683E {
++	if uint32(buf.Type) != 0x9123683E {
+ 		return nil, fmt.Errorf("%s is not a btrfs filesystem", rootdir)
+ 	}
+ 
+diff --git a/graphdriver/btrfs/dummy_unsupported.go b/graphdriver/btrfs/dummy_unsupported.go
+index 6c44615..4613bde 100644
+--- a/graphdriver/btrfs/dummy_unsupported.go
++++ b/graphdriver/btrfs/dummy_unsupported.go
+@@ -1,3 +1,3 @@
+-// +build !linux !amd64
++// +build !linux !amd64,!arm
+ 
+ package btrfs
+diff --git a/pkg/graphdb/conn_linux.go b/pkg/graphdb/conn_linux.go
+index 7a1ab8c..893b806 100644
+--- a/pkg/graphdb/conn_linux.go
++++ b/pkg/graphdb/conn_linux.go
+@@ -1,4 +1,4 @@
+-// +build amd64
++// +build amd64 arm
+ 
+ package graphdb
+ 
+diff --git a/pkg/graphdb/conn_unsupported.go b/pkg/graphdb/conn_unsupported.go
+index c2d6025..1da959f 100644
+--- a/pkg/graphdb/conn_unsupported.go
++++ b/pkg/graphdb/conn_unsupported.go
+@@ -1,4 +1,4 @@
+-// +build !linux !amd64
++// +build !linux !amd64,!arm
+ 
+ package graphdb
+ 
+diff --git a/pkg/mount/flags_linux.go b/pkg/mount/flags_linux.go
+index b7124b1..2e9ef05 100644
+--- a/pkg/mount/flags_linux.go
++++ b/pkg/mount/flags_linux.go
+@@ -1,4 +1,4 @@
+-// +build amd64
++// +build amd64 arm
+ 
+ package mount
+ 
+diff --git a/pkg/mount/flags_unsupported.go b/pkg/mount/flags_unsupported.go
+index c894efe..5688fdd 100644
+--- a/pkg/mount/flags_unsupported.go
++++ b/pkg/mount/flags_unsupported.go
+@@ -1,4 +1,4 @@
+-// +build !linux !amd64
++// +build !linux !amd64,!arm
+ 
+ package mount
+ 
+diff --git a/pkg/mount/mounter_linux.go b/pkg/mount/mounter_linux.go
+index 70b7798..1d72009 100644
+--- a/pkg/mount/mounter_linux.go
++++ b/pkg/mount/mounter_linux.go
+@@ -1,4 +1,4 @@
+-// +build amd64
++// +build amd64 arm
+ 
+ package mount
+ 
+diff --git a/pkg/mount/mounter_unsupported.go b/pkg/mount/mounter_unsupported.go
+index ee27b35..bf5f5cd 100644
+--- a/pkg/mount/mounter_unsupported.go
++++ b/pkg/mount/mounter_unsupported.go
+@@ -1,4 +1,4 @@
+-// +build !linux !amd64
++// +build !linux !amd64,!arm
+ 
+ package mount
+ 
+diff --git a/pkg/netlink/netlink_linux.go b/pkg/netlink/netlink_linux.go
+index 0ea5b4d..bb38427 100644
+--- a/pkg/netlink/netlink_linux.go
++++ b/pkg/netlink/netlink_linux.go
+@@ -1,4 +1,4 @@
+-// +build amd64
++// +build amd64 arm
+ 
+ package netlink
+ 
+diff --git a/pkg/netlink/netlink_unsupported.go b/pkg/netlink/netlink_unsupported.go
+index cd796b3..96721a9 100644
+--- a/pkg/netlink/netlink_unsupported.go
++++ b/pkg/netlink/netlink_unsupported.go
+@@ -1,4 +1,4 @@
+-// +build !linux !amd64
++// +build !linux !amd64,!arm
+ 
+ package netlink
+ 
+diff --git a/reflink_copy_linux.go b/reflink_copy_linux.go
+index 74a0cb9..8c1dfea 100644
+--- a/reflink_copy_linux.go
++++ b/reflink_copy_linux.go
+@@ -1,4 +1,4 @@
+-// +build amd64
++// +build amd64 arm
+ 
+ package docker
+ 
+diff --git a/reflink_copy_unsupported.go b/reflink_copy_unsupported.go
+index 271ed01..67ba8fc 100644
+--- a/reflink_copy_unsupported.go
++++ b/reflink_copy_unsupported.go
+@@ -1,4 +1,4 @@
+-// +build !linux !amd64
++// +build !linux !amd64,!arm
+ 
+ package docker
+ 
+diff --git a/utils/uname_linux.go b/utils/uname_linux.go
+index 2f4afb4..ac8c1cb 100644
+--- a/utils/uname_linux.go
++++ b/utils/uname_linux.go
+@@ -1,4 +1,4 @@
+-// +build amd64
++// +build amd64 arm
+ 
+ package utils
+ 
+diff --git a/utils/uname_unsupported.go b/utils/uname_unsupported.go
+index 57b82ec..b9b0207 100644
+--- a/utils/uname_unsupported.go
++++ b/utils/uname_unsupported.go
+@@ -1,4 +1,4 @@
+-// +build !linux !amd64
++// +build !linux !amd64,!arm
+ 
+ package utils
+ 


### PR DESCRIPTION
This also contains the upstream changes to PKGBUILD.

Sorry, this being my first real contribution, I am a bit puzzled on how the other packages are built. I had to add `arch=('armv7h')` in order for _makepkg_ to work for me (on the ODROID-U3). When using `--ignorearch`, it complained about _gd_ missing as a dependency.

Also, I was not able to test any other than the btrfs storage driver, which works ok so far, although there are a few glitches I cannot explain yet. (AUFS needs a patched kernel and device mapper does not like my eMMC.)

Hoping docker will adopt the ARM architecture soon so we do not need such a lot of build arch patches.
