### PR TITLE
alarm/fake-hwclock: use systemd timer unit, to 0.3

### DIFF
--- a/alarm/fake-hwclock/PKGBUILD
+++ b/alarm/fake-hwclock/PKGBUILD
@@ -1,24 +1,33 @@
 # Maintainer: Oleg Rakhmanov <orakhmanov [at] gmail [dot] com>
+# Contributor: Peter Wu <peter (at) lekensteyn (dot) nl>
 #
 # Reworked Alexander Manning's rc.d script for systemd
 # Reference: http://archplusplus.co.uk/post/31401843803/fake-hwclock-for-arch-linux-arm-on-raspberry-pi
 
 pkgname=fake-hwclock
-pkgver=0.2
+pkgver=0.3
 pkgrel=1
 pkgdesc="Saves time on shutdown and restores it on boot from a file"
-arch=('arm')
+arch=('any')
 license=('GPL')
 install=fake-hwclock.install
 source=('fake-hwclock.sh'
-        'fake-hwclock.service')
+        'fake-hwclock.service'
+        'fake-hwclock-save.service'
+        'fake-hwclock-save.timer')
 
-md5sums=('09cea0ee86071fb86d3cdbc52feabe69'
-         '8a328ff872a092dcdf86088ae2c20fd3')
+md5sums=('713f9cd5d8dc0073b5eca5dd14de1271'
+         'fa52aac3db246575c3cc8c1bf608766c'
+         '9f93ed2b74260d204a9c285d35ee2daa'
+         'b2b494cb4ba99eb12df3cb4188902ca4')
 
 package() {
-  mkdir -p "${pkgdir}/usr/lib/systemd/"{scripts,system}
-
-  cp "${srcdir}/fake-hwclock.sh" "${pkgdir}/usr/lib/systemd/scripts/"
-  cp "${srcdir}/fake-hwclock.service" "${pkgdir}/usr/lib/systemd/system/"
+  install -D -m755 "${srcdir}/fake-hwclock.sh" "${pkgdir}/usr/lib/systemd/scripts/fake-hwclock.sh"
+  for unit in \
+    fake-hwclock.service \
+    fake-hwclock-save.service \
+    fake-hwclock-save.timer
+  do
+    install -D -m644 "${srcdir}/$unit" "${pkgdir}/usr/lib/systemd/system/$unit"
+  done
 }

--- a/alarm/fake-hwclock/fake-hwclock-save.service
+++ b/alarm/fake-hwclock/fake-hwclock-save.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Periodically saves system time to file
+After=fake-hwclock.service
+Requires=fake-hwclock.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/fake-hwclock.sh save
+StandardOutput=null

--- a/alarm/fake-hwclock/fake-hwclock-save.timer
+++ b/alarm/fake-hwclock/fake-hwclock-save.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Periodically saves system time to file timer
+After=fake-hwclock.service
+
+[Timer]
+OnActiveSec=15min
+OnUnitActiveSec=15min
+
+[Install]
+WantedBy=fake-hwclock.service

--- a/alarm/fake-hwclock/fake-hwclock.install
+++ b/alarm/fake-hwclock/fake-hwclock.install
@@ -1,9 +1,8 @@
 post_install () {
-  echo "**********************************************************************"
-  echo "To keep fake-hwclock up to date in case of a power failure, add the"
-  echo "following job to root crontab: "
-  echo "*/15 * * * * /usr/lib/systemd/scripts/fake-hwclock.sh save"
-  echo "**********************************************************************"
+  echo "To restore the system time on boot, save the time on shutdown and"
+  echo "periodically save the system time in case of power failure:"
+  echo "  systemctl enable fake-hwclock fake-hwclock-save.timer"
+  echo "  systemctl start fake-hwclock"
 }
 
 post_upgrade () {

--- a/alarm/fake-hwclock/fake-hwclock.service
+++ b/alarm/fake-hwclock/fake-hwclock.service
@@ -1,13 +1,12 @@
 [Unit]
-Description=Saves time on shutdown and sets it at boot.
+Description=Restore system time on boot and save it on shutdown
 After=sysinit.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/lib/systemd/scripts/fake-hwclock.sh set
+ExecStart=/usr/lib/systemd/scripts/fake-hwclock.sh load
 ExecStop=/usr/lib/systemd/scripts/fake-hwclock.sh save
 RemainAfterExit=true
 
 [Install]
 WantedBy=sysinit.target
-

--- a/alarm/fake-hwclock/fake-hwclock.sh
+++ b/alarm/fake-hwclock/fake-hwclock.sh
@@ -1,27 +1,37 @@
 #!/bin/bash
 
 THISFILE=$0
+STATEFILE=$0
 
-setclock() {
-	echo "Setting clock."
-	MYTIME=$(date -r $THISFILE '+%Y-%m-%d %H:%M:%S')
-	date --set="$MYTIME" &>/dev/null
+loadclock() {
+	local savedtime=$(stat -c %Y "$STATEFILE")
+	if [ $(date +%s) -lt $savedtime ]; then
+		echo "Restoring saved system time"
+		date -s @$savedtime
+	else
+		echo "Not restoring old system time"
+	fi
 }
 
 saveclock() {
 	echo "Saving current time."
-	touch $THISFILE &>/dev/null
+	touch "$STATEFILE"
 }
 
 case "$1" in
+	load)
+		loadclock
+		;;
 	set)
-		setclock
+		echo "'set' is deprecated, use 'load' instead."
+		echo "Consider using the systemd timer unit fake-hwclock-save.timer"
+		loadclock
 		;;
 	save)
 		saveclock
 		;;
 	*)
-		echo "Usage: $THISFILE {set|save}"
+		echo "Usage: $THISFILE {load|save}"
 		exit 1
 		;;
 esac


### PR DESCRIPTION
- PKGBUILD: modified to install directories with correct permissions (in
  case of a restrictive umask).
- PKGBUILD: change arch to any as this is arch-indep.
- fake-hwclock.sh: add 'load' command that sets the system time only if
  the current time is older; make 'set' an deprecated alias of it.
- Add fake-hwclock-save timer and service that saves the time every 15
  minutes.
- install: suggest to enable timer unit instead of cron.
