### PR TITLE
core/linux-kirkwood-dt: Build devicetree blob for the Zyxel NSA320

### DIFF
--- a/core/linux-kirkwood-dt/PKGBUILD
+++ b/core/linux-kirkwood-dt/PKGBUILD
@@ -8,7 +8,7 @@ pkgbase=linux-kirkwood-dt
 _kernelname=${pkgbase#linux}
 _desc="Marvell Kirkwood DT"
 pkgver=3.16
-pkgrel=1
+pkgrel=2
 cryptodev_commit=8af0fe8a977f33236d3e00306ac3648063052704
 bfqver=v7r5
 
@@ -111,7 +111,7 @@ build() {
   #yes "" | make config
 
 msg "Building!"
-  make ${MAKEFLAGS} zImage modules dtbs
+  make ${MAKEFLAGS} zImage modules dtbs kirkwood-nsa320.dtb
 
 msg "Building cryptodev module"
   cd "${srcdir}/cryptodev-linux-${cryptodev_commit}"


### PR DESCRIPTION
Upstream kernel source now contains a dts file for this device, but
the dtb won't get built by the 'dtbs' target, it has to be specified
explicitly.
