### PR TITLE
use install script arguments in core/linux-raspberrypi

### DIFF
--- a/core/linux-raspberrypi/linux-raspberrypi.install
+++ b/core/linux-raspberrypi/linux-raspberrypi.install
@@ -1,13 +1,10 @@
 # arg 1:  the new package version
 # arg 2:  the old package version
 
-KERNEL_NAME=-raspberrypi
-KERNEL_VERSION=3.12.19-1-ARCH
-
 post_install () {
   # updating module dependencies
   echo ">>> Updating module dependencies. Please wait ..."
-  depmod ${KERNEL_VERSION}
+  depmod ${1}-ARCH
 }
 
 post_upgrade() {
@@ -20,5 +17,5 @@ post_upgrade() {
 
   # updating module dependencies
   echo ">>> Updating module dependencies. Please wait ..."
-  depmod ${KERNEL_VERSION}
+  depmod ${1}-ARCH
 }


### PR DESCRIPTION
This patch would save the maintainers having to update the install script every time they bump the version. Just a suggestion!
