### PR TITLE
linux-odroid: generate initramfs image (to support persistent partition names)

### DIFF
--- a/core/linux-odroid/PKGBUILD
+++ b/core/linux-odroid/PKGBUILD
@@ -8,21 +8,26 @@ pkgname=('linux-odroid-x' 'linux-odroid-x2' 'linux-odroid-u2' 'linux-headers-odr
 _kernelname=${pkgname#linux}
 _basekernel=3.8
 pkgver=${_basekernel}.13.28
-pkgrel=3
+pkgrel=4
 arch=('armv7h')
 url="http://github.com/hardkernel/linux/"
 license=('GPL2')
-makedepends=('xmlto' 'docbook-xsl' 'kmod' 'git' 'inetutils' 'bc')
+makedepends=('xmlto' 'docbook-xsl' 'kmod' 'git' 'inetutils' 'bc' 'uboot-tools')
 options=('!strip')
 _commit=3bcdf52287dbfa82643a8f59dc32c14fed2587b0
 source=("https://github.com/hardkernel/linux/archive/${_commit}.tar.gz"
         'config_x'
         'config_x2'
-        'config_u2')
+        'config_u2'
+        'linux-odroid.preset')
 md5sums=('535dc7f921ae5c4618c2ab8de535c166'
          'd62dbed886fb95750031d4ab577c4739'
          '4ee9bbb8bf22b078ffcb6d5d60f9d431'
-         'e2e88e5c82e509d13287d45f78a6caeb')
+         'e2e88e5c82e509d13287d45f78a6caeb'
+         'f4b60c38c4930d40bf025e50d3ec45d3')
+
+# Kernel and initrd images go here
+_bootdir=/boot
 
 prepare() {
   cd "${srcdir}/linux-${_commit}"
@@ -49,13 +54,22 @@ build_kernel_package() {
 
   mkdir -p "${pkgdir}"/{lib/modules,lib/firmware,boot}
   make INSTALL_MOD_PATH="${pkgdir}" modules_install
-  cp arch/$KARCH/boot/zImage "${pkgdir}/boot/zImage"
+  cp arch/$KARCH/boot/zImage "${pkgdir}/${_bootdir}/zImage"
 
   # set correct depmod command for install
   sed \
     -e  "s/KERNEL_NAME=.*/KERNEL_NAME=${_kernelname}/g" \
     -e  "s/KERNEL_VERSION=.*/KERNEL_VERSION=${_kernver}/g" \
+    -e  "s|BOOT_DIR=.*|BOOT_DIR=${_bootdir}|g" \
     -i "${startdir}/${pkgbase}.install"
+
+  # install mkinitcpio preset file for kernel
+  install -D -m644 "${startdir}/${pkgbase}.preset" "${pkgdir}/etc/mkinitcpio.d/${pkgbase}.preset"
+  sed \
+    -e "s|ALL_kver=.*|ALL_kver=${_kernver}|" \
+    -e "s|BOOT_DIR=.*|BOOT_DIR=${_bootdir}|" \
+    -i "${pkgdir}/etc/mkinitcpio.d/${pkgbase}.preset"
+
   # remove build and source links
   rm -f "${pkgdir}"/lib/modules/${_kernver}/{source,build}
   # remove the firmware
@@ -83,6 +97,7 @@ package_linux-odroid-x() {
   provides=('kernel26' "linux=${pkgver}")
   conflicts=('linux-odroidx' 'linux-odroid-x-mali' 'linux-odroid-u2' 'linux-odroid-u2-mali' 'linux-odroid-x2')
   replaces=('linux-odroidx' 'linux-odroid-x-mali')
+  backup=("etc/mkinitcpio.d/${pkgbase}.preset")
   install=${pkgbase}.install
 
   build_kernel_package config_x
@@ -95,6 +110,7 @@ package_linux-odroid-x2() {
   provides=('kernel26' "linux=${pkgver}")
   conflicts=('linux-odroidx' 'linux-odroid-x-mali' 'linux-odroid-u2' 'linux-odroid-u2-mali' 'linux-odroid-x')
   replaces=('linux-odroidx' 'linux-odroid-x-mali')
+  backup=("etc/mkinitcpio.d/${pkgbase}.preset")
   install=${pkgbase}.install
 
   build_kernel_package config_x2
@@ -107,6 +123,7 @@ package_linux-odroid-u2() {
   provides=('kernel26' "linux=${pkgver}")
   conflicts=('linux-odroidx' 'linux-odroid-x' 'linux-odroid-x-mali' 'linux-odroid-u2-mali' 'linux-odroid-x2')
   replaces=('linux-odroid-u2-mali')
+  backup=("etc/mkinitcpio.d/${pkgbase}.preset")
   install=${pkgbase}.install
 
   build_kernel_package config_u2

--- a/core/linux-odroid/linux-odroid.install
+++ b/core/linux-odroid/linux-odroid.install
@@ -1,16 +1,31 @@
 # arg 1:  the new package version
 # arg 2:  the old package versio
 
-KERNEL_VERSION=3.8.13-1-ARCH
+# Set by PKGBUILD
+KERNEL_VERSION=
+BOOT_DIR=
+
+# Image file name must match with the name in the .preset file for mkinitcpio
+INITRAMFS_IMAGE=initramfs-linux
+
+# Packed image file name should match the default name in uboot-odroid package
+PACKED_INITRAMFS_IMAGE=${INITRAMFS_IMAGE}.img
+
+make_initrd() {
+  echo ">>> Generating initial ramdisk, using mkinitcpio. Please wait..."
+  mkinitcpio -p linux-odroid
+  mkimage -A arm -O linux -T ramdisk -C none \
+          -n "image ${source_archive}" \
+          -d ${BOOT_DIR}/${INITRAMFS_IMAGE} \
+          ${BOOT_DIR}/${PACKED_INITRAMFS_IMAGE} >/dev/null
+}
 
 post_install () {
   # updating module dependencies
   echo ">>> Updating module dependencies. Please wait ..."
   depmod ${KERNEL_VERSION}
+  make_initrd
   sync
-
- # echo "NOTE: You will probably need to copy /boot/uImage to the first partition"
- # echo "      of your SD card."
 }
 
 post_upgrade() {
@@ -25,7 +40,10 @@ post_upgrade() {
   # updating module dependencies
   echo ">>> Updating module dependencies. Please wait ..."
   depmod ${KERNEL_VERSION}
+  make_initrd
   sync
-#  echo "NOTE: You will probably need to copy /boot/uImage to the first partition"
-#  echo "      of your SD card."
+}
+
+post_remove() {
+  rm -f ${BOOT_DIR}/${INITRAMFS_IMAGE} ${BOOT_DIR}/${PACKED_INITRAMFS_IMAGE}
 }

--- a/core/linux-odroid/linux-odroid.preset
+++ b/core/linux-odroid/linux-odroid.preset
@@ -1,0 +1,15 @@
+# mkinitcpio preset file for the 'linux-odroid' package
+
+# BOOT_DIR is replaced by PKGBUILD to have it defined in one place only
+BOOT_DIR=
+
+ALL_config="/etc/mkinitcpio.conf"
+
+# Kernel version is set by PKGBUILD
+ALL_kver=
+
+PRESETS=('default')
+
+#default_config="/etc/mkinitcpio.conf"
+default_image="${BOOT_DIR}/initramfs-linux"
+#default_options=""


### PR DESCRIPTION
**Package**: linux-odroid (-u3,-x,-x2), uboot-odroid
**Architecture**: armv7h
**Device**: Hardkernel Odroid U3 (also affected X, X2)

**What it isn't doing**: Linux does not boot from MMC when an SD card is present.
**What it should be doing**: It should be possible to configure U-Boot (uEnv.txt) such that Linux can boot from MMC regardless of whether an SD card is present or not.

**Steps to reproduce**:
1. On Odroid U3 board install Arch to MMC by [official instructions](http://archlinuxarm.org/platforms/armv7/samsung/odroid-u3#qt-platform_tabs-ui-tabs2). The default root file system specification in U-Boot config (`/boot/uEnv.txt`) is  `root=/dev/mmcblk0p1`.
2. Plug in an SD card whose first partition does not contain Linux.
3. Attempt to boot: Linux will fail to mount root file system because `/dev/mmcblk0p1` points to the first partition on the SD card not on the MMC. Changing to `/dev/mmcblk1p1` will work... until you decide to take the SD card out and the MMC device index will flip back to 0.

I actually did not follow these exact steps since my MMC is partitioned differently from the default into (`/boot, swap, /, /home` in that order), but that is not relevant to the issue.

**Details**: On Odroid U3 board there are two _removable_ block devices: SD card and MMC module. If only one of the two is plugged in, then the one and only device is assigned index 0. Otherwise, the MMC module is assigned index 1 and the SD card index 0. Thus, the MMC module may be either at index 0 or 1 depending on whether an SD card is plugged into the SD slot. As a result, any given U-Boot configuration using device numbers can either boot the system when the SD card is present OR when it is not present, but not in both cases.

**Solution**: Use a persistent name for the root partition, such as `root=LABEL=sys` or `root=UUID=...`. However, for that to work, a ramdisk with early userspace is needed. The proposed commit updates `linux-odroid` package to generate an initramfs image using mkinitcpio and pack it using mkimage for use by U-Boot.

The latter step (mkimage) means a build dependency on `uboot-tools` and a reference to the boot loader in a kernel package which is logically independent of boot loaders. However, the integrated and automated solution is worth this dependency wrinkle. Otherwise, the user would have to pack the image manually before using persistent names in `uEnv.txt`. In contrast, in the proposed version, the user can start using `LABEL=` or `UUID=` in uEnv.txt immediately after installing the new `linux-odroid`. U-Boot from `odroid-uboot` already looks for a ramdisk by default (`rdfile=` in `uEnv.txt` can only override the filename), and this patch generates it with the default name.

Commit b8f6d4e is some harmless factoring of the package script to avoid duplicating identical build code for the three boards.
