### PR TITLE
Fix comment for debug's default value

### DIFF
--- a/core/linux-raspberrypi/config.txt
+++ b/core/linux-raspberrypi/config.txt
@@ -61,7 +61,7 @@
 #                                  (default "on")
 #         invert                   "on" = invert the output pin (default "off")
 #         debug                    "on" = enable additional debug messages
-                                 (default "off")
+#                                  (default "off")
 #device_tree_overlay=lirc-rpi
 #device_tree_param=gpio_out_pin=17
 #device_tree_param=gpio_in_pin=18


### PR DESCRIPTION
The default value should be marked as a comment using '#'.