### PR TITLE
enable ALSA support

### DIFF
--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -8,7 +8,7 @@ buildarch=20
 pkgname=kodi-rbp
 pkgver=14.1
 _codename=Helix
-pkgrel=3
+pkgrel=4
 pkgdesc="A software media player and entertainment hub for digital media for the Raspberry Pi"
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
@@ -75,7 +75,6 @@ build() {
   --disable-xrandr \
   --enable-airplay \
   --enable-airtunes \
-  --disable-alsa \
   --enable-avahi \
   --enable-libbluray \
   --enable-dvdcss \


### PR DESCRIPTION
ALSA support is needed for other audio devices like USB and the HiFiBerry. Tested and confirmed that on-board audio still works and USB audio works as well.