### PR TITLE
[uboot-sunxi] add a20-olinuxino-lime2

### DIFF
--- a/alarm/uboot-sunxi/PKGBUILD
+++ b/alarm/uboot-sunxi/PKGBUILD
@@ -5,6 +5,7 @@ buildarch=4
 
 pkgbase=uboot-sunxi
 pkgname=('uboot-cubieboard2' 'uboot-cubietruck' 'uboot-a20-olinuxino-micro' 'uboot-a13-olinuxino-micro'
+         'uboot-a20-olinuxino-lime' 'uboot-a20-olinuxino-lime2'
          'uboot-a10s-olinuxino-micro' 'uboot-a10s-olinuxino-micro-lcd7' 'uboot-cubieboard')
 pkgver=2015.01
 pkgrel=2
@@ -28,6 +29,8 @@ boards=('Cubieboard'
         'Cubieboard2'
         'Cubietruck'
         'A20-OLinuXino_MICRO'
+        'A20-OLinuXino-Lime'
+        'A20-OLinuXino-Lime2'
         'A13-OLinuXinoM'
         'A10s-OLinuXino-M')
 
@@ -110,6 +113,36 @@ package_uboot-a20-olinuxino-micro() {
   install -Dm644 bin_A20-OLinuXino_MICRO/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
 
   fex2bin sunxi-boards/sys_config/a20/a20-olinuxino_micro.fex "${pkgdir}"/boot/script.bin
+  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
+  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
+  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
+}
+
+package_uboot-a20-olinuxino-lime() {
+  pkgdesc="U-Boot for A20 OLinuXino Lime"
+  install=${pkgbase}.install
+  provides=('uboot-sunxi')
+  conflicts=('uboot-sunxi')
+
+  install -d "${pkgdir}"/boot
+  install -Dm644 bin_A20-OLinuXino-Lime/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
+
+  fex2bin sunxi-boards/sys_config/a20/a20-olinuxino_lime.fex "${pkgdir}"/boot/script.bin
+  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
+  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
+  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
+}
+
+package_uboot-a20-olinuxino-lime2() {
+  pkgdesc="U-Boot for A20 OLinuXino Lime2"
+  install=${pkgbase}.install
+  provides=('uboot-sunxi')
+  conflicts=('uboot-sunxi')
+
+  install -d "${pkgdir}"/boot
+  install -Dm644 bin_A20-OLinuXino-Lime2/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
+
+  fex2bin sunxi-boards/sys_config/a20/a20-olinuxino_lime2.fex "${pkgdir}"/boot/script.bin
   install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
   install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
   install -Dm755 mkscr "${pkgdir}"/boot/mkscr


### PR DESCRIPTION
Add u-boot-sunxi target for A20-OLinuXino-Lime2 board.