### PR TITLE
alarm/xbmc-imx to 13.2beta1

### DIFF
--- a/alarm/xbmc-imx/PKGBUILD
+++ b/alarm/xbmc-imx/PKGBUILD
@@ -6,8 +6,8 @@
 buildarch=4
 
 pkgname=xbmc-imx-git
-pkgver=13.20140609
-pkgrel=2
+pkgver=13.20140724
+pkgrel=1
 pkgdesc="A software media player and entertainment hub for digital media for select imx6 systems"
 arch=('armv7h')
 url="http://xbmc.org"


### PR DESCRIPTION
xbmc-imx6/xbmc#80 has been merged.
Bump to 13.2beta1.

Cheers
