### PR TITLE
alarm/xbmc-imx: fix unchangable refresh rate

### DIFF
--- a/alarm/xbmc-imx/PKGBUILD
+++ b/alarm/xbmc-imx/PKGBUILD
@@ -7,7 +7,7 @@ buildarch=4
 
 pkgname=xbmc-imx-git
 pkgver=13.20140421
-pkgrel=1
+pkgrel=2
 pkgdesc="A software media player and entertainment hub for digital media for select imx6 systems"
 arch=('armv7h')
 url="http://xbmc.org"
@@ -29,7 +29,7 @@ source=('xbmc.service'
 
 md5sums=('07096dfd530cc432fa6073ee1a32e7f6'
          '730ac095a89b05c3c2cf2dd93947cb5c'
-         '00704fd638de9b7f071479cb22e81dae')
+         '8fab4cc5cac44a7090ca7e839e326ec8')
 
 # master branch of xbmc-imx6 organization. Modified by Stephan "wolgar" Rafin, Chris "koying" Browet, Rudi "rudi-warped" Ihle and smallint
 _gitname="xbmc"

--- a/alarm/xbmc-imx/xbmc.conf
+++ b/alarm/xbmc-imx/xbmc.conf
@@ -1,1 +1,2 @@
 m /sys/devices/virtual/graphics/fbcon/cursor_blink 0666 root root - -
+m /sys/class/graphics/fb0/mode 0666 root root - -


### PR DESCRIPTION
On i.MX6, the refresh rate is changable (for e.g. 24Hz playback) via /sys/class/graphics/fb0/mode, but it was read only on arch.
