### PR TITLE
server: bb.org: migrate rcn-ee.net to rcn-ee.com

### DIFF
--- a/core/linux-am33x-legacy/PKGBUILD
+++ b/core/linux-am33x-legacy/PKGBUILD
@@ -17,7 +17,7 @@ makedepends=('xmlto' 'docbook-xsl' 'uboot-mkimage' 'kmod' 'git' 'inetutils')
 options=('!strip')
 source=("ftp://ftp.kernel.org/pub/linux/kernel/v3.x/linux-${_basekernel}.tar.xz"
         "ftp://ftp.kernel.org/pub/linux/kernel/v3.x/patch-${pkgver}.bz2"
-        "http://rcn-ee.net/deb/sid-armhf/v${pkgver}-bone${bonerel}/patch-${pkgver}-bone${bonerel}.diff.gz"
+        "http://rcn-ee.com/deb/sid-armhf/v${pkgver}-bone${bonerel}/patch-${pkgver}-bone${bonerel}.diff.gz"
         'config'
         'change-default-console-loglevel.patch'
         'aufs3-3.8.patch.xz')

--- a/core/linux-am33x/PKGBUILD
+++ b/core/linux-am33x/PKGBUILD
@@ -17,7 +17,7 @@ makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'git')
 options=('!strip')
 source=("http://www.kernel.org/pub/linux/kernel/v3.x/${_srcname}.tar.xz"
         "http://www.kernel.org/pub/linux/kernel/v3.x/patch-${pkgver}.xz"
-        "http://rcn-ee.net/deb/sid-armhf/v${pkgver}-${rcnrel}/patch-${pkgver%.0}-${rcnrel}.diff.gz"
+        "http://rcn-ee.com/deb/sid-armhf/v${pkgver}-${rcnrel}/patch-${pkgver%.0}-${rcnrel}.diff.gz"
         "git://git.code.sf.net/p/aufs/aufs3-standalone#branch=aufs${pkgver%.*}"
         #"git://git.code.sf.net/p/aufs/aufs3-standalone#branch=aufs3.x-rcN" 
         'config')

--- a/core/linux-armv7-rc/PKGBUILD
+++ b/core/linux-armv7-rc/PKGBUILD
@@ -21,7 +21,7 @@ makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'git' 'uboot-tools')
 options=('!strip')
 source=("http://www.kernel.org/pub/linux/kernel/v3.x/${_srcname}.tar.xz"
         "https://www.kernel.org/pub/linux/kernel/v4.x/testing/patch-${_rcver}-rc${_rcrel}.xz"
-        "http://rcn-ee.net/deb/sid-armhf/v${_rcver}.0-rc${_rcrel}-${_rcnrel}/patch-${_rcver}-rc${_rcrel}-${_rcnrel}.diff.gz"
+        "http://rcn-ee.com/deb/sid-armhf/v${_rcver}.0-rc${_rcrel}-${_rcnrel}/patch-${_rcver}-rc${_rcrel}-${_rcnrel}.diff.gz"
         "git://git.code.sf.net/p/aufs/aufs3-standalone#branch=aufs3.x-rcN"
         '0001-ARM-atags-add-support-for-Marvell-s-u-boot.patch'
         '0002-ARM-atags-fdt-retrieve-MAC-addresses-from-Marvell-bo.patch'

--- a/core/linux-armv7/PKGBUILD
+++ b/core/linux-armv7/PKGBUILD
@@ -17,7 +17,7 @@ makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'git' 'uboot-tools')
 options=('!strip')
 source=("http://www.kernel.org/pub/linux/kernel/v3.x/${_srcname}.tar.xz"
         "http://www.kernel.org/pub/linux/kernel/v3.x/patch-${pkgver}.xz"
-        "http://rcn-ee.net/deb/sid-armhf/v${pkgver}-${rcnrel}/patch-${pkgver%.0}-${rcnrel}.diff.gz"
+        "http://rcn-ee.com/deb/sid-armhf/v${pkgver}-${rcnrel}/patch-${pkgver%.0}-${rcnrel}.diff.gz"
         "git://git.code.sf.net/p/aufs/aufs3-standalone#branch=aufs${pkgver%.*}"
         #"git://git.code.sf.net/p/aufs/aufs3-standalone#branch=aufs3.x-rcN"
         '0001-ARM-atags-add-support-for-Marvell-s-u-boot.patch'


### PR DESCRIPTION
I have a new dedicated box running rcn-ee.com, to prevent any possible
downtime as i move rcn-ee.net over, switch to the .com now.

btw: https is also available, if you want to eventually enable that too.

Signed-off-by: Robert Nelson <robertcnelson@gmail.com>