### PR TITLE
alarm/xbmc-imx switched branch to newest devel branch

### DIFF
--- a/alarm/xbmc-imx/PKGBUILD
+++ b/alarm/xbmc-imx/PKGBUILD
@@ -7,7 +7,7 @@
 buildarch=4
 
 pkgname=xbmc-imx-git
-pkgver=13.20140128
+pkgver=13.20140226
 pkgrel=1
 pkgdesc="A software media player and entertainment hub for digital media for the Wandboard"
 arch=('armv7h')
@@ -28,10 +28,10 @@ source=('xbmc.service')
 
 md5sums=('36780e43d432c488259d9a899b1bcb28')
 
-# imx-wip branch by Stephan "wolfgar" Rafin
+# master branch of xbmc-imx6 organization. Modified by Stephan "wolgar" Rafin, Chris "koying" Browet, Rudi "rudi-warped" Ihle and smallint
 _gitname="xbmc"
-_gitroot="git://github.com/wolfgar"
-_gitbranch="imx-wip"
+_gitroot="git://github.com/xbmc-imx6"
+_gitbranch="master"
 
 _prefix=/usr
 


### PR DESCRIPTION
Switched the git path from wolfgars private git to the new organisation dedicated to imx6 xbmc development.
