### PR TITLE
alarm/xbmc-imx fix compile after 51d8b23414

### DIFF
--- a/alarm/xbmc-imx/PKGBUILD
+++ b/alarm/xbmc-imx/PKGBUILD
@@ -7,7 +7,7 @@
 buildarch=4
 
 pkgname=xbmc-imx-git
-pkgver=13.20140226
+pkgver=13.20140304
 pkgrel=1
 pkgdesc="A software media player and entertainment hub for digital media for the Wandboard"
 arch=('armv7h')
@@ -74,7 +74,7 @@ build() {
   # dirty: copy headers from kernel as we need those but apart from that want to use the ones in /usr/include 
   KERNELSRC=/usr/src/linux-${_kernel_release}
   mkdir -p linux-includes/include/linux
-  for f in mxcfb.h mxc_v4l2.h; do
+  for f in mxcfb.h mxc_v4l2.h ipu.h; do
     cp "${KERNELSRC}/include/linux/${f}" linux-includes/include/linux/
   done
 


### PR DESCRIPTION
528441343e of upstream introduced hardware-assisteted deinterlacing which requires the ipu.h from the freescale kernel tree. This fixes the compilation problem.
