### PR TITLE
Qt5 cmake: Fix the case where a single library appears in multiple _qt5gui_find_extra_libs calls

### DIFF
--- a/extra/qt5/PKGBUILD
+++ b/extra/qt5/PKGBUILD
@@ -35,7 +35,7 @@ pkgname=('qt5-base'
          'qt5-x11extras'
          'qt5-xmlpatterns')
 pkgver=5.3.1
-pkgrel=1.2
+pkgrel=1.3
 arch=('i686' 'x86_64')
 url='http://qt-project.org/'
 license=('GPL3' 'LGPL' 'FDL' 'custom')
@@ -58,7 +58,7 @@ md5sums=('f9a24a0d5645efa0715b6ff0fa13d60f'
          '188da8f4c87316e730ebf1c6217bf5a0'
          '322b419b16c75d4de0ee7ad0a246caa1'
          'a378deccf363bd6079da459c89aff7b9'
-         '762b33b1b083c0d19ccbd1ac2b9eb5c7'
+         '46ff379ce216fc6929dd65e401c86295'
          'd9eb94a6cf4f178a7d77d6b8a9280ee2')
 
 prepare() {

--- a/extra/qt5/rpi.patch
+++ b/extra/qt5/rpi.patch
@@ -44,3 +44,19 @@
  !!IF !mac
                  NO_DEFAULT_PATH
  !!ENDIF
+@@ -150,8 +150,15 @@
+                 unset(Qt5Gui_${_cmake_lib_name}_LIBRARY_DEBUG CACHE)
+                 list(APPEND Qt5Gui_${Name}_LIBRARIES Qt5::Gui_${_cmake_lib_name})
+             endif()
++        else()
++            if (WIN32 AND NOT Qt5Gui_${_cmake_lib_name}_LIBRARY)
++                list(APPEND Qt5Gui_${Name}_LIBRARIES ${_lib})
++            else()
++                list(APPEND Qt5Gui_${Name}_LIBRARIES Qt5::Gui_${_cmake_lib_name})
++            endif()
+         endif()
+     endforeach()
++    list(REMOVE_DUPLICATES Qt5Gui_${Name}_LIBRARIES)
+     if (NOT CMAKE_CROSSCOMPILING)
+         foreach(_dir ${Qt5Gui_${Name}_INCLUDE_DIRS})
+             _qt5_Gui_check_file_exists(${_dir})


### PR DESCRIPTION
Necessary on the raspberry pi, because Broadcom's EGL needs libEGL and libGLESv2, but OpenGL ES 2 is libGLESv2 only.
Should work on all other platforms, too. Will file an upstream bug once we've solved any remaining issues. Hopefully this is last :)
Fixes the stellarium build.
