### PR TITLE
Hifiberry passthrough support

### DIFF
--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -25,15 +25,17 @@ makedepends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libva'
              'udisks' 'upower' 'git' 'autoconf' 'java-environment')
 source=("https://github.com/xbmc/xbmc/archive/$pkgver-$_codename.tar.gz"
         'kodi.service'
-        'polkit.rules')
+        'polkit.rules'
+	'xbmc-14.2-Helix.patch')
 
 sha256sums=('d9cb8590430a925fb789a5beb4da2695cdcd2d2500dd31126f3b77b31aa267f4'
             '5235068d5800d69f0287087815990e7fe8d6572733d60c8800546d35f608e87f'
-            '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96')
+            '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96'
+            'cf4d8dd279f76acd44a0e146d61b10230b92100bf8a83d381c45e4ec82b9e7cb')
 
 prepare() {
   cd "$srcdir/xbmc-$pkgver-$_codename"
-
+  patch -p1 -i ../xbmc-14.2-Helix.patch
   find -type f -name *.py -exec sed 's|^#!.*python$|#!/usr/bin/python2|' -i "{}" +
   sed 's|^#!.*python$|#!/usr/bin/python2|' -i tools/depends/native/rpl-native/rpl
 	sed 's/python/python2/' -i tools/Linux/kodi.sh.in

--- a/alarm/kodi-rbp/xbmc-14.2-Helix.patch
+++ b/alarm/kodi-rbp/xbmc-14.2-Helix.patch
@@ -1,0 +1,14 @@
+diff -aur xbmc-14.2-Helix/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp xbmc-14.2-Helix.p/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+--- xbmc-14.2-Helix/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp	2015-03-26 18:25:20.000000000 +0000
++++ xbmc-14.2-Helix.p/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp	2015-04-24 18:39:46.803714793 +0000
+@@ -1333,6 +1333,10 @@
+     if (snd_card_get_name(cardNr, &cardName) == 0)
+       info.m_displayName = cardName;
+ 
++     // hack: hifiberry digi doesn't correctly report as iec958 device. Needs fixing in kernel driver
++    if (info.m_displayName == "snd_rpi_hifiberry_digi")
++        info.m_deviceType = AE_DEVTYPE_IEC958;
++
+     if (info.m_deviceType == AE_DEVTYPE_HDMI && info.m_displayName.size() > 5 &&
+         info.m_displayName.substr(info.m_displayName.size()-5) == " HDMI")
+     {


### PR DESCRIPTION
Hi,

i recently bought a Raspberry Pi 2 and a Hifiberry digi+. I wanted to connect the raspberry pis hdmi to my tv and give the sound via spdif/toslink-passthrough to my av-receiver. But I encountered the problem that the receiver only got stereo from the raspberry allthough the played files had a 5.1 audio-track.
I noticed that the "digital passthrough device" in Settings/System/Audio was grayed out and permanently set to "HDMI". After some search i found [this commit](https://github.com/OpenELEC/OpenELEC.tv/blob/f6d2a67e07f3380a6960809c9071ee3bbbf5d672/projects/RPi/patches/kodi/kodi-001-isengard-rpb-backports.patch) in OpenElec that claimed to solve this problem by enforcing the hifiberry digi to be recognized as a digital output device. And indeed after patching and rebuilding, passthrough-output-selection and audio-passthrough finally worked as expected.

As the hifiberry is a popular extension for the raspberry pi and its (for now partly broken) key feature is to extend its audio capabilities i think this hotfix is quite useful.