### PR TITLE
alarm/xbmc-imx Fixed colliding header name

### DIFF
--- a/alarm/xbmc-imx/PKGBUILD
+++ b/alarm/xbmc-imx/PKGBUILD
@@ -6,14 +6,14 @@
 buildarch=4
 
 pkgname=xbmc-imx-git
-pkgver=13.20140329
+pkgver=13.20140330
 pkgrel=1
 pkgdesc="A software media player and entertainment hub for digital media for select imx6 systems"
 arch=('armv7h')
 url="http://xbmc.org"
 license=('GPL' 'custom')
 depends=('fribidi' 'lzo2' 'smbclient' 'libtiff' 'libpng' 'libcdio' 'yajl' 'libmariadbclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd' 'sdl_image' 'python2' 'libass' 'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'libbluray' 'libnfs' 'afpfs-ng' 'libshairport' 'avahi' 'bluez-libs' 'tinyxml' 'libplist' 'swig' 'taglib' 'libxslt' 'libfslvpuwrap' 'gpu-viv-bin-mx6q-fb' 'libcec-imx6')
-makedepends=('boost' 'cmake' 'gperf' 'nasm' 'zip' 'udisks' 'upower' 'git' 'autoconf' 'java-runtime-headless' 'linux-headers-imx6')
+makedepends=('boost' 'cmake' 'gperf' 'nasm' 'zip' 'udisks' 'upower' 'git' 'autoconf' 'java-runtime-headless' 'linux-headers-imx6-fsl')
 optdepends=(
   'lirc: remote controller support'
   'udisks: automount external drives'

--- a/core/linux-imx6-cubox-dt/PKGBUILD
+++ b/core/linux-imx6-cubox-dt/PKGBUILD
@@ -15,7 +15,7 @@ _srcname=linux-linaro-stable-mx6-${_commit}
 _kernelname=${pkgname#linux}
 _basekernel=3.10
 pkgver=${_basekernel}.30
-pkgrel=11
+pkgrel=12
 arch=('arm')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -138,7 +138,7 @@ package_linux-imx6-cubox-dt() {
 
 package_linux-headers-imx6-cubox-dt() {
   pkgdesc="Header files and scripts for building modules for linux kernel - i.MX6 cubox-i"
-  provides=("linux-headers=${pkgver}" "linux-headers-imx6=${pkgver}")
+  provides=("linux-headers=${pkgver}" "linux-headers-imx6-fsl=${pkgver}")
   conflicts=('linux-headers-omap' 'linux-headers-trimslice')
 
   install -dm755 "${pkgdir}/usr/lib/modules/${_kernver}"

--- a/core/linux-imx6-cubox/PKGBUILD
+++ b/core/linux-imx6-cubox/PKGBUILD
@@ -15,7 +15,7 @@ _srcname=linux-imx6-${_commit}
 _kernelname=${pkgname#linux}
 _basekernel=3.0
 pkgver=${_basekernel}.35
-pkgrel=17
+pkgrel=18
 arch=('arm')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -140,7 +140,7 @@ package_linux-imx6-cubox() {
 
 package_linux-headers-imx6-cubox() {
   pkgdesc="Header files and scripts for building modules for linux kernel - i.MX6 cubox-i"
-  provides=("linux-headers=${pkgver}" "linux-headers-imx6=${pkgver}")
+  provides=("linux-headers=${pkgver}" "linux-headers-imx6-fsl=${pkgver}")
   conflicts=('linux-headers-omap' 'linux-headers-trimslice')
 
   install -dm755 "${pkgdir}/usr/lib/modules/${_kernver}"

--- a/core/linux-imx6-wandboard-dt/PKGBUILD
+++ b/core/linux-imx6-wandboard-dt/PKGBUILD
@@ -9,7 +9,7 @@ _srcname=linux-wandboard_imx_3.10.17_1.0.0_beta
 _kernelname=${pkgbase#linux}
 _desc="i.MX6 Wandboard"
 pkgver=3.10.17
-pkgrel=3
+pkgrel=4
 rcnrel=wand6
 arch=('armv7h')
 url="http://www.kernel.org/"
@@ -119,7 +119,7 @@ _package() {
 
 _package-headers() {
   pkgdesc="Header files and scripts for building modules for linux kernel - ${_desc}"
-  provides=("linux-headers=${pkgver}" "linux-headers-imx6=${pkgver}")
+  provides=("linux-headers=${pkgver}" "linux-headers-imx6-fsl=${pkgver}")
   conflicts=('linux-headers-omap' 'linux-headers-trimslice')
 
   install -dm755 "${pkgdir}/usr/lib/modules/${_kernver}"


### PR DESCRIPTION
linux-headers-imx6 does collide with the linux-imx6 package.
Renamed linux-headers-imx6 to linux-headers-imx6-fsl and changed provides/makedepends accordingly.

Sorry for all the confusion.

Cheers
