### PR TITLE
kodi user should not have shell access

### DIFF
--- a/alarm/kodi-rbp/kodi.install
+++ b/alarm/kodi-rbp/kodi.install
@@ -2,7 +2,7 @@ post_install() {
   [[ $(type -p gtk-update-icon-cache) ]] && usr/bin/gtk-update-icon-cache -qtf usr/share/icons/hicolor
   [[ $(type -p update-desktop-database) ]] && usr/bin/update-desktop-database -q usr/share/applications
   getent group kodi > /dev/null || groupadd -r kodi
-  getent passwd kodi > /dev/null || useradd -r -m -d /var/lib/kodi -g kodi kodi
+  getent passwd kodi > /dev/null || useradd -r -m -d /var/lib/kodi -g kodi -s /usr/bin/nologin kodi
   usermod -a -G kodi,audio,video,power,network,optical,storage,disk kodi
   mkdir -p var/lib/kodi
   chown -R kodi:kodi var/lib/kodi


### PR DESCRIPTION
kodi-rbp 14.0-1 creates a kodi user with /bin/bash as the default shell which presents a security risk IMO.
