### PR TITLE
Adds Mali T6xx X11 userspace (mesa) driver

### DIFF
--- a/alarm/mali-t604-x11-libgl/PKGBUILD
+++ b/alarm/mali-t604-x11-libgl/PKGBUILD
@@ -1,0 +1,40 @@
+# Mali T604 X11 GL Driver
+# Based on ODROID Mali GL Driver PKGBUILD
+# Maintainer: Derek Stavis <derekstavis@icloud.com>
+
+buildarch=4
+
+pkgname=mali-t604-x11-libgl
+pkgver=r4p0
+pkgrel=1
+arch=('armv7h')
+pkgdesc="Mali T604 GL Driver"
+url="http://malideveloper.arm.com/develop-for-mali/features/mali-t6xx-gpu-user-space-drivers/"
+license=('Proprietary')
+provides=('libmali' 'libegl' 'libgles' 'libmali' 'libopencl')
+source=("http://malideveloper.arm.com/downloads/drivers/binary/r4p0-02rel0/mali-t604_r4p0-02rel0_linux_1+x11.tar.gz")
+md5sums=('36fa57b36bde62bd60262cf1ba77de1c')
+
+package() {
+    install -d -m 0755 ${pkgdir}/opt/${pkgname}/lib
+
+    cd ${srcdir}/x11
+    install -m 0755 libmali.so ${pkgdir}/opt/${pkgname}/lib
+    install -m 0755 libEGL.so ${pkgdir}/opt/${pkgname}/lib
+    install -m 0755 libGLESv1_CM.so ${pkgdir}/opt/${pkgname}/lib
+    install -m 0755 libGLESv2.so ${pkgdir}/opt/${pkgname}/lib
+    install -m 0755 libOpenCL.so ${pkgdir}/opt/${pkgname}/lib
+
+    cd ${pkgdir}/opt/${pkgname}/lib
+    
+    ln -s libEGL.so libEGL.so.1
+    ln -s libEGL.so.1 libEGL.so.1.4
+    ln -s libGLESv1_CM.so libGLESv1_CM.so.1 
+    ln -s libGLESv1_CM.so.1 libGLESv1_CM.so.1.1 
+    ln -s libGLESv2.so libGLESv2.so.2 
+    ln -s libGLESv2.so.2 libGLESv2.so.2.0 
+
+    install -d -m 0755 ${pkgdir}/etc/ld.so.conf.d
+
+    echo "/opt/${pkgname}/lib" > ${pkgdir}/etc/ld.so.conf.d/${pkgname}.conf
+}


### PR DESCRIPTION
Download binary blobs directly from ARM website. Instead of providing a umbrella package, like libmesa, this PKGBUILD provides libmali, libegl libgles and libopencl. It does so by installing a entry in ld.so.conf.d.

This PKGBUILD is a  `odroid-libgl` ripoff, taking the same concept (and discussion, vide #857) to allow using libmesa as a libgl fallback to GLX, as ARM distribution lacks it.
