### PR TITLE
alarm/xbmc-imx: Update PKGBUILD to use new vcs syntax

### DIFF
--- a/alarm/xbmc-imx/PKGBUILD
+++ b/alarm/xbmc-imx/PKGBUILD
@@ -22,7 +22,11 @@ optdepends=(
 provides=("xbmc")
 conflicts=("xbmc")
 install="xbmc.install"
-source=('xbmc.service'
+
+_gitname=$pkgname
+# master branch of xbmc-imx6 organization. Modified by Stephan "wolgar" Rafin, Chris "koying" Browet, Rudi "rudi-warped" Ihle and smallint
+source=(${_gitname}'::git://github.com/xbmc-imx6/xbmc#branch=master'
+        'xbmc.service'
         'runxbmc'
         'xbmc.conf'
         '10-xbmc.rules'
@@ -30,36 +34,17 @@ source=('xbmc.service'
         'imx-hdmi-soc.conf')
 
 
-md5sums=('07096dfd530cc432fa6073ee1a32e7f6'
+md5sums=('SKIP'
+         '07096dfd530cc432fa6073ee1a32e7f6'
          '730ac095a89b05c3c2cf2dd93947cb5c'
          '8fab4cc5cac44a7090ca7e839e326ec8'
          'c3ad87fc9f278f9530d673be9b1f58f0'
          'df3edfc7269d4a4d6f94d935c9adb0ac'
          '90f401e9f255291ec75414056e0d30c0')
 
-# master branch of xbmc-imx6 organization. Modified by Stephan "wolgar" Rafin, Chris "koying" Browet, Rudi "rudi-warped" Ihle and smallint
-_gitname="xbmc"
-_gitroot="git://github.com/xbmc-imx6"
-_gitbranch="master"
-
 _prefix=/usr
 
 prepare() {
-  cd "${srcdir}"
-
-
-  msg2 "Connecting to GIT server..."
-  
-  if [[ -d "${_gitname}" ]]; then
-     cd "${_gitname}" && git pull origin "$_gitbranch"
-     msg2 "The local files are updated."
-  else
-     git clone --branch ${_gitbranch} --depth 1 "${_gitroot}/${_gitname}"
-  fi
-  
-  msg2 "GIT checkout done or server timeout." 
-
-
   cd "${srcdir}/${_gitname}"
 
   # fix lsb_release dependency


### PR DESCRIPTION
Using the new VCS features in makepkg allows for a local cache to be used if the same branch has been fetched before.
