### PR TITLE
Update Weston to 1.8.0.

### DIFF
--- a/alarm/weston-rpi/PKGBUILD
+++ b/alarm/weston-rpi/PKGBUILD
@@ -11,8 +11,8 @@
 buildarch=4
 
 pkgname=weston-rpi
-pkgver=1.7.0
-pkgrel=2
+pkgver=1.8.0
+pkgrel=1
 pkgdesc='Reference implementation of a Wayland compositor (Raspberry Pi 2)'
 arch=('armv7h')
 url='http://wayland.freedesktop.org'
@@ -22,7 +22,7 @@ makedepends=('raspberrypi-firmware')
 provides=('weston')
 conflicts=('weston')
 source=("http://wayland.freedesktop.org/releases/weston-$pkgver.tar.xz")
-sha1sums=('931a7a99a0b8ca03c28cd277525c5176dd7e02ce')
+sha1sums=('d49e06e8dfbef9bcba8589a20b5bfa2dddc4a7bd')
 
 build() {
 	export RPI_BCM_HOST_LIBS="-L/opt/vc/lib"


### PR DESCRIPTION
Weston 1.8.0 was released on [June 2, 2015](http://lists.freedesktop.org/archives/wayland-devel/2015-June/022416.html).