### PR TITLE
support for Ralink mt7610U

### DIFF
--- a/alarm/dkms-mt7610/PKGBUILD
+++ b/alarm/dkms-mt7610/PKGBUILD
@@ -1,0 +1,53 @@
+# Maintainer: Adrian Fedoreanu <adrian.fedoreanu@gmail.com>
+pkgname=dkms-mt7610
+pkgver=v3.0.0.2
+pkgrel=1
+pkgdesc="Driver for Ralink/MediaTek MT7610 chipset wireless adaptors"
+arch=('any')
+url="http://www.ralinktech.com"
+license=('GPL')
+depends=('dkms' 'linux-headers')
+conflicts=()
+install=${pkgname}.install
+options=(!strip)
+_pkgname="mt7610"
+source=("https://github.com/phedoreanu/mt7610u_wifi_sta_v3002_dpo_20130916/releases/download/v3.0.0.2/mt7610u_wifi_sta_v3002_dpo_20130916.tar.bz2"
+        "https://mt7601-openwrt.googlecode.com/hg/patches/002-rt2870-mt7601Usta-kuid_t-kgid_t.patch"
+        "https://github.com/phedoreanu/mt7610u_wifi_sta_v3002_dpo_20130916/releases/download/v3.0.0.2/0001-compiling-error-macro-__DATE__-might-prevent-reprodu.patch"
+        "dkms.conf")
+
+md5sums=('2b552aff1bbd4effe94185e222eb761e'
+         'a12442972c9518aca6b063426d060de6'
+         '16e64bc827336490cca3086589a0f287'
+         'd470c24251bb61a06f467ec5de7b4340')
+
+prepare() {
+    rm -rf ${srcdir}/$_pkgname-$pkgver
+
+    # Change src dir name
+    mv ${srcdir}/mt7610u_wifi_sta_v3002_dpo_20130916 ${srcdir}/$_pkgname-$pkgver
+    cd "${srcdir}/${_pkgname}-${pkgver}/"
+
+    patch -Np1 -i ${srcdir}/0001-compiling-error-macro-__DATE__-might-prevent-reprodu.patch
+    patch -Np1 -i ${srcdir}/002-rt2870-mt7601Usta-kuid_t-kgid_t.patch
+}
+
+package() {
+    installDir="$pkgdir/usr/src/$_pkgname-$pkgver"
+
+    install -dm755 "$installDir"
+    install -m644 "$srcdir/dkms.conf" "$installDir"
+    install -dm755 "$pkgdir/etc/modprobe.d"
+
+    cd "${srcdir}/${_pkgname}-${pkgver}/"
+
+    for d in `find . -type d`
+    do
+        install -dm755  "$installDir/$d"
+    done
+
+    for f in `find . -type f -o -type l`
+    do
+        install -m644 "${srcdir}/${_pkgname}-${pkgver}/$f" "$installDir/$f"
+    done
+}

--- a/alarm/dkms-mt7610/dkms-mt7610.install
+++ b/alarm/dkms-mt7610/dkms-mt7610.install
@@ -1,0 +1,57 @@
+pre_install(){
+    rm -rf /etc/Wireless/RT2860STA
+}
+
+post_install(){
+    MODULE="mt7610"
+    VERSION="v3.0.0.2"
+    KERNEL_MODULE_NAME="mt7650u_sta"
+    USR_SRC="/usr/src"
+    SRC_DIR=$USR_SRC/$MODULE-$VERSION
+
+    dkms add -m $MODULE -v $VERSION
+    dkms build -m $MODULE -v $VERSION
+    dkms install -m $MODULE -v $VERSION
+
+    # This file is read form a hardcoded location.
+    # Can we put this in a standard location?
+    PARAMSDIR="/etc/Wireless/RT2860STA"
+    mkdir -p $PARAMSDIR
+    cp $SRC_DIR/conf/RT2860STA.dat $PARAMSDIR
+
+    depmod -a $(uname -r)
+
+    modprobe -a $KERNEL_MODULE_NAME 
+}
+
+pre_upgrade(){
+    pre_remove
+}
+
+post_upgrade(){
+    post_install
+}
+
+pre_remove (){
+    _inmemory=$(/usr/bin/lsmod | /usr/bin/grep $KERNEL_MODULE_NAME)
+    if [ ! -z "$_inmemory" ]; then
+        /usr/bin/rmmod $KERNEL_MODULE_NAME &> /dev/null
+    fi
+
+    _line=$(dkms status -m mt7610)
+    if echo "$_line" | grep -E 'added|built|installed'; then
+        version=$(echo "$_line" | sed 's/mt7610,\([^,]*\)[,:].*/\1/;t;d')
+        dkms remove -m mt7610 -v $version --all
+    fi
+
+    rm -rf /etc/Wireless/RT2860STA
+    #rmdir --ignore-fail-on-non-empty /etc/Wireless
+}
+
+post_remove () {
+    /sbin/depmod -a
+}
+
+op=$1
+shift
+$op $*

--- a/alarm/dkms-mt7610/dkms.conf
+++ b/alarm/dkms-mt7610/dkms.conf
@@ -1,0 +1,12 @@
+PACKAGE_NAME="mt7610"
+PACKAGE_VERSION="v3.0.0.2"
+
+AUTOINSTALL="yes"
+
+MAKE[0]="make -j 4"
+
+BUILT_MODULE_NAME[0]="mt7650u_sta"
+
+BUILT_MODULE_LOCATION[0]="os/linux"
+
+DEST_MODULE_LOCATION[0]="/kernel/drivers/net/wireless"


### PR DESCRIPTION
Hey guys,

I've recently bought a Raspberry Pi 2 and attached a `MT7610U`/`AC600` [5Ghz nano USB dongle](http://www.amazon.co.uk/dp/B00VHB0EW0).

This dkms-module supports these chipsets:
* `mt7650u`
* `mt7630u`
* `mt7610u`

It's using the official [Mediatek](http://www.mediatek.com/en/downloads/mt7601u-usb/) driver along with two other patches:
* `kuid_t-kgid_t.patch`
* `__DATE__ & __TIME__macro-warning.patch`

to fix compilation issues.

P.S.: The link is good, check the description of the driver. There's an URL error on Mediatek's website.
[mt7610u](http://www.mediatek.com/en/downloads/mt7601u-usb/) & [mt7601u](http://www.mediatek.com/en/downloads/mt7610u-usb/) are switched.