### PR TITLE
Updated U-boot for ODroid to 2015.07

### DIFF
--- a/alarm/uboot-odroid/PKGBUILD
+++ b/alarm/uboot-odroid/PKGBUILD
@@ -5,7 +5,7 @@ buildarch=4
 
 pkgbase=uboot-odroid
 pkgname=('uboot-odroid' 'uboot-odroid-x')
-pkgver=2015.04
+pkgver=2015.07
 pkgrel=1
 arch=('armv7h')
 url='http://www.denx.de/wiki/U-Boot/WebHome'
@@ -22,7 +22,7 @@ source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
         '0001-arch-linux-arm-modifications.patch'
         '0002-odroid-x-support.patch'
         'uEnv.txt')
-md5sums=('570bdc2c47270c2a98ca60ff6c5c74cd'
+md5sums=('3dac9a0b46fed77fc768ad3bd2d68c05'
          '3ab6d3cc2061bc2590d60320254017c6'
          '841502de02bd42f2898e36c89c260b0f'
          'c38faafa02a6a1ae834457f378c82113'


### PR DESCRIPTION
Tested on ODroid U2 with Linux-armv7-rc, works great.
U-boot 2015.04 (the old version) had issues with the USB controller initialisation in Linux for me, and would only work when 'usb start' was commented out in the boot command.