### PR TITLE
Fix download location for pepperflash

### DIFF
--- a/alarm/chromium-pepper-flash/PKGBUILD
+++ b/alarm/chromium-pepper-flash/PKGBUILD
@@ -14,8 +14,8 @@ provides=("chromium-pepper-flash=${pkgver}")
 optdepends=('pulseaudio-alsa: For PulseAudio users')
 install=chromium-pepper-flash.install
 source=('license.html::http://www.google.com/chrome/intl/en/eula_text.html'
-         "http://mirror.nekinie.com/chromium-pepper-flash-armv7h/PepperFlash-${pkgver}-armv7h.tar.gz")
-	 # Backup (slow) mirror "https://www.dray.be/PepperFlash-${pkgver}-armv7h.tar.gz"
+         "http://odroidxu.leeharris.me.uk/PepperFlash-${pkgver}-armv7h.tar.gz")
+	 # Backup (slow) mirror "https://www.dray.be/arch/files/PepperFlash-${pkgver}-armv7h.tar.gz"
 md5sums=('ba19ea498f294975d320ff0b26a6cd63'
          '7631da586071874409dac066f85ca567')
 


### PR DESCRIPTION
http://mirror.nekinie.com/chromium-pepper-flash-armv7h/PepperFlash-${pkgver}-armv7h.tar.gz
is non-existent and the files location on the backup server has changed.
I have made the file available on my own server http://odroidxu.leeharris.me.uk
