### PR TITLE
alarm/parallella-firmware: add updated headless 7010/7020 variants

### DIFF
--- a/alarm/parallella-firmware/PKGBUILD
+++ b/alarm/parallella-firmware/PKGBUILD
@@ -1,21 +1,35 @@
 # Parallella Firmware Files
 # Maintainer: Kevin Mihelich <kevin@archlinuxarm.org>
+# Modified: Scott Tincman <sctincman@gmail.com>
 
 buildarch=4
 
-pkgname=parallella-firmware
-pkgver=20140318
+pkgbase=parallella-firmware
+pkgname=('parallella-firmware-headless-7010' 'parallella-firmware-headless-7020')
+pkgver=2015.1
 pkgrel=1
-pkgdesc="Parallella Firmware"
+pkgdesc="Bitstream files for Parallella"
+provides=("parallella-firmware")
+conflicts=("parallella-firmware")
 arch=('armv7h')
 url="https://github.com/parallella/parallella-hw"
 license=('GPL')
-_commit=baff80c6ce317b417209b7d566fcb709b92a028c
-source=("https://github.com/parallella/parallella-hw/raw/${_commit}/parallella_main/firmware/parallella_e16_z7020_hdmi.bit.bin")
-md5sums=('fdf143fe96319182c92c5b1141792242')
+_commit=beb4ca09e9616cc76364735f19e8502c438cd61c
+source=("https://github.com/parallella/parallella-hw/raw/${_commit}/fpga/bitstreams/parallella_e16_headless_gpiose_7010.bit.bin"
+	"https://github.com/parallella/parallella-hw/raw/${_commit}/fpga/bitstreams/parallella_e16_headless_gpiose_7020.bit.bin")
+sha256sums=('507d6241908bcea2150eaf45b2c723b3827d89b7822a19c2bc37d219b24f3c3a'
+            '5e8f72ce0dc809fdf039e00f260a4a37db6a1278d41d502d1432725ab6313bc5')
 
-package() {
-  mkdir -p "${pkgdir}"/boot
+package_parallella-firmware-headless-7010() {
+    pkgdesc="Bitstream files needed for Parallella (Headless, Zynq 7010)"
+    install -m 0755 -d "${pkgdir}"/boot
 
-  cp parallella_e16_z7020_hdmi.bit.bin "${pkgdir}"/boot/parallella.bit.bin
+    install -m 0755 parallella_e16_headless_gpiose_7010.bit.bin "${pkgdir}"/boot/parallella.bit.bin
+}
+
+package_parallella-firmware-headless-7020() {
+    pkgdesc="Bitstream files needed for Parallella (Headless, Zynq 7020)"
+    install -m 0755 -d "${pkgdir}"/boot
+
+    install -m 0755 parallella_e16_headless_gpiose_7020.bit.bin "${pkgdir}"/boot/parallella.bit.bin
 }


### PR DESCRIPTION
This adds two new packages for the [updated] headless 7010/7020 parallella bitstreams.

This is based on the 2015.1 release, which only provides the headless variants. HDMI variants can be added once those bitstreams are hosted somewhere.

This also removes the older alarm/parallella-firmware package as it is out of date.

These packages provide/conflict "parallella-firmware" and the hope is a user can install whichever matches their board by selecting {HDMI,headless}-{7010,7020}