### PR TITLE
Build glibc with unwind tables

### DIFF
--- a/core/glibc/PKGBUILD
+++ b/core/glibc/PKGBUILD
@@ -71,6 +71,9 @@ build() {
   CFLAGS=${CFLAGS/-fstack-protector/}
   CPPFLAGS=${CPPFLAGS/-D_FORTIFY_SOURCE=2/}
 
+  # enable unwinding tables so that gdb can unwind the standard functions
+  CFLAGS+=" -funwind-tables"
+
   ${srcdir}/${pkgname}-${pkgver}/configure --prefix=/usr \
       --libdir=/usr/lib --libexecdir=/usr/lib \
       --with-headers=/usr/include \


### PR DESCRIPTION
Without debug symbols or this you cannot have reliable backtraces in gdb. For
instance this is on a Raspberry Pi without the unwind tables:

```
$ gcc -x c <(echo 'void abort(); int main() { abort(); }')
$ gdb ./a.out <<< $'r\nbt'
...
#1  0xb6eb2e44 in abort () from /usr/lib/libc.so.6
#2  0x00000020 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt
stack?)
...
```

Here's with the unwind tables enabled:

```
$ gcc -x c <(echo 'void abort(); int main() { abort(); }')
$ gdb ./a.out <<< $'r\nbt'
...
#1  0xb6eade44 in abort () from /usr/lib/libc.so.6
#2  0x000084e0 in main ()
...
```

The upside of the unwind tables compared to the debug symbols is that they don't
take up a lot of space.
