### PR TITLE
alarm/xbmc-imx bump to rebuild

### DIFF
--- a/alarm/xbmc-imx/PKGBUILD
+++ b/alarm/xbmc-imx/PKGBUILD
@@ -6,7 +6,7 @@
 buildarch=4
 
 pkgname=xbmc-imx-git
-pkgver=13.20140724
+pkgver=13.20140728
 pkgrel=1
 pkgdesc="A software media player and entertainment hub for digital media for select imx6 systems"
 arch=('armv7h')


### PR DESCRIPTION
With libnfs updated, xbmc builds without a patch now (see #917).
This will also include the fix applied in xbmc-imx6/xbmc#82.

Cheers
