### PR TITLE
backup uEnv.txt to prevent overriding user configuration

### DIFF
--- a/alarm/uboot-sunxi/PKGBUILD
+++ b/alarm/uboot-sunxi/PKGBUILD
@@ -6,11 +6,12 @@ buildarch=4
 pkgbase=uboot-sunxi
 pkgname=('uboot-cubieboard2' 'uboot-cubietruck')
 pkgver=2014.01
-pkgrel=1
+pkgrel=2
 arch=('armv7h')
 url="https://github.com/linux-sunxi/u-boot-sunxi/tree/sunxi-current"
 license=('GPL')
 makedepends=('sunxi-tools')
+backup=(boot/uEnv.txt)
 _commit=660aa6fd9e1c25baabfcf4dfce42381547f5f59b
 source=("https://github.com/linux-sunxi/u-boot-sunxi/archive/${_commit}.tar.gz"
         'alarm.patch'


### PR DESCRIPTION
This is just to prevent that an update of this package will override the users `uEnv.txt` if they have made changes to the file.
