### PR TITLE
alarm/kodi-c1: Bump version to 15.0

### DIFF
--- a/alarm/kodi-c1/PKGBUILD
+++ b/alarm/kodi-c1/PKGBUILD
@@ -7,6 +7,7 @@
 # Contributor: BlackIkeEagle < ike DOT devolder AT gmail DOT com >
 # Contributor: Bartłomiej Piotrowski <bpiotrowski@archlinux.org>
 # Contributor: Maxime Gauduin <alucryd@gmail.com>
+# Contributor: Jan Holthuis <holthuis DOT jan AT googlemail DOT com>
 
 buildarch=4
 
@@ -14,9 +15,9 @@ _prefix=/usr
 
 pkgbase=kodi-c1
 pkgname=('kodi-c1' 'kodi-c1-eventclients')
-_commit=bd5505a1bf162d15b31f67584bfeef3d5b30b1a1
-pkgver=15.alpha2
-pkgrel=2
+_commit=cc29e56c7361fd8f3cad7e6703e77e02a6430d22
+pkgver=15.0
+pkgrel=1
 arch=('armv7h')
 url="http://kodi.tv"
 license=('GPL2')
@@ -29,8 +30,8 @@ makedepends=(
   'python2-pybluez' 'python2-simplejson' 'rtmpdump' 'sdl2' 'sdl_image'
   'shairplay' 'smbclient' 'swig' 'taglib' 'tinyxml' 'unzip' 'upower' 'yajl' 'zip'
 )
-source=("https://github.com/mdrjr/xbmc/archive/${_commit}.tar.gz")
-sha256sums=('f7916ec6da57d6c17fb6b64619b6d820d230c79221c5656089626bfe44762d5c')
+source=("https://github.com/Owersun/xbmc/archive/${_commit}.tar.gz")
+sha256sums=('156d89e8e3949e4c5bf602297efa11b619377e3e90a7a01884c672a518776882')
 
 prepare() {
   cd xbmc-${_commit}


### PR DESCRIPTION
Bump Kodi/XBMC version to 15.0 final.

This changes the upstream git repo from [mdrjr/xbmc](https://github.com/mdrjr/xbmc/tree/k_c1) to [Owersun/xbmc](https://github.com/Owersun/xbmc/tree/Isengard/xbmc), which is
apparently what Hardkernel did too:
http://forum.odroid.com/viewtopic.php?f=111&t=14278#p99812

The version bump should be fine, too:

```
$ vercmp "15.alpha2" "15.0"
-1
```

**IMPORTANT**: This is not tested, since I'm using a custom non-X11 build (and thus don't have xorg installed). Please test this before merging.