### PR TITLE
alarm/firmware-imx fix installation path

### DIFF
--- a/alarm/firmware-imx/PKGBUILD
+++ b/alarm/firmware-imx/PKGBUILD
@@ -5,7 +5,7 @@ buildarch=4
 pkgname=firmware-imx
 pkgver=3.5.7_1.0.0
 _pkgver=${pkgver/_/-}
-pkgrel=1
+pkgrel=2
 pkgdesc="Freescale proprietary firmware for i.MX6 SoC"
 url="https://community.freescale.com/docs/DOC-95560"
 arch=('armv7h')
@@ -15,18 +15,14 @@ md5sums=('7285345d99e1064bdbad113e3d9b8f40')
 
 prepare() {
   cd "${srcdir}"
-  #chmod for execution, library is packed as binary to accept EULA
-#  chmod +x ${pkgname}-${_pkgver}.bin
+  #extract the firmware, its packed as a script
   sh ${pkgname}-${_pkgver}.bin --force --auto-accept
   sed -n '/EOEULA/,/EOEULA/p' ${pkgname}-${_pkgver}.bin | grep -v EOEULA > LICENSE.$pkgname
 }
 
 package() {
-  #cd "${pkgdir}"
-  #ls -l
-  #ls -l "${srcdir}/${pkgname}-${_pkgver}"
-  mkdir -p "${pkgdir}/lib/firmware/vpu"
-  cp -rv "${srcdir}/${pkgname}-${_pkgver}/firmware/vpu/"* "${pkgdir}/lib/firmware/vpu"
+  mkdir -p "${pkgdir}/usr/lib/firmware/vpu"
+  cp -rv "${srcdir}/${pkgname}-${_pkgver}/firmware/vpu/"* "${pkgdir}/usr/lib/firmware/vpu"
 
   mkdir -p "${pkgdir}/opt/fsl/licenses"
   cp "${srcdir}/LICENSE.$pkgname" "$pkgdir/opt/fsl/licenses"


### PR DESCRIPTION
Change the installation path from /lib to /usr/lib to comply with packaging standards.
Thanks to @aplund for pointing this out and providing a fix :)
