### PR TITLE
Update PKGBUILD aur/asterisk

### DIFF
--- a/aur/asterisk/PKGBUILD
+++ b/aur/asterisk/PKGBUILD
@@ -3,8 +3,8 @@
 # Contributor: Maik Broemme <mbroemme@libmpq.org>
 
 pkgname=asterisk
-pkgver=12.3.2
-pkgrel=2
+pkgver=12.4.0
+pkgrel=1
 pkgdesc="A complete PBX solution"
 arch=('i686' 'x86_64')
 backup=('etc/asterisk/acl.conf'
@@ -118,15 +118,15 @@ backup=('etc/asterisk/acl.conf'
 	'etc/asterisk/xmpp.conf')
 url="http://www.asterisk.org"
 license=('GPL')
-depends=('alsa-lib' 'speex' 'popt' 'libvorbis' 'curl' 'libxml2' 'jansson' 'libxslt')
-makedepends=('sqlite3' 'gsm' 'pjproject')
+depends=('alsa-lib' 'speex' 'popt' 'libvorbis' 'curl' 'libxml2' 'jansson' 'libxslt' 'pjproject')
+makedepends=('sqlite3' 'gsm')
 optdepends=('lua51' 'libsrtp' 'postgresql' 'unixodbc' 'libpri' 'libss7' 'openr2' 'iksemel' 'radiusclient-ng' 'dahdi')
 source=(http://downloads.asterisk.org/pub/telephony/asterisk/releases/asterisk-${pkgver}.tar.gz \
 	${pkgname}.service \
 	${pkgname}.logrotated \
 	${pkgname}.tmpfile)
 install=${pkgname}.install
-sha256sums=('0724ab25ba6e9334d69b7dd3866c046cb09b8c08a7b42ce4281a5f00393d5576'
+sha256sums=('6c72d0060d1ce7a7d09f510d91d588f269aac0032de6a4464d5449b0d5600a72'
 	'74e0b278d553499f0c648a6e3d55c0dbb11b0c6dc93a85b020a21eafadb83783'
 	'caa24cfec5c6b4f8cea385269e39557362acad7e2a552994c3bc24080e3bdd4e'
 	'673c0c55bce8068c297f9cdd389402c2d5d5a25e2cf84732cb071198bd6fa78a')
@@ -153,3 +153,4 @@ package(){
   install -D -m 644 ${srcdir}/asterisk.service ${pkgdir}/usr/lib/systemd/system/asterisk.service
   install -D -m 644 ${srcdir}/asterisk.tmpfile ${pkgdir}/usr/lib/tmpfiles.d/asterisk.conf
  }
+


### PR DESCRIPTION
I worked with the maintainer of the "asterisk" package in the AUR to have some dependencies corrected and to update to the latest version of asterisk v12.4.0.  The asterisk package maintainer updated the PKGBUILD file with the new version, new release number, new sha256sum, as well as made the corrections to the dependencies.  I downloaded the PKGBUILD from the AUR.
