### PR TITLE
Add alarm/weston-rpi

### DIFF
--- a/alarm/weston-rpi/PKGBUILD
+++ b/alarm/weston-rpi/PKGBUILD
@@ -1,0 +1,47 @@
+# $Id$
+# Maintainer: Sébastien Luttringer
+# Contributor: Joel Teichroeb <joel@teichroeb.net>
+
+# ALARM: Kevin Mihelich <kevin@archlinuxarm.org>
+#  - export flags for rpi
+
+# ALARM: Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+#  - build for armv7h
+
+buildarch=4
+
+pkgname=weston-rpi
+pkgver=1.7.0
+pkgrel=1
+pkgdesc='Reference implementation of a Wayland compositor (Raspberry Pi 2)'
+arch=('armv7h')
+url='http://wayland.freedesktop.org'
+license=('MIT')
+depends=('libxkbcommon' 'libinput' 'libunwind' 'poppler-glib' 'mtdev' 'libxcursor' 'glu' 'pango' 'colord')
+makedepends=('raspberrypi-firmware')
+provides=('weston')
+conflicts=('weston')
+source=("http://wayland.freedesktop.org/releases/weston-$pkgver.tar.xz")
+sha1sums=('931a7a99a0b8ca03c28cd277525c5176dd7e02ce')
+
+build() {
+	export RPI_BCM_HOST_LIBS="-L/opt/vc/lib"
+	export RPI_BCM_HOST_CFLAGS="-I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux"
+	export WESTON_NATIVE_BACKEND="rpi-backend.so"
+	export RPI_COMPOSITOR_LIBS="-ludev -lmtdev -lbcm_host"
+	CONFIG='--disable-egl'
+
+	cd weston-$pkgver
+	./configure \
+		--prefix=/usr \
+		--libexecdir=/usr/lib/weston \
+		--enable-demo-clients-install $CONFIG
+	make
+}
+
+package() {
+	cd weston-$pkgver
+	make DESTDIR="$pkgdir" install
+	# license
+	install -Dm644 COPYING "$pkgdir/usr/share/licenses/$pkgname/COPYING"
+}


### PR DESCRIPTION
This package builds weston with the Raspberry Pi compositor on armv7h too.

As a matter of fact the weston package from community only support
the Raspberry Pi armv6h models, hence this package is needed for
proper Raspberry Pi 2 support.