### PR TITLE
Added phantomjs fixes for ARM

### DIFF
--- a/community/phantomjs/PKGBUILD
+++ b/community/phantomjs/PKGBUILD
@@ -1,0 +1,46 @@
+# $Id$
+# Maintainer: Felix Yan <felixonmars@gmail.com>
+# Contributor: grimsock <lord.grimsock at gmail dot com>
+# Contributor: Dieter Plaetinck <dieter@plaetinck.be>
+# Contributor: Vladimir Chizhov <jagoterr@gmail.com>
+# Contributor: Henry Tang <henryykt@gmail.com>
+
+# ALARM: Kevin Mihelich <kevin@archlinuxarm.org>
+#  - Just say NO to x86 optimizations, and no neon
+#  - added -fno-strict-volatile-bitfields to CXXFLAGS to fix ARM bug
+
+
+pkgname=phantomjs
+pkgver=1.9.8
+pkgrel=1
+pkgdesc="Headless WebKit with JavaScript API"
+url="http://www.phantomjs.org/"
+license=('BSD' 'LGPL' 'MIT')
+arch=('i686' 'x86_64')
+depends=('gstreamer0.10-base' 'fontconfig' 'freetype2' 'gcc-libs')
+makedepends=('git')
+source=("git+https://github.com/ariya/${pkgname}.git#tag=$pkgver")
+
+build() {
+  cd $pkgname
+
+  # workaround for http://code.google.com/p/phantomjs/issues/detail?id=635
+  sed -i 's/QMAKE_LFLAGS+=-fuse-ld=gold/#QMAKE_LFLAGS+=-fuse-ld=gold/' src/qt/src/3rdparty/webkit/Source/common.pri
+
+  export CXXFLAGS="$CXXFLAGS -fno-strict-volatile-bitfields"
+
+  ./build.sh --confirm --qt-config \
+      "-no-rpath -no-mmx -no-3dnow -no-sse -no-sse2 -no-sse3 -no-ssse3 -no-sse4.1 -no-sse4.2 -no-avx -no-neon"
+}
+
+package() {
+  install -Dm755 "$srcdir/$pkgname/bin/phantomjs" "$pkgdir/usr/bin/phantomjs"
+
+  mkdir -p "$pkgdir/usr/share/$pkgname"
+  cp -r "$srcdir/$pkgname/examples" "$pkgdir/usr/share/$pkgname"/
+
+  install -Dm644 "$srcdir/$pkgname/LICENSE.BSD" "$pkgdir/usr/share/licenses/$pkgname/LICENSE.BSD"
+  install -Dm644 "$srcdir/$pkgname/third-party.txt" "$pkgdir/usr/share/licenses/$pkgname/third-party.txt"
+}
+
+sha512sums=('SKIP')


### PR DESCRIPTION
This has been tested working on armv7h. It needs testing on the other platforms.
The fixes are ported from the qt4 PKGBUILD (phantomjs bundles Qt). It appears that -fno-strict-volatile-bitfields is no longer needed.