### PR TITLE
Qt5: Link to libEGL even if only libGLESv2 was requested. Fixes texmaker build.

### DIFF
--- a/extra/qt5/PKGBUILD
+++ b/extra/qt5/PKGBUILD
@@ -35,7 +35,7 @@ pkgname=('qt5-base'
          'qt5-x11extras'
          'qt5-xmlpatterns')
 pkgver=5.3.1
-pkgrel=1.3
+pkgrel=1.4
 arch=('i686' 'x86_64')
 url='http://qt-project.org/'
 license=('GPL3' 'LGPL' 'FDL' 'custom')
@@ -88,6 +88,7 @@ prepare() {
    sed -i "/^QMAKE_INCDIR_EGL\s/s|=|= $vc_include_dir|g" qtbase/mkspecs/common/linux.conf
    sed -i "/^QMAKE_LIBDIR_EGL\s/s|=|= $vc_lib_dir|g" qtbase/mkspecs/common/linux.conf
    sed -i "/^QMAKE_LIBS_EGL\s/s|= -lEGL|= -lEGL -lGLESv2|g" qtbase/mkspecs/common/linux.conf
+   sed -i "/^QMAKE_LIBS_OPENGL_ES2\s/s|= -lGLESv2|= -lEGL -lGLESv2|g" qtbase/mkspecs/common/linux.conf
 
    echo "EGLFS_PLATFORM_HOOKS_SOURCES = $PWD/qtbase/mkspecs/devices/linux-rasp-pi-g++/qeglfshooks_pi.cpp" >> qtbase/mkspecs/common/linux.conf
    echo "EGLFS_PLATFORM_HOOKS_LIBS = -lbcm_host" >> qtbase/mkspecs/common/linux.conf


### PR DESCRIPTION
Some symbols are only defined in one and needed by the other. This fixes the texmaker build.
