### PR TITLE
core/linux-odroid-c1 to 3.10.72-3

### DIFF
--- a/core/linux-odroid-c1/PKGBUILD
+++ b/core/linux-odroid-c1/PKGBUILD
@@ -4,12 +4,12 @@
 buildarch=4
 
 pkgbase=linux-odroid-c1
-_commit=8636cd1de545eddbaba364797dfcf5983fe0756c
+_commit=312f9bed71bcb411538514f917349490f05b1175
 _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="ODROID-C1"
 pkgver=3.10.72
-pkgrel=2
+pkgrel=3
 arch=('armv7h')
 url="https://github.com/hardkernel/linux"
 license=('GPL2')
@@ -21,7 +21,7 @@ source=("https://github.com/hardkernel/linux/archive/${_commit}.tar.gz"
         'amlogic.service'
         '0001-dirty-status-led-active-low-hack.patch'
         '0002-remove-backports-cflags.patch')
-md5sums=('90def96e189b1d5429c5db0f8a6e01a6'
+md5sums=('9ac0faa7ea8cbc157f465ade8ba9b145'
          'SKIP'
          '8194b92d76e26e103be3bf971649f4b0'
          'b8956789318f49cec5b8bb0b41654a9b'


### PR DESCRIPTION
This fixes an issue with the mali driver fbdev support.