### PR TITLE
Update xbmc-rbp package to build version 12.3.

### DIFF
--- a/alarm/xbmc-rbp/PKGBUILD
+++ b/alarm/xbmc-rbp/PKGBUILD
@@ -1,8 +1,9 @@
 # Contributor tomasgroth at yahoo.dk
 # Contributor WarheadsSE <max@warheads.net>
+# Contributor Romzetron <asromzek@gmail.com>
 pkgname=xbmc-rbp
-pkgver=12.2
-pkgrel=7
+pkgver=12.3
+pkgrel=1
 buildarch=16
 
 pkgdesc="A software media player and entertainment hub for digital media for the Raspberry Pi"
@@ -26,13 +27,15 @@ source=("http://mirrors.xbmc.org/releases/source/xbmc-${pkgver}.tar.gz"
 	"polkit.rules"
 	"xbmc.service")
 
-md5sums=('489f3877decae4e265ece54f9eaef0ba'
+md5sums=('7ae385ebf8e5cfcb917393235e6efbdb'
          'fc6a925a09ba1b13d84daf1121b42ab9'
          '02f7951824ee13103344f36009c0ef2a'
          '4e28664d3e0df08e08dba5b09a855ced')
 _prefix=/usr
 
 prepare() {
+  # Fix source directory name.
+  mv "${srcdir}/xbmc-${pkgver}-Frodo" "${srcdir}/xbmc-${pkgver}"
   cd "${srcdir}/xbmc-${pkgver}"
 
   # fix lsb_release dependency


### PR DESCRIPTION
I was able to compile XBMC 12.3 directly on a model B 512MB raspberry pi with this xbmc-rbp PKGBUILD. In order to compile, I had to set gpu_mem_512=64 in /boot/config.txt to allocate enough memory. I don't believe there were any other modifications needed beyond that.
