### PR TITLE
Enable spidev kernel module for use with HummingBoard

### DIFF
--- a/core/linux-imx6-cubox-dt/PKGBUILD
+++ b/core/linux-imx6-cubox-dt/PKGBUILD
@@ -16,7 +16,7 @@ _srcname=linux-imx6-3.14-${_commit}
 _kernelname=${pkgname#linux}
 _basekernel=3.14
 pkgver=${_basekernel}.32
-pkgrel=1
+pkgrel=2
 cryptodev_commit=6aa62a2c320b04f55fdfe0ed015c3d9b48997239
 arch=('arm')
 url="http://www.kernel.org/"
@@ -36,7 +36,7 @@ md5sums=('d4c399933152f8f56378d67d7462cced'
          'ddf7876487c876f6676ef0e050e9d204'
          'SKIP'
          '1b276abe16d14e133f3f28d9c9e6bd68'
-         '8fb83f618262a84164b5604b7386cbc3'
+         '5315fab8f481b34a2ed6abe5d27035ca'
          '8bf79a580704e8dab806f58043720a90'
          '6391a74bf1d451b74df6f189a25cf642'
          'a70798b63a0e7c3fb50a57ea1815d353')

--- a/core/linux-imx6-cubox-dt/config
+++ b/core/linux-imx6-cubox-dt/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 3.14.27-2 Kernel Configuration
+# Linux/arm 3.14.32-2 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_MIGHT_HAVE_PCI=y
@@ -2882,7 +2882,7 @@ CONFIG_SPI_IMX=y
 #
 # SPI Protocol Masters
 #
-# CONFIG_SPI_SPIDEV is not set
+CONFIG_SPI_SPIDEV=m
 # CONFIG_SPI_TLE62X0 is not set
 # CONFIG_HSI is not set
 


### PR DESCRIPTION
This will create /dev/spidev1.0 and /dev/spidev1.1 on the HummingBoard.

SPI requires modifications to the current dtb files, which can be seen in
https://github.com/SolidRun/linux-imx6-3.14/pull/19