### PR TITLE
alarm/libfslvpuwrap apply upstream patch

### DIFF
--- a/alarm/libfslvpuwrap/PKGBUILD
+++ b/alarm/libfslvpuwrap/PKGBUILD
@@ -5,21 +5,25 @@ buildarch=4
 pkgname=libfslvpuwrap
 pkgver=3.10.17_1.0.0
 _pkgver=1.0.46
-pkgrel=2
+pkgrel=3
 pkgdesc="Wrapper library for the freescale proprietary VPU extensions"
 url="https://community.freescale.com/docs/DOC-95560"
 arch=('armv7h')
 license=('proprietary')
 depends=("imx-vpu=$pkgver")
-source=("http://www.freescale.com/lgfiles/NMG/MAD/YOCTO/${pkgname}-${_pkgver}.bin")
-md5sums=('1f50110cb6de8ebf767fb9c5f8baf20d')
+source=("http://www.freescale.com/lgfiles/NMG/MAD/YOCTO/${pkgname}-${_pkgver}.bin"
+	'0001-vpu_wrapper-fix-tests-of-return-value-from-IOGetVirt.patch')
+md5sums=('1f50110cb6de8ebf767fb9c5f8baf20d'
+         '478d6d6bb5043cdcdced42fcd9fec48d')
 
 prepare() {
   cd "${srcdir}"
-  #chmod for execution, library is packed as binary to accept EULA
-#  chmod +x ${pkgname}-${_pkgver}.bin
+  #library is packed as binary, accept EULA
   sh ${pkgname}-${_pkgver}.bin --force --auto-accept
   sed -n '/EOEULA/,/EOEULA/p' ${pkgname}-${_pkgver}.bin | grep -v EOEULA > LICENSE.$pkgname
+
+  cd "${pkgname}-${_pkgver}"
+  patch -Np1 < ../0001-vpu_wrapper-fix-tests-of-return-value-from-IOGetVirt.patch
 }
 
 build() {


### PR DESCRIPTION
Apply the upstream [patch](https://github.com/Freescale/meta-fsl-arm/blob/master/recipes-multimedia/libfslvpuwrap/libfslvpuwrap/0001-vpu_wrapper-fix-tests-of-return-value-from-IOGetVirt.patch) from [Freescale/meta-fsl-arm](https://github.com/Freescale/meta-fsl-arm/tree/master/recipes-multimedia/libfslvpuwrap).

Cheers
