### PR TITLE
alarm/xbmc-imx: enable xbmc to restart/shutdown the system

### DIFF
--- a/alarm/xbmc-imx/10-xbmc.rules
+++ b/alarm/xbmc-imx/10-xbmc.rules
@@ -1,0 +1,11 @@
+polkit.addRule(function(action, subject) {
+    if (action.id.match("org.freedesktop.login1.") && subject.isInGroup("power")) {
+        return polkit.Result.YES;
+    }
+});
+
+polkit.addRule(function(action, subject) {
+    if (action.id.indexOf("org.freedesktop.udisks") == 0 && subject.isInGroup("storage")) {
+        return polkit.Result.YES;
+    }
+});

--- a/alarm/xbmc-imx/PKGBUILD
+++ b/alarm/xbmc-imx/PKGBUILD
@@ -7,17 +7,16 @@ buildarch=4
 
 pkgname=xbmc-imx-git
 pkgver=13.20140423
-pkgrel=1
+pkgrel=2
 pkgdesc="A software media player and entertainment hub for digital media for select imx6 systems"
 arch=('armv7h')
 url="http://xbmc.org"
 license=('GPL' 'custom')
 depends=('fribidi' 'lzo2' 'smbclient' 'libtiff' 'libpng' 'libcdio' 'yajl' 'libmariadbclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd' 'sdl_image' 'python2' 'libass' 'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'libbluray' 'libnfs' 'afpfs-ng' 'libshairport' 'avahi' 'bluez-libs' 'tinyxml' 'libplist' 'swig' 'taglib' 'libxslt' 'libfslvpuwrap' 'gpu-viv-bin-mx6q-fb' 'libcec-imx6' 'firmware-imx')
-makedepends=('boost' 'cmake' 'gperf' 'nasm' 'zip' 'udisks' 'upower' 'git' 'autoconf' 'java-runtime-headless' 'linux-headers-imx6-fsl')
+makedepends=('boost' 'cmake' 'gperf' 'nasm' 'zip' 'udisks' 'git' 'autoconf' 'java-runtime-headless' 'linux-headers-imx6-fsl')
 optdepends=(
   'lirc: remote controller support'
   'udisks: automount external drives'
-  'upower: used to trigger suspend functionality'
   'unrar: access compressed files without unpacking them'
 )
 provides=("xbmc")
@@ -25,11 +24,13 @@ conflicts=("xbmc")
 install="xbmc.install"
 source=('xbmc.service'
         'runxbmc'
-        'xbmc.conf')
+        'xbmc.conf'
+        '10-xbmc.rules')
 
 md5sums=('07096dfd530cc432fa6073ee1a32e7f6'
          '730ac095a89b05c3c2cf2dd93947cb5c'
-         '8fab4cc5cac44a7090ca7e839e326ec8')
+         '8fab4cc5cac44a7090ca7e839e326ec8'
+         '1cbf21efa5fef760e1651115d475faf9')
 
 # master branch of xbmc-imx6 organization. Modified by Stephan "wolgar" Rafin, Chris "koying" Browet, Rudi "rudi-warped" Ihle and smallint
 _gitname="xbmc"
@@ -119,7 +120,8 @@ package() {
   install -Dm0644 $srcdir/xbmc.service $pkgdir/usr/lib/systemd/system/xbmc.service
   install -Dm0755 $srcdir/runxbmc $pkgdir/usr/bin/runxbmc
   install -Dm0644 $srcdir/xbmc.conf $pkgdir/etc/tmpfiles.d/xbmc.conf
-
+  install -Dm0644 $srcdir/10-xbmc.rules $pkgdir/etc/polkit-1/rules.d/10-xbmc.rules
+  chmod 700 $pkgdir/etc/polkit-1/rules.d
 }
 
 


### PR DESCRIPTION
With this, the shutdown/restart command appear and work in the xbmc exit menu.
polkit script source: https://bbs.archlinux.org/viewtopic.php?pid=1202676

Upower must be removed (maybe even add to conflicts?), otherwise neighter shutdown nor restart will be in the menu. Probably because it's only for suspend/hybernate, and since the platform is unable to do that, the related dbus call will return an error, which will disable the whole power handling. 
