### PR TITLE
Add alarm/gpu-viv-g2d: Vivante G2D package

### DIFF
--- a/alarm/gpu-viv-g2d/PKGBUILD
+++ b/alarm/gpu-viv-g2d/PKGBUILD
@@ -2,7 +2,7 @@
 
 buildarch=4
 pkgname=gpu-viv-g2d
-pkgver=3.10.9_1.0.0
+pkgver=3.10.17_1.0.2
 _pkgver=${pkgver//_/-}
 pkgrel=1
 pkgdesc="Freescale proprietary Vivante 2D graphics drivers for i.MX6 Quad SoC"
@@ -15,7 +15,7 @@ url="https://community.freescale.com/docs/DOC-95560"
 arch=('armv7h')
 license=('proprietary')
 source=("http://www.freescale.com/lgfiles/NMG/MAD/YOCTO/${pkgname}-${_pkgver}.bin")
-md5sums=('SKIP')
+md5sums=('82d1418c06ca46e4e51deea2749c14d8')
 
 prepare() {
   cd "${srcdir}"

--- a/alarm/gpu-viv-g2d/PKGBUILD
+++ b/alarm/gpu-viv-g2d/PKGBUILD
@@ -1,0 +1,35 @@
+# Derived from the gpu-viv-mx6q-bin PKGBUILD
+
+buildarch=4
+pkgname=gpu-viv-g2d
+pkgver=3.10.9_1.0.0
+_pkgver=${pkgver//_/-}
+pkgrel=1
+pkgdesc="Freescale proprietary Vivante 2D graphics drivers for i.MX6 Quad SoC"
+
+# filesystem prefix for the include files and license
+_install_prefix=/opt/fsl
+# filesystem prefix for the libraries
+_install_exec_prefix=/opt/fsl
+url="https://community.freescale.com/docs/DOC-95560"
+arch=('armv7h')
+license=('proprietary')
+source=("http://www.freescale.com/lgfiles/NMG/MAD/YOCTO/${pkgname}-${_pkgver}.bin")
+md5sums=('SKIP')
+
+prepare() {
+  cd "${srcdir}"
+  sh ${pkgname}-${_pkgver}.bin --force --auto-accept
+  sed -n '/EOEULA/,/EOEULA/p' ${pkgname}-${_pkgver}.bin | grep -v EOEULA > LICENSE.$pkgname
+}
+
+package() {
+  cd ${srcdir}/"${pkgname}-${_pkgver}"
+  mkdir -p "${pkgdir}${_install_prefix}/include"  "${pkgdir}${_install_exec_prefix}/lib"
+  cp -r usr/include/* "${pkgdir}${_install_prefix}/include"
+  cp -r usr/lib/* "${pkgdir}${_install_prefix}/lib"
+  mkdir -p "${pkgdir}${_install_prefix}/licenses"
+  cp "${srcdir}/LICENSE.$pkgname" "$pkgdir${_install_prefix}/licenses"
+  mkdir -p "${pkgdir}/etc/ld.so.conf.d"
+  echo "${_install_prefix}/lib" > "${pkgdir}/etc/ld.so.conf.d/$pkgname.conf"
+}


### PR DESCRIPTION
The next version of Kodi for imx will have a significant rewrite of the graphics and video playback.  The 2d hardware support will become required in future versions of Kodi.  This pull request adds a package which just contains the vivante g2d library, header and licence.  It is based on the gpu-viv-bin-mx6q PKGBUILD.