### PR TITLE
core/linux-imx6-cubox-dt: enable WiFi devices based on some Atheros chipsets

### DIFF
--- a/core/linux-imx6-cubox-dt/PKGBUILD
+++ b/core/linux-imx6-cubox-dt/PKGBUILD
@@ -15,7 +15,7 @@ _srcname=linux-linaro-stable-mx6-${_commit}
 _kernelname=${pkgname#linux}
 _basekernel=3.10
 pkgver=${_basekernel}.30
-pkgrel=24
+pkgrel=25
 arch=('arm')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -28,7 +28,7 @@ source=("https://github.com/warped-rudi/linux-linaro-stable-mx6/archive/${_commi
         'http://hg.openbricks.org/openbricks/raw-file/414a70875fc4/config/platforms/arm/imx6/machines/cuboxi/packages/linux/patches/991_cubox-i-use-ipu0.patch'
         'http://hg.openbricks.org/openbricks/raw-file/414a70875fc4/config/platforms/arm/imx6/machines/cuboxi/packages/linux/patches/992_hummingboard-use-ipu0-disable-cec.patch')
 md5sums=('3f6420eaa207158ac729394cd92ccbbb'
-         '29a52d616a001bbfd13450b9dd03b1ae'
+         '15305aa19f1b57471944a0737c9484d0'
          '9d3c56a4b999c8bfbd4018089a62f662'
          '7f91cc11b6a63771e415bb3549de8fdd'
          'a2579ff8da52d1b922d704f160cfaa08'

--- a/core/linux-imx6-cubox-dt/config
+++ b/core/linux-imx6-cubox-dt/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 3.10.30-23 Kernel Configuration
+# Linux/arm 3.10.30-25 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_MIGHT_HAVE_PCI=y
@@ -1927,8 +1927,12 @@ CONFIG_ATH_CARDS=y
 # CONFIG_ATH_DEBUG is not set
 # CONFIG_ATH5K is not set
 # CONFIG_ATH5K_PCI is not set
+CONFIG_ATH9K_HW=m
+CONFIG_ATH9K_COMMON=m
+CONFIG_ATH9K_BTCOEX_SUPPORT=y
 # CONFIG_ATH9K is not set
-# CONFIG_ATH9K_HTC is not set
+CONFIG_ATH9K_HTC=m
+# CONFIG_ATH9K_HTC_DEBUGFS is not set
 CONFIG_CARL9170=m
 CONFIG_CARL9170_LEDS=y
 CONFIG_CARL9170_WPC=y


### PR DESCRIPTION
This enables a number of config options for Atheros AR9001 and AR9002 family hardware.

Kernel has been compiled and tested on a Cubox-i2eX with the TP-Link TL-WN722N
