### PR TITLE
dkms-7601: Changed upstream source to https://github.com/porjo/mt7601

### DIFF
--- a/alarm/dkms-mt7601/PKGBUILD
+++ b/alarm/dkms-mt7601/PKGBUILD
@@ -1,41 +1,30 @@
-pkgname=dkms-mt7601
-pkgver=v3.0.0.4
-pkgrel=2
-pkgdesc="Driver for Ralink MT7601 chipset wireless adaptors"
-arch=('any')
-url="http://www.ralinktech.com"
-license=('GPL')
-depends=('dkms' 'linux-headers')
-conflicts=()
-install=${pkgname}.install
-options=(!strip)
-_pkgname="mt7601"
-source=("https://ddaygold.github.io/DPO_MT7601U_LinuxSTA_3.0.0.4_20150203.pfc.tar.bz2"
-        "dkms.conf")
+# Maintainer of AUR mt7601-git package: Cyker Way < cykerway at gmail dot com >
 
-md5sums=('75ba9f00abb288db8cbbdfdd87dee2e4'
-         'f07b4518d0f1190e0c72230137afadb4')
+_gitname=mt7601
+pkgname=dkms-mt7601
+pkgver=2015.06.08
+pkgrel=1
+pkgdesc="Linux driver for MediaTek MT7601U chip with patch for stability and performance"
+arch=('any')
+url="https://github.com/porjo/$_gitname"
+license=('GPL')
+install=dkms-mt7601.install
+depends=('linux>3.19' 'dkms' 'linux-headers>3.19')
+makedepends=('git')
+options=(!strip)
+source=("git+${url}.git" "dkms.conf")
+
+md5sums=('SKIP' 'fee0be459a26a0c9f4a8afcd7ec0a2a6')
+
+pkgver() {
+   cd "$srcdir/$_gitname"
+   git log -1 --format="%cd" --date=short | sed 's|-|.|g'
+}
 
 package() {
-
-    # Change src dir name
-    mv ${srcdir}/DPO_MT7601U_LinuxSTA_3.0.0.4_20130913 ${srcdir}/$_pkgname-$pkgver
-
-    installDir="$pkgdir/usr/src/$_pkgname-$pkgver"
-
-    install -dm755 "$installDir"
-    install -m644 "$srcdir/dkms.conf" "$installDir"
-    install -dm755 "$pkgdir/etc/modprobe.d"
-
-    cd "${srcdir}/${_pkgname}-${pkgver}/"
-
-    for d in `find . -type d`
-    do
-        install -dm755  "$installDir/$d"
-    done
-
-    for f in `find . -type f -o -type l`
-    do
-        install -m644 "${srcdir}/${_pkgname}-${pkgver}/$f" "$installDir/$f"
-    done
+   cp dkms.conf "$srcdir/$_gitname/src"
+   cd "$srcdir/$_gitname/src"
+   mkdir -p "$pkgdir/usr/src/mt7601-$pkgver" 
+   cp -r . "$pkgdir/usr/src/mt7601-$pkgver" 
+   install -Dm644 RT2870STA.dat "$pkgdir/etc/Wireless/RT2870STA/RT2870STA.dat"
 }

--- a/alarm/dkms-mt7601/dkms-mt7601.install
+++ b/alarm/dkms-mt7601/dkms-mt7601.install
@@ -1,55 +1,11 @@
-post_install (){
-
-    MODULE="mt7601"
-    VERSION="v3.0.0.4"
-
-    # TODO: replace /usr/src with a variable.
-    SRCDIR=/usr/src/$MODULE-$VERSION
-
-    dkms add -m $MODULE -v $VERSION
-    dkms build -m $MODULE -v $VERSION
-    dkms install -m $MODULE -v $VERSION
-
-    # This file is read form a hardcoded location.
-    # Can we put this in a standard location?
-    PARAMSDIR="/etc/Wireless/RT2870STA"
-    mkdir -p $PARAMSDIR
-    cp $SRCDIR/RT2870STA.dat $PARAMSDIR
-
-    depmod -a $(uname -r)
-
-    modprobe -a mt7601Usta 
+post_install() {
+   dkms install "mt7601/2015.06.08"
 }
 
-pre_upgrade(){
-    pre_remove
+post_upgrade() {
+   post_install
 }
 
-post_upgrade(){
-    post_install
+pre_remove() {
+   dkms remove "mt7601/2015.06.08" --all
 }
-
-pre_remove (){
-    _inmemory=$(/usr/bin/lsmod | /usr/bin/grep mt7601)
-    if [ ! -z "$_inmemory" ]; then
-        /usr/bin/rmmod mt7601 &> /dev/null
-    fi
-
-
-    _line=$(dkms status -m mt7601)
-    if echo "$_line" | grep -E 'added|built|installed'; then
-        version=$(echo "$_line" | sed 's/mt7601,\([^,]*\)[,:].*/\1/;t;d')
-        dkms remove -m mt7601 -v $version --all
-    fi
-
-    rm -rf /etc/Wireless/RT2870STA
-    rmdir --ignore-fail-on-non-empty /etc/Wireless
-}
-
-post_remove () {
-    /sbin/depmod -a
-}
-
-op=$1
-shift
-$op $*

--- a/alarm/dkms-mt7601/dkms.conf
+++ b/alarm/dkms-mt7601/dkms.conf
@@ -1,7 +1,9 @@
 PACKAGE_NAME="mt7601"
-PACKAGE_VERSION="v3.0.0.4"
+PACKAGE_VERSION="2015.06.08"
 
 AUTOINSTALL="yes"
+
+CLEAN[0]="make clean"
 
 MAKE[0]="make"
 


### PR DESCRIPTION
I had been making fixes to my own copy of the source, but this new
upstream does it better.

I've started with the AUR mt7601-git PKGBUILD, and added dkms.

I also fixed dkms to actually work.