### PR TITLE
kodi-imx missing freetype2 dep

### DIFF
--- a/alarm/kodi-imx/PKGBUILD
+++ b/alarm/kodi-imx/PKGBUILD
@@ -20,7 +20,7 @@ pkgbase=kodi
 pkgname=('kodi-imx' 'kodi-imx-eventclients')
 pkgver=15.0
 _codename=Isengard
-pkgrel=4
+pkgrel=5
 arch=('armv7h')
 url="http://kodi.tv"
 license=('GPL2')
@@ -112,7 +112,7 @@ package_kodi-imx() {
     'libjpeg-turbo' 'libmariadbclient' 'libmicrohttpd' 'libpulse' 'libssh'
     'libva' 'libxrandr' 'libxslt' 'lzo' 'sdl2' 'smbclient' 'taglib' 'tinyxml'
     'yajl' 'libfslvpuwrap' 'gpu-viv-bin-mx6q-fb' 'libcec-imx6' 'firmware-imx'
-    'gpu-viv-g2d'
+    'gpu-viv-g2d' 'freetype2'
   )
   optdepends=(
     'afpfs-ng: Apple shares support'


### PR DESCRIPTION
srp 06 15:22:35 cubox.lan systemd[1]: Starting Starts an instance of Kodi...
srp 06 15:22:35 cubox.lan systemd[1]: Started Starts an instance of Kodi.
srp 06 15:22:36 cubox.lan kodi-standalone[333]: /usr/lib/kodi/kodi.bin: error while loading shared libraries: libfreetype.so.6: cannot open shared object file: No such file or directory
srp 06 15:22:36 cubox.lan kodi-standalone[333]: /usr/lib/kodi/kodi.bin: error while loading shared libraries: libfreetype.so.6: cannot open shared object file: No such file or directory
srp 06 15:22:36 cubox.lan kodi-standalone[333]: /usr/lib/kodi/kodi.bin: error while loading shared libraries: libfreetype.so.6: cannot open shared object file: No such file or directory
srp 06 15:22:36 cubox.lan kodi-standalone[333]: /usr/bin/kodi --standalone -l /run/lirc/lircd has exited uncleanly 3 times in the last 1 seconds.