### PR TITLE
Support for non-CEA resolutions and DVI

### DIFF
--- a/core/linux-imx6-cubox/HDMI-non-CEA-and-DVI.pat
+++ b/core/linux-imx6-cubox/HDMI-non-CEA-and-DVI.pat
@@ -1,0 +1,25 @@
+This fixes problems with DVI monitors connected to the HDMI port
+via a DVI <-> HDMI cable. With dvi monitors, the list of CEA modes
+is always zero, preventing modes higher than 1024x768 to be used.
+This patch disables the CEA mode check.
+
+Upstream-Status: Pending
+
+diff --git a/drivers/video/mxc_hdmi.c b/drivers/video/mxc_hdmi.c
+index 544f352..fa67128 100644
+--- a/drivers/video/mxc_hdmi.c
++++ b/drivers/video/mxc_hdmi.c
+@@ -1804,10 +1804,10 @@ static void mxc_hdmi_edid_rebuild_modelist(struct mxc_hdmi *hdmi)
+ 		 */
+ 		mode = &hdmi->fbi->monspecs.modedb[i];
+ 
+-		if (!(mode->vmode & FB_VMODE_INTERLACED) &&
+-				(mxc_edid_mode_to_vic(mode) != 0)) {
++		if (!(mode->vmode & FB_VMODE_INTERLACED)) {
++			int vic = mxc_edid_mode_to_vic(mode);
+ 
+-			dev_dbg(&hdmi->pdev->dev, "Added mode %d:", i);
++			dev_dbg(&hdmi->pdev->dev, "%s: Added mode %d(VIC %u):", __func__, i, vic);
+ 			dev_dbg(&hdmi->pdev->dev,
+ 				"xres = %d, yres = %d, freq = %d, vmode = %d, flag = %d\n",
+ 				hdmi->fbi->monspecs.modedb[i].xres,

--- a/core/linux-imx6-cubox/PKGBUILD
+++ b/core/linux-imx6-cubox/PKGBUILD
@@ -15,7 +15,7 @@ _srcname=linux-imx6-${_commit}
 _kernelname=${pkgname#linux}
 _basekernel=3.0
 pkgver=${_basekernel}.35
-pkgrel=12
+pkgrel=13
 arch=('arm')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -24,10 +24,12 @@ options=('!strip')
 
 source=("https://github.com/solidrun/linux-imx6/archive/${_commit}.tar.gz"
         'config'
-        'change-default-console-loglevel.pat')
+        'change-default-console-loglevel.pat'
+	'HDMI-non-CEA-and-DVI.pat')
 md5sums=('b3ac96e3f1fb02a39d4efed0e25fbc5b'
-         '3705606b05de16cc2d8d25ff3639aed6'
-         '9d3c56a4b999c8bfbd4018089a62f662')
+         'ad61576d986e5b7011618b2a237e1470'
+         '9d3c56a4b999c8bfbd4018089a62f662'
+	 '7a4730c2040fbd208045ce2770978fe9')
 
 prepare() {
   cd "${srcdir}/${_srcname}"
@@ -44,6 +46,7 @@ prepare() {
   # remove this when a Kconfig knob is made available by upstream
   # (relevant patch sent upstream: https://lkml.org/lkml/2011/7/26/227)
   patch -Np1 -i "${srcdir}/change-default-console-loglevel.pat"
+  patch -Np1 -i "${srcdir}/HDMI-non-CEA-and-DVI.pat"
 
 }
 

--- a/core/linux-imx6-cubox/config
+++ b/core/linux-imx6-cubox/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated make config: don't edit
-# Linux/arm 3.0.35-12 Kernel Configuration
+# Linux/arm 3.0.35-13 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_HAVE_PWM=y


### PR DESCRIPTION
This pull request will update the PKGBUILD to apply a patch "HDMI-non-CEA-and-DVI.pat" to the kernel source.

The patch itself does two things:
1. Adds support for non-CEA resolutions.
2. Adds support for HDMI <==> DVI converter cables.

I have cleanly built using these exact changes on my cubox-i quad.  The only thing I had to do was change the arch=('arm') to arch=('armv7h') in PKGBUILD.  I decided not to include this in the pull request because it appears that that's preferred.

I can confirm that the resulting 3.0.35 kernel does now support non-CEA resolutions and HDMI <==> DVI converter cables.

Please note: I did not create the patch, it actually comes from here: https://github.com/Freescale/meta-fsl-arm-extra/blob/master/recipes-kernel/linux/linux-cubox-i-3.0.35/mxc_hdmi-dont-require-cea-mode.patch

Rob
