### PR TITLE
core/linux-raspberrypi: Add support for tcp_lp module

### DIFF
--- a/core/linux-raspberrypi/PKGBUILD
+++ b/core/linux-raspberrypi/PKGBUILD
@@ -12,7 +12,7 @@ _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="Raspberry Pi"
 pkgver=3.18.7
-pkgrel=7
+pkgrel=8
 bfqver=v7r7
 arch=('armv6h' 'armv7h')
 url="http://www.kernel.org/"
@@ -35,11 +35,11 @@ md5sums=('420cf1e7be96d68fa099dce1cd20d7cf'
          '1c7c2d0338939a9e6953a64d80861471'
          'a81346cce95baeac2c56cf60d3c7e5b6'
          '8f2743651280f5a022e541f4e95e5546'
-         '405015cdeb544575c25018b3487a2e76'
+         '69d50a4604a587ae770e4be244e293bd'
          'fa4377b3247d80efade0ed3d5ec650f1'
          '60bc3624123c183305677097bcd56212'
-         'bd735deecc572abe1ab9ee97d518bb13'
-         'a7ec4d364011d651f111f2bd5b5463a6')
+         '72ead81d0d449adaaf98cf08b99c970e'
+         '0dfadce13613046c738e7925084fa15c')
 
 prepare() {
   cd "${srcdir}/${_srcname}"

--- a/core/linux-raspberrypi/config.v6
+++ b/core/linux-raspberrypi/config.v6
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 3.18.7-7 Kernel Configuration
+# Linux/arm 3.18.7-8 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_SYS_SUPPORTS_APM_EMULATION=y
@@ -609,7 +609,7 @@ CONFIG_TCP_CONG_HTCP=m
 # CONFIG_TCP_CONG_HYBLA is not set
 # CONFIG_TCP_CONG_VEGAS is not set
 # CONFIG_TCP_CONG_SCALABLE is not set
-# CONFIG_TCP_CONG_LP is not set
+CONFIG_TCP_CONG_LP=m
 # CONFIG_TCP_CONG_VENO is not set
 # CONFIG_TCP_CONG_YEAH is not set
 # CONFIG_TCP_CONG_ILLINOIS is not set

--- a/core/linux-raspberrypi/config.v7
+++ b/core/linux-raspberrypi/config.v7
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 3.18.7-7 Kernel Configuration
+# Linux/arm 3.18.7-8 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_SYS_SUPPORTS_APM_EMULATION=y
@@ -655,7 +655,7 @@ CONFIG_TCP_CONG_HTCP=m
 # CONFIG_TCP_CONG_HYBLA is not set
 # CONFIG_TCP_CONG_VEGAS is not set
 # CONFIG_TCP_CONG_SCALABLE is not set
-# CONFIG_TCP_CONG_LP is not set
+CONFIG_TCP_CONG_LP=m
 # CONFIG_TCP_CONG_VENO is not set
 # CONFIG_TCP_CONG_YEAH is not set
 # CONFIG_TCP_CONG_ILLINOIS is not set


### PR DESCRIPTION
it can be used in trasmission to avoid saturate the bandwidth.
see http://www.pps.univ-paris-diderot.fr/~jch/software/bittorrent/tcp-congestion-control.html