### PR TITLE
alarm/imx-vpu update to most recent 3.10.17

### DIFF
--- a/alarm/imx-vpu/PKGBUILD
+++ b/alarm/imx-vpu/PKGBUILD
@@ -3,15 +3,15 @@
 
 buildarch=4
 pkgname=imx-vpu
-pkgver=3.10.9_1.0.0
-_pkgver=${pkgver/_/-}
+pkgver=3.10.17_1.0.0
+_pkgver=${pkgver/_/-}_beta
 pkgrel=1
 pkgdesc="Freescale proprietary extensions for i.MX6 SoC"
 url="https://community.freescale.com/docs/DOC-95560"
 arch=('armv7h')
 license=('proprietary')
 source=("http://www.freescale.com/lgfiles/NMG/MAD/YOCTO/${pkgname}-${_pkgver}.bin" '99-mxc-vpu.rules')
-md5sums=('61331c9ed2d4c1b3aeab9c35fd034ac3'
+md5sums=('7ba78483bd1cf61bb6fce4ed9e9287d6'
           'b749d82b96a323d8f914c63c65de9f92')
 
 

--- a/alarm/libfslvpuwrap/PKGBUILD
+++ b/alarm/libfslvpuwrap/PKGBUILD
@@ -3,7 +3,7 @@
 
 buildarch=4
 pkgname=libfslvpuwrap
-pkgver=3.10.9_1.0.0
+pkgver=3.10.17_1.0.0
 _pkgver=1.0.45
 pkgrel=1
 pkgdesc="Wrapper library for the freescale proprietary VPU extensions"


### PR DESCRIPTION
This updates imx-vpu to the most recent release.
I also updated the pkgver of libfslvpuwrap to 3.10.17 to match imx-vpu. (This version of libfslvpuwrap does also originally belong to the 3.10.17 release, so this makes perfect sense).
