### PR TITLE
alarm/xbmc-imx bump to gotham beta4

### DIFF
--- a/alarm/xbmc-imx/PKGBUILD
+++ b/alarm/xbmc-imx/PKGBUILD
@@ -6,8 +6,8 @@
 buildarch=4
 
 pkgname=xbmc-imx-git
-pkgver=13.20140421
-pkgrel=2
+pkgver=13.20140423
+pkgrel=1
 pkgdesc="A software media player and entertainment hub for digital media for select imx6 systems"
 arch=('armv7h')
 url="http://xbmc.org"


### PR DESCRIPTION
@wolfgar has merged xbmc-imx6/xbmc#61 which updates to official xbmc gotham beta4.
Bump pkgver to rebuild, reset pkgrel.
