### PR TITLE
alarm/odroid-c1-libgl-headers: add conflicts for libump

### DIFF
--- a/alarm/odroid-c1-libgl/PKGBUILD
+++ b/alarm/odroid-c1-libgl/PKGBUILD
@@ -42,6 +42,7 @@ package_odroid-c1-libgl-fb() {
 
 package_odroid-c1-libgl-headers() {
   pkgdesc="ODROID-C1 Mali driver headers"
+  conflicts=('libump')
 
   install -d "${pkgdir}"/usr/include
   cp -a c1_mali_libs/x11/mali_headers/{ump,umplock} "${pkgdir}"/usr/include


### PR DESCRIPTION
The packages odroid-c1-libgl-headers and libump(-git) own the same
files in the file system (at least partially). This is easily
reproducable by having odroid-c1-lib-headers installed and trying to
install libump:
```
# pacman -Ss odroid-c1-libgl-headers
alarm/odroid-c1-libgl-headers r4p0-2 [installed]

# pacman -S libump
resolving dependencies...
looking for conflicting packages...

Packages (1) libump-git-3-0

Total Installed Size:  0.09 MiB

:: Proceed with installation? [Y/n] y
(1/1) checking keys in keyring                                  [##################################] 100%
(1/1) checking package integrity                                [##################################] 100%
(1/1) loading package files                                     [##################################] 100%
(1/1) checking for file conflicts                               [##################################] 100%
error: failed to commit transaction (conflicting files)
libump-git: /usr/include/ump/ump.h exists in filesystem
libump-git: /usr/include/ump/ump_debug.h exists in filesystem
libump-git: /usr/include/ump/ump_osu.h exists in filesystem
libump-git: /usr/include/ump/ump_platform.h exists in filesystem
libump-git: /usr/include/ump/ump_ref_drv.h exists in filesystem
libump-git: /usr/include/ump/ump_uk_types.h exists in filesystem
Errors occurred, no packages were upgraded.

# pacman -Qo /usr/include/ump/ump.h
/usr/include/ump/ump.h is owned by odroid-c1-libgl-headers r4p0-2
```

The files in question are:
```
/usr/include/ump/ump.h
/usr/include/ump/ump_debug.h
/usr/include/ump/ump_osu.h
/usr/include/ump/ump_platform.h
/usr/include/ump/ump_ref_drv.h
/usr/include/ump/ump_uk_types.h
```

This fix is therefore needed to resolve conflicts before
actually trying to put files into the filesystem that
already exist (and thus quit with an error).