### PR TITLE
ti-uim: provide backup repo url (as a comment)

### DIFF
--- a/alarm/ti-uim/PKGBUILD
+++ b/alarm/ti-uim/PKGBUILD
@@ -15,6 +15,8 @@ depends=('bluez')
 makedepends=('git')
 install='ti-uim.install'
 
+# As gitorious was aquired by gitlab and they might shutdown gitorious.org
+# I created a backup of the git repo on my github account: git://github.com/asdil12/ti-uim.git
 source=("$pkgname::git://git.gitorious.org/uim/uim.git" "ti-bluetooth-uim" "ti-uim.service")
 md5sums=('SKIP'
          'defc01e5c17bf00a051dcf4ff51ae3ed'


### PR DESCRIPTION
As gitorious was aquired by gitlab and they might shutdown gitorious.org
I created a backup of the git repo on my github account: `git://github.com/asdil12/ti-uim.git`

This PR just adds the above note as a comment to the PKGBUILD file.