### PR TITLE
alarm/xbmc-imx bump to 13.1

### DIFF
--- a/alarm/xbmc-imx/PKGBUILD
+++ b/alarm/xbmc-imx/PKGBUILD
@@ -6,7 +6,7 @@
 buildarch=4
 
 pkgname=xbmc-imx-git
-pkgver=13.20140506
+pkgver=13.20140609
 pkgrel=1
 pkgdesc="A software media player and entertainment hub for digital media for select imx6 systems"
 arch=('armv7h')


### PR DESCRIPTION
Rebuild xbmc-imx to update to 13.1  (see xbmc-imx6/xbmc#71).

Cheers
