### PR TITLE
core/linux-kirkwood-dt: Fix typo

### DIFF
--- a/core/linux-kirkwood-dt/PKGBUILD
+++ b/core/linux-kirkwood-dt/PKGBUILD
@@ -31,7 +31,7 @@ source=("ftp://ftp.kernel.org/pub/linux/kernel/v3.x/linux-${pkgver}.tar.xz"
         'usb-add-reset-resume-quirk-for-several-webcams.patch'
 	'0001-disable-mv643xx_eth-TSO.patch'
         "git://git.code.sf.net/p/aufs/aufs3-standalone#branch=${aufsbranch}"
-        "cryptodev-${cryptodev-commit}.tar.gz::https://github.com/cryptodev-linux/cryptodev-linux/archive/${cryptodev_commit}.tar.gz"
+        "cryptodev-${cryptodev_commit}.tar.gz::https://github.com/cryptodev-linux/cryptodev-linux/archive/${cryptodev_commit}.tar.gz"
         "ftp://teambelgium.net/bfq/patches/${bfqkern}.0-${bfqver}/0001-block-cgroups-kconfig-build-bits-for-BFQ-${bfqver}-${bfqkern}.patch"
         "ftp://teambelgium.net/bfq/patches/${bfqkern}.0-${bfqver}/0002-block-introduce-the-BFQ-${bfqver}-I-O-sched-for-${bfqkern}.patch"
         "ftp://teambelgium.net/bfq/patches/${bfqkern}.0-${bfqver}/0003-block-bfq-add-Early-Queue-Merge-EQM-to-BFQ-${bfqver}-for-${bfqkern}.0.patch"


### PR DESCRIPTION
Fix typo introduced in commit 571b9ac25791e48035c91e5990d083266b6796eb
Sorry, my bad.