### PR TITLE
add Cubietruck to linux-armv7

### DIFF
--- a/core/linux-armv7/PKGBUILD
+++ b/core/linux-armv7/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-3.18
 _kernelname=${pkgbase#linux}
 _desc="ARMv7 multi-platform"
 pkgver=3.18.1
-pkgrel=1
+pkgrel=2
 rcnrel=armv7-x2
 arch=('armv7h')
 url="http://www.kernel.org/"
@@ -280,7 +280,7 @@ _package-headers() {
 _package-smileplug() {
   pkgdesc="The Linux Kernel - ${_desc} - Marvell SMILE Plug"
   depends=('linux-armv7')
-  conflicts=('linux-armv7-mirabox' 'linux-armv7-ax3' 'linux-armv7-d3plug' 'linux-armv7-cubox')
+  conflicts=('linux-armv7-mirabox' 'linux-armv7-ax3' 'linux-armv7-d3plug' 'linux-armv7-cubox' 'linux-armv7-cubietruck')
   replaces=('linux-mvebu-smileplug')
 
   cd "${srcdir}/${_srcname}"
@@ -293,7 +293,7 @@ _package-smileplug() {
 _package-mirabox() {
   pkgdesc="The Linux Kernel - ${_desc} - Globalscale Mirabox"
   depends=('linux-armv7')
-  conflicts=('linux-armv7-smileplug' 'linux-armv7-ax3' 'linux-armv7-d3plug' 'linux-armv7-cubox')
+  conflicts=('linux-armv7-smileplug' 'linux-armv7-ax3' 'linux-armv7-d3plug' 'linux-armv7-cubox' 'linux-armv7-cubietruck')
   replaces=('linux-mvebu-mirabox')
 
   cd "${srcdir}/${_srcname}"
@@ -306,7 +306,7 @@ _package-mirabox() {
 _package-ax3() {
   pkgdesc="The Linux Kernel - ${_desc} - OpenBlocks AX3-4"
   depends=('linux-armv7')
-  conflicts=('linux-armv7-mirabox' 'linux-armv7-smileplug' 'linux-armv7-d3plug' 'linux-armv7-cubox')
+  conflicts=('linux-armv7-mirabox' 'linux-armv7-smileplug' 'linux-armv7-d3plug' 'linux-armv7-cubox' 'linux-armv7-cubietruck')
   replaces=('linux-mvebu-ax3')
 
   cd "${srcdir}/${_srcname}"
@@ -319,7 +319,7 @@ _package-ax3() {
 _package-d3plug() {
   pkgdesc="The Linux Kernel - ${_desc} - Globalscale D3Plug"
   depends=('linux-armv7')
-  conflicts=('linux-armv7-mirabox' 'linux-armv7-smileplug' 'linux-armv7-ax3' 'linux-armv7-cubox')
+  conflicts=('linux-armv7-mirabox' 'linux-armv7-smileplug' 'linux-armv7-ax3' 'linux-armv7-cubox' 'linux-armv7-cubietruck')
   #replaces=('linux-d3plug')
 
   cd "${srcdir}/${_srcname}"
@@ -332,7 +332,7 @@ _package-d3plug() {
 _package-cubox() {
   pkgdesc="The Linux Kernel - ${_desc} - SolidRun Cubox (Marvell)"
   depends=('linux-armv7')
-  conflicts=('linux-armv7-mirabox' 'linux-armv7-smileplug' 'linux-armv7-ax3' 'linux-armv7-d3plug')
+  conflicts=('linux-armv7-mirabox' 'linux-armv7-smileplug' 'linux-armv7-ax3' 'linux-armv7-d3plug' 'linux-armv7-cubietruck')
   #replaces=('linux-cubox')
 
   cd "${srcdir}/${_srcname}"
@@ -342,7 +342,20 @@ _package-cubox() {
   mkimage -A arm -O linux -T kernel -C none -a 0x00008000 -e 0x00008000 -n "${pkgname}" -d myimage "${pkgdir}/boot/uImage"
 }
 
-pkgname=("${pkgbase}" "${pkgbase}-headers" "${pkgbase}-smileplug" "${pkgbase}-mirabox" "${pkgbase}-ax3" "${pkgbase}-d3plug" "${pkgbase}-cubox")
+_package-cubietruck() {
+  pkgdesc="The Linux Kernel - ${_desc} - Cubietruck"
+  depends=('linux-armv7')
+  conflicts=('linux-armv7-mirabox' 'linux-armv7-smileplug' 'linux-armv7-ax3' 'linux-armv7-d3plug' 'linux-armv7-cubox')
+  #replaces=('linux-sun7i')
+
+  cd "${srcdir}/${_srcname}"
+
+  mkdir -p "${pkgdir}/boot"
+  cat arch/$KARCH/boot/zImage arch/$KARCH/boot/dts/sun7i-a20-cubietruck.dtb > myimage
+  mkimage -A arm -O linux -T kernel -C none -a 0x40008000 -e 0x40008000 -n "${pkgname}" -d myimage "${pkgdir}/boot/uImage"
+}
+
+pkgname=("${pkgbase}" "${pkgbase}-headers" "${pkgbase}-smileplug" "${pkgbase}-mirabox" "${pkgbase}-ax3" "${pkgbase}-d3plug" "${pkgbase}-cubox" "${pkgbase}-cubietruck")
 for _p in ${pkgname[@]}; do
   eval "package_${_p}() {
     _package${_p#${pkgbase}}


### PR DESCRIPTION
Adds a packet called 'linux-armv7-cubietruck' to 'linux-armv7' to support the Cubieboard3/Cubietruck.

Changes:
- added _package-cubietruck() function
- added 'linux-armv7-cubietruck' to conflicts for each other packet
- bumped packet version 

Cubieboard 1 and 2 should work fine, too. But since i don't have those boards i couldn't test anything.

Things worth mentioning that aren't supported in 3.18:
- Bluetooth
- graphic output **
- NAND **

*\* added in 3.19-rc1
