### PR TITLE
alarm/weston-rpi: Increase release for rebuild

### DIFF
--- a/alarm/weston-rpi/PKGBUILD
+++ b/alarm/weston-rpi/PKGBUILD
@@ -12,7 +12,7 @@ buildarch=4
 
 pkgname=weston-rpi
 pkgver=1.7.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Reference implementation of a Wayland compositor (Raspberry Pi 2)'
 arch=('armv7h')
 url='http://wayland.freedesktop.org'


### PR DESCRIPTION
libinput changed ABI so the old weston doesn't run.
Increase the release to make a new build with the new libinput happen.