### PR TITLE
Don't check the md5sum of linux-chromebook source tarballs

### DIFF
--- a/core/linux-chromebook/PKGBUILD
+++ b/core/linux-chromebook/PKGBUILD
@@ -21,7 +21,8 @@ source=("https://chromium.googlesource.com/chromiumos/third_party/kernel/+archiv
         'config'
         'kernel.its')
 noextract=("${_commit}.tar.gz")
-md5sums=('06b85c85adf960c6e441314755e0df59'
+# Skipping the source, the tarball is regenerated regularly with new timestamps.
+md5sums=('SKIP'
          'f01929a84dd2e295ebf6e2b5e3cdbf82'
          '56f8343875b928b6aa4e83921e5df25f')
 


### PR DESCRIPTION
Make the linux-chromebook package feasible to build again.

Commit af0a9081f743265a71db625633bb2e58481a88e6 introduced an md5sum for the chromebook archive .tar.gz tarball pulled from chromium.googlesource.com, but even though these tarballs are specific to a commit they are regenerated regularly (on each download?) with new timestamps, so the md5sum changes.

I just put back in the SKIP value that had been present in the previous commit 303fd6d7f570d635913fd2133703c2cb3ae19007 (since f6d5381f0abf6e629ab1f39173fb2dbf6598a5a4), and clarified the comment to avoid this disappearing in the future.
