### PR TITLE
alarm/xbmc-imx bump; add alsa config

### DIFF
--- a/alarm/xbmc-imx/PKGBUILD
+++ b/alarm/xbmc-imx/PKGBUILD
@@ -6,7 +6,7 @@
 buildarch=4
 
 pkgname=xbmc-imx-git
-pkgver=13.20140806
+pkgver=13.20140812
 pkgrel=1
 pkgdesc="A software media player and entertainment hub for digital media for select imx6 systems"
 arch=('armv7h')
@@ -25,12 +25,17 @@ install="xbmc.install"
 source=('xbmc.service'
         'runxbmc'
         'xbmc.conf'
-        '10-xbmc.rules')
+        '10-xbmc.rules'
+        'imx-spdif.conf'
+        'imx-hdmi-soc.conf')
+
 
 md5sums=('07096dfd530cc432fa6073ee1a32e7f6'
          '730ac095a89b05c3c2cf2dd93947cb5c'
          '8fab4cc5cac44a7090ca7e839e326ec8'
-         'c3ad87fc9f278f9530d673be9b1f58f0')
+         'c3ad87fc9f278f9530d673be9b1f58f0'
+         'df3edfc7269d4a4d6f94d935c9adb0ac'
+         '90f401e9f255291ec75414056e0d30c0')
 
 # master branch of xbmc-imx6 organization. Modified by Stephan "wolgar" Rafin, Chris "koying" Browet, Rudi "rudi-warped" Ihle and smallint
 _gitname="xbmc"
@@ -122,6 +127,10 @@ package() {
   install -Dm0644 $srcdir/xbmc.conf $pkgdir/etc/tmpfiles.d/xbmc.conf
   install -Dm0644 $srcdir/10-xbmc.rules $pkgdir/etc/polkit-1/rules.d/10-xbmc.rules
   chmod 700 $pkgdir/etc/polkit-1/rules.d
+
+  # imx6-specific alsa conf
+  install -Dm0644 $srcdir/imx-spdif.conf $pkgdir/usr/share/alsa/cards/imx-spdif.conf
+  install -Dm0644 $srcdir/imx-hdmi-soc.conf $pkgdir/usr/share/alsa/cards/imx-hdmi-soc.conf
 }
 
 

--- a/alarm/xbmc-imx/imx-hdmi-soc.conf
+++ b/alarm/xbmc-imx/imx-hdmi-soc.conf
@@ -1,0 +1,33 @@
+#
+# Configuration for iMX6 HDMI output - /usr/share/alsa/cards/imx-hdmi-soc.conf
+# Taken from https://github.com/OpenBricks/openbricks/blob/master/packages/sound/alsa-lib/config/imx-hdmi-soc.conf
+#
+
+<confdir:pcm/hdmi.conf>
+
+imx-hdmi-soc.pcm.hdmi.0 {
+	@args [ CARD AES0 AES1 AES2 AES3 ]
+	@args.CARD { type string }
+	@args.AES0 { type integer }
+	@args.AES1 { type integer }
+	@args.AES2 { type integer }
+	@args.AES3 { type integer }
+	type hooks
+	slave.pcm {
+		type hw
+		card $CARD
+	}
+	hooks.0 {
+		type ctl_elems
+		hook_args [
+			{
+				interface MIXER
+				name "IEC958 Playback Default"
+				lock true
+				preserve true
+				optional true
+				value [ $AES0 $AES1 $AES2 $AES3 ]
+			}
+		]
+	}
+}

--- a/alarm/xbmc-imx/imx-spdif.conf
+++ b/alarm/xbmc-imx/imx-spdif.conf
@@ -1,0 +1,33 @@
+#
+# Configuration for iMX6 SPDIF output - /usr/share/alsa/cards/imx-spdif.conf
+# Taken from https://github.com/OpenBricks/openbricks/blob/master/packages/sound/alsa-lib/config/imx-spdif.conf
+#
+
+<confdir:pcm/iec958.conf>
+
+imx-spdif.pcm.iec958.0 {
+	@args [ CARD AES0 AES1 AES2 AES3 ]
+	@args.CARD { type string }
+	@args.AES0 { type integer }
+	@args.AES1 { type integer }
+	@args.AES2 { type integer }
+	@args.AES3 { type integer }
+	type hooks
+	slave.pcm {
+		type hw
+		card $CARD
+	}
+	hooks.0 {
+		type ctl_elems
+		hook_args [
+			{
+				interface MIXER
+				name "IEC958 Playback Default"
+				lock true
+				preserve true
+				optional true
+				value [ $AES0 $AES1 $AES2 $AES3 ]
+			}
+		]
+	}
+}


### PR DESCRIPTION
Rebuild to latest version.
They removed the imx-specific audio parts from the source which makes it necessary to configure alsa correctly. @pepedog recommended to add those configs to this package (see xbmc-imx6/xbmc#68).
Alternatively, this conf files could be added to the respective kernels.

I built this version and audio worked fine. I was not able to test passthrough though (missing the hardware).

As far as I know, this does not enable hd-audio. Unfortunately, I can not test this. If someone has the necessary hardware and wants to give it a trym just contact me.

Cheers
