### PR TITLE
Update kodi-rbp-git to beta 1 from alpha1

### DIFF
--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -10,7 +10,7 @@ pkgbase=kodi-rbp-git
 pkgname=('kodi-rbp-git' 'kodi-rbp-git-eventclients')
 pkgver=15.20150330
 
-_commit=e826779451fdcb865f6a66cc092e17d6ec5f2d6e
+_commit=d1a2c33b6c477badb8b9664e8897523a78da91b4
 pkgrel=2
 pkgdesc="A software media player and entertainment hub for digital media for the Raspberry Pi"
 arch=('armv6h' 'armv7h')
@@ -27,7 +27,7 @@ source=("kodi-${_commit}.tar.gz::https://github.com/xbmc/xbmc/archive/${_commit}
         'kodi.service'
         'polkit.rules')
 
-sha256sums=('9302b3cc9eb72f4e17e7a44a46d2ae739937fcf1bbe52f0408da8b6c974b8756'
+sha256sums=('d3df8509c4a3401beedeb1cd1b23c364c9064283512b8f85d65eb3838af89c1a'
             '5235068d5800d69f0287087815990e7fe8d6572733d60c8800546d35f608e87f'
             '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96')
 prepare() {


### PR DESCRIPTION
This updates the pkgbuild for the kodi-rbp-git package from the alpha build to the latest beta build.