### PR TITLE
core/linux-{peach,veyron}: md5sums should SKIP the nondeterministic kernel tar.gz

### DIFF
--- a/core/linux-peach/PKGBUILD
+++ b/core/linux-peach/PKGBUILD
@@ -26,7 +26,7 @@ source=("https://chromium.googlesource.com/chromiumos/third_party/kernel/+archiv
         'kernel.keyblock'
         'kernel_data_key.vbprivk'
         'cmdline')
-md5sums=('f96ba628b63718cc1ed8a649ce4b36f7'
+md5sums=('SKIP'
          'bda543cb5943eac34e16d12911f3ee99'
          'dc6da2272ffb8ea63f10bc4457cc3f70'
          '5d74feddd86b9c1e6cd23704795cc7d7'

--- a/core/linux-veyron/PKGBUILD
+++ b/core/linux-veyron/PKGBUILD
@@ -29,7 +29,7 @@ source=("https://chromium.googlesource.com/chromiumos/third_party/kernel/+archiv
         'cmdline'
         'brcmfmac4354-sdio.txt'
         '99-veyron-brcm.rules')
-md5sums=('bfe89c90286511d358a7a1d89f776dfc'
+md5sums=('SKIP'
          'bda543cb5943eac34e16d12911f3ee99'
          '5e2d7cd74de07d13052de99411c13a2f'
          '1534c1dbfe5df35a5634072f7b912840'


### PR DESCRIPTION
SKIP was already implemented for `linux-chromebook2`, but after the rewrite to `linux-peach` and after `-veyron` was created the packages lost this property. However the chromeos git servers are still annoyingly nondeterministic, so if `makepkg` is called without `--skipinteg` it will most likely fail.

I do not update the pkgrels as my changes do not affect the resulting packages.