### PR TITLE
linux-odroid: make header packaging robust to any kernel config

### DIFF
--- a/core/linux-odroid/PKGBUILD
+++ b/core/linux-odroid/PKGBUILD
@@ -258,40 +258,61 @@ package_linux-headers-odroid() {
   cp include/linux/inotify.h "${pkgdir}/usr/src/linux-${_kernver}/include/linux/"
 
   # add wireless headers
-  mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/net/mac80211/"
-  cp net/mac80211/*.h "${pkgdir}/usr/src/linux-${_kernver}/net/mac80211/"
+  if [ -d net/mac80211 ]
+  then
+    mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/net/mac80211/"
+    cp net/mac80211/*.h "${pkgdir}/usr/src/linux-${_kernver}/net/mac80211/"
+  fi
 
   # add dvb headers for external modules
   # in reference to:
   # http://bugs.archlinux.org/task/9912
-  mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/dvb-core"
-  cp drivers/media/dvb-core/*.h "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/dvb-core/"
+  if [ -d drivers/media/dvb-core ]
+  then
+    mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/dvb-core"
+    cp drivers/media/dvb-core/*.h "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/dvb-core/"
+  fi
   # and...
   # http://bugs.archlinux.org/task/11194
-  mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/include/config/dvb/"
-  cp include/config/dvb/*.h "${pkgdir}/usr/src/linux-${_kernver}/include/config/dvb/"
+  if [ -d include/config/dvb ]
+  then
+    mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/include/config/dvb/"
+    cp include/config/dvb/*.h "${pkgdir}/usr/src/linux-${_kernver}/include/config/dvb/"
+  fi
 
   # add dvb headers for http://mcentral.de/hg/~mrec/em28xx-new
   # in reference to:
   # http://bugs.archlinux.org/task/13146
-  mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/dvb-frontends/"
-  cp drivers/media/dvb-frontends/lgdt330x.h "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/dvb-frontends/"
-  cp drivers/media/i2c/msp3400-driver.h "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/i2c/"
+  if [ -e drivers/media/dvb-frontends/lgdt330x.h ]
+  then
+    mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/dvb-frontends/"
+    cp drivers/media/dvb-frontends/lgdt330x.h "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/dvb-frontends/"
+  fi
+  if [ -e drivers/media/i2c/msp3400-driver.h ]
+  then
+    mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/i2c/"
+    cp drivers/media/i2c/msp3400-driver.h "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/i2c/"
+  fi
 
   # add dvb headers
   # in reference to:
   # http://bugs.archlinux.org/task/20402
-  mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/usb/dvb-usb"
-  cp drivers/media/usb/dvb-usb/*.h "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/usb/dvb-usb/"
-  mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/dvb-frontends"
-  cp drivers/media/dvb-frontends/*.h "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/dvb-frontends/"
-  mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/tuners"
-  cp drivers/media/tuners/*.h "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/tuners/"
+  for folder in usb/dvb-usb dvb-frontends tuners
+  do
+    if [ -d drivers/media/$folder ]
+    then
+      mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/$folder"
+      cp drivers/media/$folder/*.h "${pkgdir}/usr/src/linux-${_kernver}/drivers/media/$folder/"
+    fi
+  done
 
   # add xfs and shmem for aufs building
-  mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/fs/xfs"
-  mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/mm"
-  cp fs/xfs/xfs_sb.h "${pkgdir}/usr/src/linux-${_kernver}/fs/xfs/xfs_sb.h"
+  if [ -e fs/xfs/xfs_sb.h ]
+  then
+    mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/fs/xfs"
+    mkdir -p "${pkgdir}/usr/src/linux-${_kernver}/mm"
+    cp fs/xfs/xfs_sb.h "${pkgdir}/usr/src/linux-${_kernver}/fs/xfs/xfs_sb.h"
+  fi
 
   # copy in Kconfig files
   for i in `find . -name "Kconfig*"`; do


### PR DESCRIPTION
**Package**: linux-odroid (linux-headers-odroid)
**Architecture**: armv7h
**Device**: Hardkernel Odroid U3 (also affected X, X2)

**What it isn't doing**: Packaging script fails to build the `linux-headers-odroid` package when the script is re-used to package a kernel built with a customized configuration. That is, in the case when PKGBUILD is unchanged except for the kernel config file it uses. The failure is because it is trying to move some headers that don't exist.
**What it should be doing**: The packaging script should be robust enough to build and package up a kernel with a customized config.

**Steps to reproduce:** Try `makepkg` on `linux-odroid` after modifying the kernel config file to exclude a bunch of drivers.

**Solution**: Perform the packaging commands that apply to particular headers only if those headers actually exist.

This patch does not change the resulting package from what it is now at all, hence did not bump the package version.
