### PR TITLE
gst-imx: Fix md5sum after commit change, and correct build options

### DIFF
--- a/alarm/gst-imx/PKGBUILD
+++ b/alarm/gst-imx/PKGBUILD
@@ -5,7 +5,7 @@ buildarch=4
 pkgname=gst-imx
 _commit=0c8c284f598c777e14ecec6be72aea836f774ad8
 pkgver=0.9.7
-pkgrel=2
+pkgrel=3
 pkgdesc="GStreamer plugins for i.MX platforms"
 arch=('armv7h')
 license=('LGPL')
@@ -13,7 +13,7 @@ url="https://github.com/Freescale/gstreamer-imx"
 depends=('gst-plugins-base-libs' 'libfslvpuwrap' 'gpu-viv-bin-mx6q-fb')
 makedepends=('python2' 'linux-headers-imx6-fsl')
 source=("https://github.com/Freescale/gstreamer-imx/archive/${_commit}.tar.gz")
-md5sums=('fb1f4982bca844e305255b68f9e47bab')
+md5sums=('d0fab25f0d37a7255b56404951e842ec')
 
 LDFLAGS+=' -L/opt/fsl/lib'
 CPPFLAGS+=' -I/opt/fsl/include'
@@ -25,7 +25,8 @@ build() {
 
   python2 waf configure --prefix=/usr \
     --with-package-name="GStreamer plugins for i.MX platforms" \
-    --with-package-origin="https://github.com/archlinuxarm/PKGBUILDs/tree/master/alarm/gst-imx"
+    --with-package-origin="https://github.com/archlinuxarm/PKGBUILDs/tree/master/alarm/gst-imx" \
+    --egl-platform=fb
   
   python2 waf build $MAKEFLAGS
 }


### PR DESCRIPTION
There were two issues with 0.9.7-2:
- The source commit had changed from 0.9.7-1, but the md5sum was not updated to reflect this.
- The package was not built with --egl-platform=fb, thus defaulting to relying on X (which was erroneous due to already depending on gpu-viv-bin-mx6q-fb). This caused the imxeglvivsink GStreamer element to not function.

This PR addresses both issues.
