### PR TITLE
uboot-cubieboard2 lacked support for controlling the green led

### DIFF
--- a/alarm/uboot-sunxi/PKGBUILD
+++ b/alarm/uboot-sunxi/PKGBUILD
@@ -6,7 +6,7 @@ buildarch=4
 pkgbase=uboot-sunxi
 pkgname=('uboot-cubieboard2' 'uboot-cubietruck')
 pkgver=2014.01
-pkgrel=3
+pkgrel=4
 arch=('armv7h')
 url="https://github.com/linux-sunxi/u-boot-sunxi/tree/sunxi-current"
 license=('GPL')
@@ -19,7 +19,7 @@ source=("https://github.com/linux-sunxi/u-boot-sunxi/archive/${_commit}.tar.gz"
         'cubietruck.fex' 'cubietruck.env')
 md5sums=('019e2a420fa9d9a5e24aaf9cd8de2104'
          'f2f60fca0d93ef62c6a95c4f3254a829'
-         '7423919c2ead208c5a04756edb6b948c'
+         '36c04988cecd53151f3f5ff5c48d76a9'
          'd41d8cd98f00b204e9800998ecf8427e'
          'c898ab1b57f474d620f5704b2a53d87c'
          'd41d8cd98f00b204e9800998ecf8427e')

--- a/alarm/uboot-sunxi/cubieboard2.fex
+++ b/alarm/uboot-sunxi/cubieboard2.fex
@@ -286,11 +286,15 @@ gpio_pin_1 = port:PH20<1><default><default><1>
 
 [leds_para]
 leds_used = 1
-leds_num = 1
-leds_pin_1 = port:PH21<1><default><default><0>
-leds_name_1 = "blue:ph21:led2"
+leds_num = 2
+leds_pin_1 = port:PH20<1><default><default><0>
+leds_name_1 = "green:ph20:led1"
+leds_pin_2 = port:PH21<1><default><default><0>
+leds_name_2 = "blue:ph21:led2"
 leds_default_1 = 0
-leds_trigger_1 = "heartbeat"
+leds_trigger_1 = "none"
+leds_default_2 = 0
+leds_trigger_2 = "heartbeat"
 
 [nand_para]
 nand_used = 1


### PR DESCRIPTION
The board started with green led turned on and /sys/class/led/green:ph20:led1 was missing
Patch made following the directions found on http://linux-sunxi.org/Cubieboard/Programming/StatusLEDs
