### PR TITLE
alarm/xf86-video-fbturbo-git to 195.4c7313c

### DIFF
--- a/alarm/xf86-video-fbturbo-git/PKGBUILD
+++ b/alarm/xf86-video-fbturbo-git/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=xf86-video-fbturbo-git
 _gitname=xf86-video-fbturbo
-pkgver=193.8dec039
+pkgver=195.4c7313c
 pkgrel=1
 pkgdesc="X.org MALI video driver"
 arch=('armv7h')


### PR DESCRIPTION
Mainly because of this commit https://github.com/ssvb/xf86-video-fbturbo/commit/4c7313c6db9ee770f39740c735268c88fcd136cf

I think the rest is self-explanatory
