### PR TITLE
core/linux-imx6-wandboard-dt add patch to fix static noise on hdmi/spdif

### DIFF
--- a/core/linux-imx6-wandboard-dt/PKGBUILD
+++ b/core/linux-imx6-wandboard-dt/PKGBUILD
@@ -9,7 +9,7 @@ _srcname=linux-wandboard_imx_3.10.17_1.0.0_beta
 _kernelname=${pkgbase#linux}
 _desc="i.MX6 Wandboard"
 pkgver=3.10.17
-pkgrel=4
+pkgrel=5
 rcnrel=wand6
 arch=('armv7h')
 url="http://www.kernel.org/"
@@ -17,10 +17,12 @@ license=('GPL2')
 makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'git' 'uboot-mkimage')
 options=('!strip')
 source=("https://github.com/wandboard-org/linux/archive/wandboard_imx_3.10.17_1.0.0_beta.zip"
-        'config')
+        'config'
+	'fix-static-noise.patch')
 
 md5sums=('544cacb64a0a721a2df58ceedd367cfe'
-         'a335dd395460320d6c07fdfcb9efe0a3')
+         'a335dd395460320d6c07fdfcb9efe0a3'
+         '8fd33b21538f41c605da7e990fc99ce2')
 
 prepare() {
   cd "${srcdir}/${_srcname}"
@@ -32,6 +34,9 @@ prepare() {
 
   # don't run depmod on 'make install'. We'll do this ourselves in packaging
   sed -i '2iexit 0' scripts/depmod.sh
+
+  # fix static noise on hdmi and spdif
+  patch -l -p0 <../fix-static-noise.patch
 }
 
 build() {

--- a/core/linux-imx6-wandboard-dt/fix-static-noise.patch
+++ b/core/linux-imx6-wandboard-dt/fix-static-noise.patch
@@ -1,0 +1,31 @@
+--- sound/soc/mxs/mxs-pcm.c.orig        2014-03-31 22:18:46.554699921 +0200
++++ sound/soc/mxs/mxs-pcm.c     2014-03-31 22:19:53.964699929 +0200
+@@ -36,9 +36,7 @@
+                                  SNDRV_PCM_INFO_RESUME |
+                                  SNDRV_PCM_INFO_INTERLEAVED |
+                                  SNDRV_PCM_INFO_HALF_DUPLEX,
+-       .formats                = SNDRV_PCM_FMTBIT_S16_LE |
+-                                 SNDRV_PCM_FMTBIT_S20_3LE |
+-                                 SNDRV_PCM_FMTBIT_S24_LE,
++       .formats                = SNDRV_PCM_FMTBIT_S16_LE,
+        .channels_min           = 2,
+        .channels_max           = 2,
+        .period_bytes_min       = 32,
+diff --git sound/soc/fsl/fsl_spdif.h sound/soc/fsl/fsl_spdif.h
+index dbbbb1e..5a46dcb 100644
+--- sound/soc/fsl/fsl_spdif.h
++++ sound/soc/fsl/fsl_spdif.h
+@@ -184,9 +184,13 @@ enum spdif_txrate {
+                                         SNDRV_PCM_RATE_64000 | \
+                                         SNDRV_PCM_RATE_96000)
+
++// !!! temporary workaround for broken 24bit mode !!!
++#define FSL_SPDIF_FORMATS_PLAYBACK     (SNDRV_PCM_FMTBIT_S16_LE)
++/*
+ #define FSL_SPDIF_FORMATS_PLAYBACK     (SNDRV_PCM_FMTBIT_S16_LE | \
+                                         SNDRV_PCM_FMTBIT_S20_3LE | \
+                                         SNDRV_PCM_FMTBIT_S24_LE)
++*/
+
+ #define FSL_SPDIF_FORMATS_CAPTURE      (SNDRV_PCM_FMTBIT_S24_LE)
+


### PR DESCRIPTION
This patch fixes static noise on hdmi and spdif and is necessary until xbmc-imx6/xbmc#16 is fixed.
Thanks @warped-rudi for the hdmi part and @meld0 for the spdif equivalent.
