### PR TITLE
fix python2-apscheduler

### DIFF
--- a/aur/python2-apscheduler/PKGBUILD
+++ b/aur/python2-apscheduler/PKGBUILD
@@ -16,7 +16,9 @@ depends=('python2'
          'python2-pytz'
          'python2-tzlocal'
          'python2-futures'
-         'python2-six')
+         'python2-six'
+         'python2-setuptools'
+        )
 #makedepends=()
 #provides=()
 #conflicts=()


### PR DESCRIPTION
Adding python2-setuptools as dependency
(not make dependency - it is required at runtime)
