### PR TITLE
core/linux-kirkwood-dt: Fix cryptodev source local naming

### DIFF
--- a/core/linux-kirkwood-dt/PKGBUILD
+++ b/core/linux-kirkwood-dt/PKGBUILD
@@ -31,7 +31,7 @@ source=("ftp://ftp.kernel.org/pub/linux/kernel/v3.x/linux-${pkgver}.tar.xz"
         'usb-add-reset-resume-quirk-for-several-webcams.patch'
 	'0001-disable-mv643xx_eth-TSO.patch'
         "git://git.code.sf.net/p/aufs/aufs3-standalone#branch=${aufsbranch}"
-        "cryptodev.tar.gz::https://github.com/cryptodev-linux/cryptodev-linux/archive/${cryptodev_commit}.tar.gz"
+        "cryptodev-${cryptodev-commit}.tar.gz::https://github.com/cryptodev-linux/cryptodev-linux/archive/${cryptodev_commit}.tar.gz"
         "ftp://teambelgium.net/bfq/patches/${bfqkern}.0-${bfqver}/0001-block-cgroups-kconfig-build-bits-for-BFQ-${bfqver}-${bfqkern}.patch"
         "ftp://teambelgium.net/bfq/patches/${bfqkern}.0-${bfqver}/0002-block-introduce-the-BFQ-${bfqver}-I-O-sched-for-${bfqkern}.patch"
         "ftp://teambelgium.net/bfq/patches/${bfqkern}.0-${bfqver}/0003-block-bfq-add-Early-Queue-Merge-EQM-to-BFQ-${bfqver}-for-${bfqkern}.0.patch"


### PR DESCRIPTION
When ${cryptodev-commit} changes, local name for the source tarball
should change too, otherwise source caching will break.

I did not bump $pkgrel because the created package won't change, so no point to "upgrade" to it.
