### PR TITLE
core/linux-raspberrypi: Update Device Tree config

### DIFF
--- a/core/linux-raspberrypi/PKGBUILD
+++ b/core/linux-raspberrypi/PKGBUILD
@@ -12,7 +12,7 @@ _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="Raspberry Pi"
 pkgver=3.18.8
-pkgrel=1
+pkgrel=2
 bfqver=v7r7
 arch=('armv6h' 'armv7h')
 url="http://www.kernel.org/"
@@ -36,7 +36,7 @@ md5sums=('1eba2b2790d70a64295c1c40a65f4231'
          'a81346cce95baeac2c56cf60d3c7e5b6'
          '8f2743651280f5a022e541f4e95e5546'
          '69d50a4604a587ae770e4be244e293bd'
-         'b10de933710e1c20f3048d88aa6b2c52'
+         '6e99d8dc4413a57a67788f0c0d272256'
          '60bc3624123c183305677097bcd56212'
          'd8723946c6a5dedd2188ac1d762b4d42'
          '5be4806dbb426ae8cc7479d86b9aa638')

--- a/core/linux-raspberrypi/config.txt
+++ b/core/linux-raspberrypi/config.txt
@@ -68,20 +68,24 @@
 #device_tree_param=gpio_in_pull=down
 
 # Uncomment to enable the w1-gpio Onewire interface module
-# Use this overlay if you *don't* need a pin to drive an external pullup
-# N.B. The parasitic power feature is not yet functional using DT.
+# Use this overlay if you *don't* need a pin to drive an external pullup.
 # Params: gpiopin                  GPIO pin for I/O (default "4")
+#         pullup                   Non-zero, "on", or "y" to enable the parasitic
+#                                  power (2-wire, power-on-data) feature
 #device_tree_overlay=w1-gpio
 #device_tree_param=gpiopin=4
+#device_tree_param=pullup=on
 
 # Uncomment to enable the w1-gpio Onewire interface module
-# Use this overlay if you *do* need a pin to drive an external pullup
-# N.B. The parasitic power feature is not yet functional using DT.
+# Use this overlay if you *do* need a pin to drive an external pullup.
 # Params: gpiopin                  GPIO pin for I/O (default "4")
-#         pullup                   GPIO pin for external pullup (default "5")
-#device_tree_overlay=w1-gpio
+#         pullup                   Non-zero, "on", or "y" to enable the parasitic
+#                                  power (2-wire, power-on-data) feature
+#         extpullup                GPIO pin for external pullup (default "5")
+#device_tree_overlay=w1-gpio-pullup
 #device_tree_param=gpiopin=4
-#device_tree_param=pullup=5
+#device_tree_param=pullup=on
+#device_tree_param=extpullup=5
 
 # Uncomment to enable pps-gpio (pulse-per-second time signal via GPIO)
 # Params: gpiopin                  GPIO input pin (default "18")


### PR DESCRIPTION
* fix wrong name of overlay for w1-gpio using external pullup
* update w1-gpio(-pullup) parameters according to /boot/overlays/README