### PR TITLE
alarm/uboot-sunxi to 2014.07-1

### DIFF
--- a/alarm/uboot-sunxi/PKGBUILD
+++ b/alarm/uboot-sunxi/PKGBUILD
@@ -6,15 +6,16 @@ buildarch=4
 pkgbase=uboot-sunxi
 pkgname=('uboot-cubieboard2' 'uboot-cubietruck' 'uboot-iteaduino_plus_a10' 'uboot-iteaduino_plus_a20'
          'uboot-hackberry' 'uboot-a20-olinuxino_micro')
-pkgver=2014.04
-pkgrel=8
+pkgver=2014.07
+pkgrel=1
 arch=('armv7h')
 url="https://github.com/linux-sunxi/u-boot-sunxi"
 license=('GPL')
 makedepends=('sunxi-tools')
 backup=(boot/uEnv.txt)
-_commit=38f2efaf1157af117edcff5874568df0731e1ec0
-source=("https://github.com/linux-sunxi/u-boot-sunxi/archive/${_commit}.tar.gz"
+_commit=7c48b015100eeff0e1bbb766394f7beca23afb48
+source=("git://git.denx.de/u-boot-sunxi.git#commit=$_commit"
+        'add-more-devices.diff'
         'alarm.patch'
         'cubieboard2.fex' 'cubieboard2.env'
         'cubietruck.fex' 'cubietruck.env'
@@ -22,8 +23,9 @@ source=("https://github.com/linux-sunxi/u-boot-sunxi/archive/${_commit}.tar.gz"
         'iteaduino_plus_a20.fex' 'iteaduino_plus_a20.env'
         'hackberry.fex' 'hackberry.env'
         'a20-olinuxino_micro.fex' 'a20-olinuxino_micro.env')
-md5sums=('7b28f844d7b143b4f214cab9582681c8'
-         'c52abd6e8b1bc6d367809b5a7950d733'
+md5sums=('SKIP'
+         'dd9d42ab9ccb5ee037513af0e859596c'
+         '369b8edc91b2061266f3932a1c5e5c0c'
          '36c04988cecd53151f3f5ff5c48d76a9'
          'd41d8cd98f00b204e9800998ecf8427e'
          'c898ab1b57f474d620f5704b2a53d87c'
@@ -38,12 +40,16 @@ md5sums=('7b28f844d7b143b4f214cab9582681c8'
          'd41d8cd98f00b204e9800998ecf8427e')
 
 prepare() {
-  cd u-boot-sunxi-${_commit}
+  cd u-boot-sunxi
+  git config user.email "you@example.com"
+  git config user.name "Your Name"
+  git pull --no-edit git://git.denx.de/u-boot.git v"$pkgver"
+  patch -p1 -i "${srcdir}"/add-more-devices.diff
   patch -p1 -i "${srcdir}"/alarm.patch
 }
 
 build() {
-  cd u-boot-sunxi-${_commit}
+  cd u-boot-sunxi
 
   unset CFLAGS
   unset CXXFLAGS

--- a/alarm/uboot-sunxi/add-more-devices.diff
+++ b/alarm/uboot-sunxi/add-more-devices.diff
@@ -1,0 +1,110 @@
+diff --git a/board/sunxi/Makefile b/board/sunxi/Makefile
+index 62acb8f..e66db61 100644
+--- a/board/sunxi/Makefile
++++ b/board/sunxi/Makefile
+@@ -11,7 +11,11 @@
+ obj-y	+= board.o
+ obj-$(CONFIG_SUNXI_GMAC)	+= gmac.o
+ obj-$(CONFIG_A13_OLINUXINOM)	+= dram_a13_oli_micro.o
++obj-$(CONFIG_A20_OLINUXINO_M)	+= dram_sun7i_384_1024_iow16.o
+ obj-$(CONFIG_CUBIEBOARD)	+= dram_cubieboard.o
+ obj-$(CONFIG_CUBIEBOARD2)	+= dram_cubieboard2.o
+ obj-$(CONFIG_CUBIETRUCK)	+= dram_cubietruck.o
++obj-$(CONFIG_HACKBERRY)	+= dram_hackberry.o
++obj-$(CONFIG_ITEADA10)		+= dram_cubieboard.o
++obj-$(CONFIG_ITEADA20)		+= dram_cubieboard2.o
+ obj-$(CONFIG_R7DONGLE)		+= dram_r7dongle.o
+diff --git a/board/sunxi/dram_hackberry.c b/board/sunxi/dram_hackberry.c
+new file mode 100644
+index 0000000..19b07b8
+--- /dev/null
++++ b/board/sunxi/dram_hackberry.c
+@@ -0,0 +1,31 @@
++/* this file is generated, don't edit it yourself */
++
++#include <common.h>
++#include <asm/arch/dram.h>
++
++static struct dram_para dram_para = {
++	.clock = 408,
++	.type = 3,
++	.rank_num = 1,
++	.density = 4096,
++	.io_width = 16,
++	.bus_width = 32,
++	.cas = 6,
++	.zq = 123,
++	.odt_en = 1,
++	.size = 1024,
++	.tpr0 = 0x30926692,
++	.tpr1 = 0x1090,
++	.tpr2 = 0x1a0c8,
++	.tpr3 = 0,
++	.tpr4 = 0,
++	.tpr5 = 0,
++	.emr1 = 0,
++	.emr2 = 0,
++	.emr3 = 0,
++};
++
++unsigned long sunxi_dram_init(void)
++{
++	return dramc_init(&dram_para);
++}
+diff --git a/board/sunxi/dram_sun7i_384_1024_iow16.c b/board/sunxi/dram_sun7i_384_1024_iow16.c
+new file mode 100644
+index 0000000..04e4b1e
+--- /dev/null
++++ b/board/sunxi/dram_sun7i_384_1024_iow16.c
+@@ -0,0 +1,31 @@
++/* this file is generated, don't edit it yourself */
++
++#include "common.h"
++#include <asm/arch/dram.h>
++
++static struct dram_para dram_para = {
++	.clock = 384,
++	.type = 3,
++	.rank_num = 1,
++	.density = 4096,
++	.io_width = 16,
++	.bus_width = 32,
++	.cas = 9,
++	.zq = 0x7f,
++	.odt_en = 0,
++	.size = 1024,
++	.tpr0 = 0x42d899b7,
++	.tpr1 = 0xa090,
++	.tpr2 = 0x22a00,
++	.tpr3 = 0,
++	.tpr4 = 0,
++	.tpr5 = 0,
++	.emr1 = 0x4,
++	.emr2 = 0x10,
++	.emr3 = 0,
++};
++
++unsigned long sunxi_dram_init(void)
++{
++	return dramc_init(&dram_para);
++}
+diff --git a/boards.cfg b/boards.cfg
+index 3ef61e6..c78e66e 100644
+--- a/boards.cfg
++++ b/boards.cfg
+@@ -378,11 +378,15 @@ Active  arm         armv7          s5pc1xx     samsung         goni
+ Active  arm         armv7          s5pc1xx     samsung         smdkc100            smdkc100                              -                                                                                                                                 Minkyu Kang <mk7.kang@samsung.com>
+ Active  arm         armv7          socfpga     altera          socfpga             socfpga_cyclone5                      -                                                                                                                                 -
+ Active  arm         armv7          sunxi       -               sunxi               A13-OLinuXinoM                        sun5i:A13_OLINUXINOM,SPL,CONS_INDEX=2                                                                                             Hans de Goede <hdegoede@redhat.com>
++Active  arm         armv7          sunxi       -               sunxi               A20-OLinuXino_MICRO                   sun7i:A20_OLINUXINO_M,CONS_INDEX=1,SPL,SUNXI_EMAC                                                                                 -
++Active  arm         armv7          sunxi       -               sunxi               Iteaduino_Plus_A10                    sun4i:ITEADA10,SPL,SUNXI_EMAC                                                                                                     -
++Active  arm         armv7          sunxi       -               sunxi               Iteaduino_Plus_A20                    sun7i:ITEADA20,SPL,SUNXI_EMAC                                                                                                     -
+ Active  arm         armv7          sunxi       -               sunxi               Cubieboard                            sun4i:CUBIEBOARD,SPL,AXP209_POWER,SUNXI_EMAC                                                                                      Hans de Goede <hdegoede@redhat.com>
+ Active  arm         armv7          sunxi       -               sunxi               Cubieboard2                           sun7i:CUBIEBOARD2,SPL,SUNXI_GMAC                                                                                                  Ian Campbell <ijc@hellion.org.uk>:Hans de Goede <hdegoede@redhat.com>
+ Active  arm         armv7          sunxi       -               sunxi               Cubieboard2_FEL                       sun7i:CUBIEBOARD2,SPL_FEL,SUNXI_GMAC                                                                                              Ian Campbell <ijc@hellion.org.uk>:Hans de Goede <hdegoede@redhat.com>
+ Active  arm         armv7          sunxi       -               sunxi               Cubietruck                            sun7i:CUBIETRUCK,SPL,AXP209_POWER,SUNXI_GMAC,RGMII                                                                                Ian Campbell <ijc@hellion.org.uk>:Hans de Goede <hdegoede@redhat.com>
+ Active  arm         armv7          sunxi       -               sunxi               Cubietruck_FEL                        sun7i:CUBIETRUCK,SPL_FEL,AXP209_POWER,SUNXI_GMAC,RGMII                                                                            Ian Campbell <ijc@hellion.org.uk>:Hans de Goede <hdegoede@redhat.com>
++Active  arm         armv7          sunxi       -               sunxi               Hackberry                             sun4i:HACKBERRY,SPL                                                                                                               -
+ Active  arm         armv7          sunxi       -               sunxi               r7-tv-dongle                          sun5i:R7DONGLE,SPL,AXP152_POWER                                                                                                   Hans de Goede <hdegoede@redhat.com>
+ Active  arm         armv7          u8500       st-ericsson     snowball            snowball                              -                                                                                                                                 Mathieu Poirier <mathieu.poirier@linaro.org>
+ Active  arm         armv7          u8500       st-ericsson     u8500               u8500_href                            -                                                                                                                                 -

--- a/alarm/uboot-sunxi/alarm.patch
+++ b/alarm/uboot-sunxi/alarm.patch
@@ -1,6 +1,7 @@
-diff -urN a/include/config_distro_defaults.h b/include/config_distro_defaults.h
---- a/include/config_distro_defaults.h	2014-06-03 11:30:04.000000000 -0600
-+++ b/include/config_distro_defaults.h	2014-06-11 20:20:44.881069479 -0600
+diff --git a/include/config_distro_defaults.h b/include/config_distro_defaults.h
+index 5d18a4b..11e655c 100644
+--- a/include/config_distro_defaults.h
++++ b/include/config_distro_defaults.h
 @@ -45,7 +45,7 @@
  
  #define CONFIG_CMDLINE_EDITING
@@ -10,10 +11,11 @@ diff -urN a/include/config_distro_defaults.h b/include/config_distro_defaults.h
  #define CONFIG_SYS_LONGHELP
  #define CONFIG_MENU
  #define CONFIG_DOS_PARTITION
-diff -urN a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
---- a/include/configs/sunxi-common.h	2014-06-03 11:30:04.000000000 -0600
-+++ b/include/configs/sunxi-common.h	2014-06-11 20:21:15.295967969 -0600
-@@ -126,7 +126,7 @@
+diff --git a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
+index 845b004..c6e29a7 100644
+--- a/include/configs/sunxi-common.h
++++ b/include/configs/sunxi-common.h
+@@ -106,13 +106,95 @@
  #define CONFIG_SYS_NO_FLASH
  
  #define CONFIG_SYS_MONITOR_LEN		(512 << 10)	/* 512 KiB */
@@ -22,33 +24,13 @@ diff -urN a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
  
  #define CONFIG_ENV_OFFSET		(544 << 10) /* (8 + 24 + 512) KiB */
  #define CONFIG_ENV_SIZE			(128 << 10)	/* 128 KiB */
-@@ -137,99 +137,55 @@
- #define RUN_BOOT_RAM	""
- #endif
  
--#define CONFIG_BOOTCOMMAND \
--	RUN_BOOT_RAM \
--	"if run loadbootenv; then " \
--	  "echo Loaded environment from ${bootenv};" \
--	  "env import -t ${scriptaddr} ${filesize};" \
--	"fi;" \
--	"if test -n \\\"${uenvcmd}\\\"; then " \
--	  "echo Running uenvcmd ...;" \
--	  "run uenvcmd;" \
--	"fi;" \
--	"if run loadbootscr; then "\
--	  "echo Jumping to ${bootscr};" \
--	  "source ${scriptaddr};" \
--	"fi;" \
--	"run autoboot;" \
--	""
--
- #ifdef CONFIG_CMD_WATCHDOG
- #define	RESET_WATCHDOG "watchdog 0"
- #else
- #define RESET_WATCHDOG "true"
- #endif
- 
++#ifdef CONFIG_CMD_WATCHDOG
++#define	RESET_WATCHDOG "watchdog 0"
++#else
++#define RESET_WATCHDOG "true"
++#endif
++
 +#if defined(CONFIG_CUBIEBOARD2)
 +  #define CONFIG_DEFAULT_FDT_FILE	"sun7i-a20-cubieboard2.dtb"
 +#elif defined(CONFIG_CUBIETRUCK)
@@ -62,75 +44,8 @@ diff -urN a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
 +#endif
 +
  #define CONFIG_EXTRA_ENV_SETTINGS \
- 	"bootm_size=0x10000000\0" \
--	"console=ttyS0,115200\0" \
--	"panicarg=panic=10\0" \
--	"extraargs=\0" \
--	"loglevel=8\0" \
--	"scriptaddr=0x44000000\0" \
--	"device=mmc\0" \
--	"partition=0:1\0" \
--	"setargs=" \
--	  "if test -z \\\\\"$root\\\\\"; then"\
--	    " if test \\\\\"$bootpath\\\\\" = \"/boot/\"; then"\
--	      " root=\"/dev/mmcblk0p1 rootwait\";"\
--	    " else" \
--	      " root=\"/dev/mmcblk0p2 rootwait\";"\
--	    " fi;"\
--	  " fi;"\
--	  " setenv bootargs console=${console} root=${root}" \
--	  " loglevel=${loglevel} ${panicarg} ${extraargs}" \
--	  "\0" \
--	"kernel=uImage\0" \
--	"bootenv=uEnv.txt\0" \
--	"bootscr=boot.scr\0" \
--	"script=script.bin\0" \
--	"loadbootscr=" \
--	  "fatload $device $partition $scriptaddr ${bootscr}" \
--	  " || " \
--	  "ext2load $device $partition $scriptaddr boot/${bootscr}" \
--	  " ||" \
--	  "ext2load $device $partition $scriptaddr ${bootscr}" \
--	  "\0" \
--	"loadbootenv=" \
--	  "fatload $device $partition $scriptaddr ${bootenv}" \
--	  " || " \
--	  "ext2load $device $partition $scriptaddr boot/${bootenv}" \
--	  " || " \
--	  "ext2load $device $partition $scriptaddr ${bootenv}" \
--	  "\0" \
--	"loadkernel=" \
--	  "if "\
--	    "bootpath=/boot/" \
--	    " && " \
--	    "ext2load $device $partition 0x43000000 ${bootpath}${script}" \
--	    " && " \
--	    "ext2load $device $partition 0x48000000 ${bootpath}${kernel}" \
--	  ";then true; elif " \
--	    "bootpath=/" \
--	    " && " \
--	    "fatload $device $partition 0x43000000 ${script}" \
--	    " && " \
--	    "fatload $device $partition 0x48000000 ${kernel}" \
--	  ";then true; elif " \
--	    "bootpath=/" \
--	    " && " \
--	    "ext2load $device $partition 0x43000000 ${bootpath}${script}" \
--	    " && " \
--	    "ext2load $device $partition 0x48000000 ${bootpath}${kernel}" \
--	  ";then true; else "\
--	    "false" \
--	  ";fi" \
--	  "\0" \
--	"autoboot=" \
--	  "run loadkernel" \
--	  " && " \
--	  "run setargs" \
--	  " && " \
--	  RESET_WATCHDOG \
--	  " && " \
--	  "bootm 0x48000000" \
--	  "\0" \
+-	"bootm_size=0x10000000\0"
++	"bootm_size=0x10000000\0" \
 +	"console=ttyS0\0" \
 +	"loadaddr=0x48000000\0" \
 +	"scriptaddr=0x43000000\0" \
@@ -160,16 +75,14 @@ diff -urN a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
 +		"run mmcargs; " \
 +		RESET_WATCHDOG ";" \
 +		"bootz ${loadaddr} - ${fdt_addr};\0" \
- 	"boot_ram=" \
- 	  "saved_stdout=$stdout;setenv stdout nc;"\
- 	  "if iminfo 0x41000000; then" \
-@@ -238,9 +194,33 @@
- 	    " source 0x41000000;" \
- 	  "else" \
- 	    " setenv stdout $saved_stdout;" \
--	  "fi" \
--	  "\0" \
--	""
++	"boot_ram=" \
++	  "saved_stdout=$stdout;setenv stdout nc;"\
++	  "if iminfo 0x41000000; then" \
++	    " " RESET_WATCHDOG ";"\
++	    " setenv stdout $saved_stdout;" \
++	    " source 0x41000000;" \
++	  "else" \
++	    " setenv stdout $saved_stdout;" \
 +	  "fi;\0"
 +
 +#define CONFIG_BOOTCOMMAND \


### PR DESCRIPTION
- Move uboot-sunix over to the u-boot-sunxi repository at git.denx.de
- As it's behind the stable repsitory merge git://git.denx.de/u-boot.git up to tag v2014.07
- While there's full support for all sun4i to sun7i devices, not all of them are added to boards.cfg --> add-more-devices.diff
- Adapted alarm.patch to 2014.07. There's no default environment in the new version and therefore no autobooting. As I couldn't figure out how to set a default environment I just readded the old and working one.

Successfully tested on Cubieboard2
