### PR TITLE
Add USB_ACM Support to linux-imx6-cubox-dt

### DIFF
--- a/core/linux-imx6-cubox-dt/PKGBUILD
+++ b/core/linux-imx6-cubox-dt/PKGBUILD
@@ -15,7 +15,7 @@ _srcname=linux-linaro-stable-mx6-${_commit}
 _kernelname=${pkgname#linux}
 _basekernel=3.10
 pkgver=${_basekernel}.30
-pkgrel=23
+pkgrel=24
 arch=('arm')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -28,7 +28,7 @@ source=("https://github.com/warped-rudi/linux-linaro-stable-mx6/archive/${_commi
         'http://hg.openbricks.org/openbricks/raw-file/414a70875fc4/config/platforms/arm/imx6/machines/cuboxi/packages/linux/patches/991_cubox-i-use-ipu0.patch'
         'http://hg.openbricks.org/openbricks/raw-file/414a70875fc4/config/platforms/arm/imx6/machines/cuboxi/packages/linux/patches/992_hummingboard-use-ipu0-disable-cec.patch')
 md5sums=('3f6420eaa207158ac729394cd92ccbbb'
-         'ec0866841fba123b24db0f5d460211ea'
+         '29a52d616a001bbfd13450b9dd03b1ae'
          '9d3c56a4b999c8bfbd4018089a62f662'
          '7f91cc11b6a63771e415bb3549de8fdd'
          'a2579ff8da52d1b922d704f160cfaa08'

--- a/core/linux-imx6-cubox-dt/config
+++ b/core/linux-imx6-cubox-dt/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 3.10.30-22 Kernel Configuration
+# Linux/arm 3.10.30-23 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_MIGHT_HAVE_PCI=y
@@ -3530,7 +3530,7 @@ CONFIG_USB_EHCI_PCI=y
 #
 # USB Device Class drivers
 #
-# CONFIG_USB_ACM is not set
+CONFIG_USB_ACM=m
 CONFIG_USB_PRINTER=m
 CONFIG_USB_WDM=m
 # CONFIG_USB_TMC is not set

--- a/core/linux-imx6-cubox-dt/linux-imx6-cubox-dt.install
+++ b/core/linux-imx6-cubox-dt/linux-imx6-cubox-dt.install
@@ -2,7 +2,7 @@
 # arg 2:  the old package version
 
 KERNEL_NAME=-imx6-cubox-dt
-KERNEL_VERSION=3.10.30-1
+KERNEL_VERSION=3.10.30-24-ARCH
 
 post_install () {
   # updating module dependencies


### PR DESCRIPTION
Issue #934: Add CONFIG_USB_ACM=m to kernel configuration to support USB modems, microcontroller serial ports, etc.

Kernel has been compiled and tested on Cubox-i2eXw
