### PR TITLE
/alarm/odroid-c1-libgl: Add odroid-c1-libgl-fb-headers

### DIFF
--- a/alarm/odroid-c1-libgl/PKGBUILD
+++ b/alarm/odroid-c1-libgl/PKGBUILD
@@ -4,9 +4,9 @@
 buildarch=4
 
 pkgbase=odroid-c1-libgl
-pkgname=("${pkgbase}-x11" "${pkgbase}-fb" "${pkgbase}-headers")
+pkgname=("${pkgbase}-x11" "${pkgbase}-fb" "${pkgbase}-x11-headers" "${pkgbase}-fb-headers")
 pkgver=r4p0
-pkgrel=2
+pkgrel=3
 arch=('armv7h')
 url="http://www.hardkernel.com/"
 license=('Proprietary')
@@ -19,8 +19,8 @@ md5sums=('SKIP'
 
 package_odroid-c1-libgl-x11() {
   pkgdesc="ODROID-C1 Mali driver (X11)"
-  conflicts=('odroid-c1-libgl')
-  provides=('odroid-c1-libgl')
+  conflicts=('odroid-c1-libgl-fb')
+  provides=('odroid-c1-libgl-x11' 'odroid-c1-libgl')
   replaces=('odroid-c1-libgl')
 
   install -d "${pkgdir}"/usr/lib/mali-egl
@@ -31,8 +31,8 @@ package_odroid-c1-libgl-x11() {
 
 package_odroid-c1-libgl-fb() {
   pkgdesc="ODROID-C1 Mali driver (framebuffer)"
-  conflicts=('odroid-c1-libgl')
-  provides=('odroid-c1-libgl')
+  conflicts=('odroid-c1-libgl-x11' 'odroid-c1-libgl')
+  provides=('odroid-c1-libgl-fb')
 
   install -d "${pkgdir}"/usr/lib/mali-egl
   install -d "${pkgdir}"/etc/ld.so.conf.d
@@ -40,9 +40,20 @@ package_odroid-c1-libgl-fb() {
   cp "${srcdir}"/mali-c1.conf "${pkgdir}"/etc/ld.so.conf.d
 }
 
-package_odroid-c1-libgl-headers() {
-  pkgdesc="ODROID-C1 Mali driver headers"
+package_odroid-c1-libgl-x11-headers() {
+  pkgdesc="ODROID-C1 Mali driver headers (X11)"
+  conflicts=('odroid-c1-libgl-fb-headers')
+  provides=('odroid-c1-libgl-x11-headers' 'odroid-c1-libgl-headers')
 
   install -d "${pkgdir}"/usr/include
   cp -a c1_mali_libs/x11/mali_headers/{ump,umplock} "${pkgdir}"/usr/include
+}
+
+package_odroid-c1-libgl-fb-headers() {
+  pkgdesc="ODROID-C1 Mali driver headers (framebuffer)"
+  conflicts=('odroid-c1-libgl-x11-headers' 'odroid-c1-libgl-headers')
+  provides=('odroid-c1-libgl-fb-headers')
+  
+  install -d "${pkgdir}"/usr/include
+  cp -a c1_mali_libs/fbdev/mali_headers/* "${pkgdir}"/usr/include
 }


### PR DESCRIPTION
Add the Mali framebuffer headers for the odroid-c1. Change odroid-c1-libgl-headers to odroid-c1-libgl-x11-headers.