### PR TITLE
Compile linux-sun7i with ecryptfs module

### DIFF
--- a/core/linux-sun7i/config
+++ b/core/linux-sun7i/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 3.3.0-7 Kernel Configuration
+# Linux/arm 3.3.0-9 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_SYS_SUPPORTS_APM_EMULATION=y
@@ -3192,7 +3192,7 @@ CONFIG_CONFIGFS_FS=m
 CONFIG_MISC_FILESYSTEMS=y
 # CONFIG_ADFS_FS is not set
 # CONFIG_AFFS_FS is not set
-# CONFIG_ECRYPT_FS is not set
+CONFIG_ECRYPT_FS=m
 # CONFIG_HFS_FS is not set
 # CONFIG_HFSPLUS_FS is not set
 # CONFIG_BEFS_FS is not set


### PR DESCRIPTION
The ecryptfs-utils package is useless without the ecryptfs kernel module. Please consider supporting ecryptfs.
