### PR TITLE
core/linux-armv7: fix point release 3.19.1

### DIFF
--- a/core/linux-armv7/PKGBUILD
+++ b/core/linux-armv7/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-3.19
 _kernelname=${pkgbase#linux}
 _desc="ARMv7 multi-platform"
 pkgver=3.19.1
-pkgrel=2
+pkgrel=3
 rcnrel=armv7-x3
 arch=('armv7h')
 url="http://www.kernel.org/"
@@ -16,7 +16,7 @@ license=('GPL2')
 makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'git' 'uboot-tools')
 options=('!strip')
 source=("http://www.kernel.org/pub/linux/kernel/v3.x/${_srcname}.tar.xz"
-        #"http://www.kernel.org/pub/linux/kernel/v3.x/patch-${pkgver}.xz"
+        "http://www.kernel.org/pub/linux/kernel/v3.x/patch-${pkgver}.xz"
         "http://rcn-ee.net/deb/sid-armhf/v${pkgver}-${rcnrel}/patch-${pkgver%.0}-${rcnrel}.diff.gz"
         "git://git.code.sf.net/p/aufs/aufs3-standalone#branch=aufs${pkgver%.*}"
         #"git://git.code.sf.net/p/aufs/aufs3-standalone#branch=aufs3.x-rcN"
@@ -28,6 +28,7 @@ source=("http://www.kernel.org/pub/linux/kernel/v3.x/${_srcname}.tar.xz"
         '0006-USB-armory-support.patch'
         'config')
 md5sums=('d3fc8316d4d4d04b65cbc2d70799e763'
+         '2f2822cf2d84a8ec3a8b044e732cf45b'
          '0f085618a0d85d406320e8bbba7fbec1'
          'SKIP'
          '4e3bed0d1833836968ebf0d7947980a2'
@@ -42,7 +43,7 @@ prepare() {
   cd "${srcdir}/${_srcname}"
 
   # add upstream patch
-  #git apply --whitespace=nowarn ../patch-${pkgver}
+  git apply --whitespace=nowarn ../patch-${pkgver}
 
   # RCN patch
   git apply ../patch-${pkgver%.0}-${rcnrel}.diff


### PR DESCRIPTION
linux-armv7-3.19.1-2 still provides 3.19.0 as the patch providing the point release hasn't been considered in PKGBUILD again.