### PR TITLE
mesa: enable freedreno gallium driver

### DIFF
--- a/extra/mesa/PKGBUILD
+++ b/extra/mesa/PKGBUILD
@@ -10,7 +10,7 @@
 pkgbase=mesa
 pkgname=('mesa' 'mesa-libgl' 'libva-mesa-driver')
 pkgver=10.5.2
-pkgrel=1
+pkgrel=2
 arch=('i686' 'x86_64')
 makedepends=('python2-mako' 'libxml2' 'libx11' 'glproto' 'libdrm' 'dri2proto' 'dri3proto' 'presentproto'
              'libxshmfence' 'libxxf86vm' 'libxdamage' 'libvdpau' 'libva' 'wayland' 'elfutils' 'llvm'
@@ -33,7 +33,7 @@ build() {
   ./configure --prefix=/usr \
     --sysconfdir=/etc \
     --with-dri-driverdir=/usr/lib/xorg/modules/dri \
-    --with-gallium-drivers=nouveau,swrast \
+    --with-gallium-drivers=freedreno,nouveau,swrast \
     --with-dri-drivers=nouveau,swrast \
     --with-egl-platforms=x11,drm,wayland \
     --enable-llvm-shared-libs \
@@ -79,17 +79,21 @@ package_mesa() {
               'mesa-vdpau: for accelerated video playback'
               'libva-mesa-driver: for accelerated video playback')
   provides=('libglapi' 'osmesa' 'libgbm' 'libgles' 'libegl' 'khrplatform-devel'
-            'ati-dri' 'intel-dri' 'nouveau-dri' 'svga-dri' 'mesa-dri')
+            'ati-dri' 'intel-dri' 'nouveau-dri' 'svga-dri' 'mesa-dri'
+            'freedreno-dri')
   conflicts=('libglapi' 'osmesa' 'libgbm' 'libgles' 'libegl' 'khrplatform-devel'
-             'ati-dri' 'intel-dri' 'nouveau-dri' 'svga-dri' 'mesa-dri')
+             'ati-dri' 'intel-dri' 'nouveau-dri' 'svga-dri' 'mesa-dri'
+             'freedreno-dri')
   replaces=('libglapi' 'osmesa' 'libgbm' 'libgles' 'libegl' 'khrplatform-devel'
-            'ati-dri' 'intel-dri' 'nouveau-dri' 'svga-dri' 'mesa-dri')
+            'ati-dri' 'intel-dri' 'nouveau-dri' 'svga-dri' 'mesa-dri'
+            'freedreno-dri')
 
   install -m755 -d ${pkgdir}/etc
   mv -v ${srcdir}/fakeinstall/etc/drirc ${pkgdir}/etc
   
   install -m755 -d ${pkgdir}/usr/lib/xorg/modules/dri
   # ati-dri, nouveau-dri, intel-dri, svga-dri, swrast
+  # msm-dri, kgsl-dri (freedreno)
   mv -v ${srcdir}/fakeinstall/usr/lib/xorg/modules/dri/* ${pkgdir}/usr/lib/xorg/modules/dri
 
   mv -v ${srcdir}/fakeinstall/usr/lib/bellagio  ${pkgdir}/usr/lib


### PR DESCRIPTION
This enables the freedreno gallium driver [upstream as of mesa 10.2].
It is useful on any [tbd, community supported] snapdragon/adreno alarm platform, and has no impact on current mainstream alarm platforms.
arch is armv7h.
tested on ifc6410.