### PR TITLE
Fix checksum for u-boot-sunxi/0001-arch-linux-arm-modifications.patch

### DIFF
--- a/alarm/uboot-sunxi/PKGBUILD
+++ b/alarm/uboot-sunxi/PKGBUILD
@@ -28,7 +28,7 @@ source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
         'boot.txt'
         'mkscr')
 md5sums=('570bdc2c47270c2a98ca60ff6c5c74cd'
-         'ead92cccf290422f5da7b0d99bc212ab'
+         'dbefe6866ee8a9497699d758f5231ec4'
          'b05eae006e4e35176ee3032eba1c4663'
          '021623a04afd29ac3f368977140cfbfd')
 


### PR DESCRIPTION
After upgrade to 2015.04, checksum for patch
00001-arch-linux-arm-modifications.patch become broken.

==> Validating source files with md5sums...
    0001-arch-linux-arm-modifications.patch ... FAILED

This patch restores checksum for current version of the patch