### PR TITLE
Add extra/intel-tbb for armv7h

### DIFF
--- a/extra/intel-tbb/PKGBUILD
+++ b/extra/intel-tbb/PKGBUILD
@@ -1,0 +1,35 @@
+# $Id$
+# Maintainer: Stéphane Gaudreault <stephane@archlinux.org>
+# Contributor: Thomas Dziedzic < gostrc at gmail >
+# Contributor: Denis Martinez <deuns.martinez AT gmail.com>
+
+# ALARM: Romain Reignier <rom.reignier AT gmail.com>
+# - add armv7h architecture
+# - add specfic CXXFLAGS for armv7h
+
+buildarch=4
+
+pkgname=intel-tbb
+pkgver=4.3_20150209
+pkgrel=1
+pkgdesc='High level abstract threading library'
+arch=('i686' 'x86_64')
+url='http://www.threadingbuildingblocks.org/'
+license=('GPL')
+depends=('gcc-libs')
+source=("http://threadingbuildingblocks.org/sites/default/files/software_releases/source/tbb${pkgver/\./}oss_src.tgz")
+sha1sums=('cb17bee2a9c98a2b98f3ff16208c1c1fae29e6ab')
+
+build() {
+  cd tbb${pkgver/\./}oss
+  CXXFLAGS+=" -DTBB_USE_GCC_BUILTINS=1 -D__TBB_64BIT_ATOMICS=0"
+  make
+}
+
+package() {
+  cd tbb${pkgver/\./}oss
+  install -d "${pkgdir}"/usr/lib
+  install -m755 build/linux_*/*.so* "${pkgdir}"/usr/lib
+  install -d "${pkgdir}"/usr/include
+  cp -a include/tbb "${pkgdir}"/usr/include
+}


### PR DESCRIPTION
Hi,

I have added the intel-tbb package from upstream extra repo to be able to compile opencv with TBB support.

Tested on Raspberry Pi 2 and Odroid C1.

I have only added the armv7h architecture and specials CXXFLAGS for it.

It is my first PKGBUILD so tell me if I did anything wrong.

Thank you.