### PR TITLE
added freeswitch from the AUR

### DIFF
--- a/aur/freeswitch/ChangeLog
+++ b/aur/freeswitch/ChangeLog
@@ -1,0 +1,66 @@
+2014-09-30 Brent Saner <bts (at) phreewifi (dot) org>
+	* 20140930-1 :
+	 Comment by chetwisniewski, 2014-09-30 02:19EDT. # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" throws build fail due to -Werror. Sedding out.
+
+2014-08-25 Brent Saner <bts (at) phreewifi (dot) org>
+	* 20140825-1 :
+	cleaned up PKGBUILD in prep for new upload to AUR, setting fixed version.
+
+2014-03-16 Brent Saner <bts (at) phreewifi (dot) org>
+
+	* 20140316-1 :
+	enabled mod_lua thanks to Humberto Diógenes; "it has no external dependencies, is extremely lightweight and it's *the* recommended language for extending FS." https://wiki.freeswitch.org/wiki/Which_scripting_language_should_I_use%3F
+	added -f (--force) to the python binary to ease in testing pkgbuilding. hoping this doesn't bite me in the ass.
+	prepping/finalizing for replacing freeswitch-git as new maintainer in AUR, removing freeswitch-fixed
+
+2014-03-04 Brent Saner <bts (at) phreewifi (dot) org>
+
+	* 20140304-1 :
+	trying to clean up to proper -git pkg to replace outdated freeswitch-git
+
+2014-02-28 Brent Saner <bts (at) phreewifi (dot) org>
+
+	* 20140228-1 :
+	"forked" package to new AUR pkg
+	added systemd support
+	removed rc.d support
+	forced unixodbc support
+	forced python support (won't build without it now)
+	forced install of higher-fidelity sound
+	now fetches from git HEAD instead of specific checkout rev
+	cleaned up PKGBUILD regarding variables
+
+2010-11-15 TJ Vanderpoel <tj@rubyists.com>
+
+	* 20101126-8 :
+	Added /var/spool/freeswitch/storage
+
+2010-10-26 TJ Vanderpoel <tj@rubyists.com>
+
+	* 20101026-7 :
+	Changed handling of configuration so that it
+	  will not be overwritten on upgrades
+
+	* 20101026-5 :
+	Removed libtool files from lib dirs
+	Moved primary --prefix to /var/lib/freeswitch
+	More symlinks to get the mod/*.so files into
+	 /usr/lib/freeswitch where namcap wants them.
+
+	* 20101026-4 :
+	Got rid of empty vars in PKGBUILD
+
+	* 20101026-3 :
+	Moved ChangeLog to changelog= and out of the sources
+	 array.
+	Using $srcdir instead of $startdir for install commands
+
+	* 20101026-2 :
+	Added README and /usr/share/doc/freeswitch files
+
+	* 20101026-1 :
+	added ChangeLog.
+	Tidied up the /etc/rc.d/freeswitch script and added
+	 the 'fgstart' option to start under a supervisor such
+	 as runit or daemontools.
+

--- a/aur/freeswitch/PKGBUILD
+++ b/aur/freeswitch/PKGBUILD
@@ -1,0 +1,264 @@
+# Maintainer: Brent Saner <r00t (at) square-r00t (dot) net>
+# Contributor: TJ Vanderpoel <tj@rubyists.com>
+
+## MAINTAINER NOTE BEGIN
+# Most (like, ~80%) of this is taken verbatim from the freeswitch AUR package currently (as of 02.28.2014) maintained by bougyman.
+# https://aur.archlinux.org/packages/freeswitch/
+# However, it's horribly out of date and doesn't seem to be actively maintained anymore.
+## MAINTAINER NOTE END
+
+
+# This builds the FreeSWITCH open source telephone engine
+# from the freeswitch git.  It enables the following modules
+# not enabled in the standard freeswitch build:
+#  * mod_callcenter
+#  * mod_xml_curl
+# And disables the following standard modules:
+#  * mod_dialplan_asterisk
+#  * mod_say_ru
+#  * mod_spidermonkey
+#  * mod_lua
+# You can modify this and other options in the BUILD CONFIGURATION section below
+
+
+# BUILD CONFIGURATION BEGINS #
+
+# SET THIS TO GET HIGHER QUALITY SOUNDFILES
+# Value can be "hd-", "uhd-", or "cd-" to get 16k, 32k, or 48k sounds.
+# By default we only download the 8k sounds. If you only use g711 or
+# 8k codecs, leave this as-is
+
+_sounds="cd-"
+
+# ADDED MODULES
+# If you don't need/want these modules remove them from _enabled_modules
+# You can add any modules here you wish to add, make sure they're not
+# in _disabled_modules, though
+#
+# xml_int/mod_xml_curl - Remote http dialplan lookups/control
+# xml_int/mod_xml_cdr - Remote http dialplan lookups/control
+# applications/mod_callcenter - Inbound call queueing system
+_enabled_modules=(xml_int/mod_xml_curl
+                  xml_int/mod_xml_cdr
+                  formats/mod_shout
+                  applications/mod_callcenter
+		  languages/mod_lua)
+
+# DISABLED MODULES
+# Remove from _disabled_modules if you want to build these
+#
+# languages/mod_spidermonkey - server-side javascript
+# languages/mod_lua - server-side lua
+# say/mod_say_ru - Russian phrases
+# dialplans/mod_dialplan_asterisk - Legacy dialplan
+_disabled_modules=(languages/mod_spidermonkey
+                   say/mod_say_ru
+                   dialplans/mod_dialplan_asterisk)
+
+# CONCURRENT BOOTSTRAP
+# Uncomment this to enable backgrounded concurrent bootstrap operations.
+# You will suffer a lot of autotools scroll from this, Fair Warning.
+
+#_concurrent="-j"
+
+# BUILD CONFIGURATION ENDS                     #
+#                                              #
+# CHANGE ANYTHING BELOW HERE AT YOUR OWN RISK! #
+#                                              #
+
+
+pkgname='freeswitch'
+pkgver='1.4.21'
+pkgrel='2'
+pkgdesc="An opensource and free (libre, price) telephony system, similar to Asterisk."
+arch=('i686'
+      'x86_64')
+url="http://freeswitch.org/"
+license=('MPL')
+depends=('curl'
+         'xz'
+         'python'
+         'libtheora'
+         'unixodbc'
+         'libvorbis'
+         'speex'
+         'libjpeg-turbo'
+         'postgresql-libs')
+# per https://wiki.freeswitch.org/wiki/FreeSwitch_Dependencies, dependencies are downloaded and built *from upstream*, so thankfully the deps are pretty minimal.
+makedepends=('git'
+             'libjpeg'
+             'curl'
+             'python2'
+             'unixodbc'
+             'sed'
+             'make')
+# per https://aur.archlinux.org/packages/freeswitch-fixed/ 2014-08-13 14:02 comment, enable this when freetdm is packaged.
+# freetdm will require libsangoma, wanpipe, libsng_isdn, libpri. see http://wiki.freeswitch.org/wiki/FreeTDM#Dependencies ; links below
+# http://wiki.sangoma.com/wanpipe-linux-drivers
+# http://downloads.asterisk.org/pub/telephony/libpri/releases
+#optdepends=('freetdm: FreeTDM support for DAHDI etc.') 
+provides=('freeswitch')
+conflicts=('freeswitch-git'
+           'freeswitch-fixed')
+install=freeswitch.install
+backup=('etc/freeswitch/private/passwords.xml'
+        'etc/freeswitch/vars.xml')
+source=("git+https://stash.freeswitch.org/scm/fs/freeswitch.git#tag=v${pkgver}"
+        'freeswitch.conf.d'
+         'README.freeswitch'
+         'run.freeswitch'
+         'run_log.freeswitch'
+         'conf_log.freeswitch'
+         'freeswitch.service')
+changelog='ChangeLog'
+_pkgname="freeswitch"
+
+
+_pathorig=${PATH}
+
+enable_module() {
+  _fs_mod=${1}
+  sed -i -e "s|^#${_fs_mod}|${_fs_mod}|" modules.conf
+}
+
+disable_module() {
+  _fs_mod=${1}
+  sed -i -e "s|^${_fs_mod}|#${_fs_mod}|" modules.conf
+}
+
+build() {
+  mkdir -p /var/tmp/bin
+  ln -sf /usr/bin/python2 /var/tmp/bin/python
+  PATH="/var/tmp/bin:${PATH}"
+  cd ${srcdir}/${_pkgname}
+
+  # BUILD BEGINS
+  msg "Bootstrapping..."
+  ./bootstrap.sh ${_concurrent} > /dev/null
+  msg "Bootstrap Complete"
+
+  # MODULE ENABLE/DISABLE
+  for _mod in ${_enabled_modules[@]};do
+    msg "Enabling ${_mod}"
+    enable_module ${_mod}
+  done
+
+  for _mod in ${_disabled_modules[@]};do
+    msg "Disabling ${_mod}"
+    disable_module ${_mod}
+  done
+
+  msg "Module Configuration Complete, Stop Now with Ctrl-C if the above is not correct"
+  sleep 5
+
+  # SED FIXES
+   sed -i -e '/if\ test\ "\$ac_cv_gcc_supports_w_no_unused_result"\ =\ yes;\ then/,+2d' configure.ac
+   #sed -i -e '/\ _BSD_SOURCE$/d' src/include/switch.h
+
+  # CONFIGURE
+  ./configure --prefix=/var/lib/freeswitch --with-python=/usr/bin/python2 \
+    --bindir=/usr/bin --sbindir=/usr/sbin --localstatedir=/var \
+    --sysconfdir=/etc/freeswitch --datarootdir=/usr/share \
+    --libexecdir=/usr/lib/freeswitch --libdir=/usr/lib/freeswitch \
+    --includedir=/usr/include/freeswitch --enable-core-odbc-support \
+    --with-recordingsdir=/var/spool/freeswitch/recordings \
+    --with-dbdir=/var/spool/freeswitch/db \
+    --with-pkgconfigdir=/usr/lib/pkgconfig \
+    --with-logfiledir=/var/log/freeswitch \
+    --with-modinstdir=/usr/lib/freeswitch/mod \
+    --with-rundir=/run/freeswitch
+
+  # COMPILE
+  make
+
+  PATH=${_pathorig}
+  rm -f /var/tmp/bin/python
+  rmdir /var/tmp/bin
+}
+
+enable_mod_xml() {
+  _fs_mod=$(basename $1)
+
+  if [ "x$(grep ${_fs_mod} ${pkgdir}/etc/freeswitch/autoload_configs/modules.conf.xml)" == "x" ];then
+    msg "Adding missing module ${_fs_mod} to modules.conf.xml"
+    sed -i -e "s|^\(\s*</modules>\)|\t\t<\!-- added by archlinux package -->\n\t\t<load module=\"${_fs_mod}\"/>\n\1|" \
+      "${pkgdir}/etc/freeswitch/autoload_configs/modules.conf.xml"
+  else
+    msg "Enabling module ${_fs_mod} in modules.conf.xml"
+    sed -i -e "s|^\(\s*\)<\!--\s*\(<load module=\"${_fs_mod}\"/>\)\s*-->|\1\2|" \
+      "${pkgdir}/etc/freeswitch/autoload_configs/modules.conf.xml"
+  fi
+
+}
+
+disable_mod_xml() {
+  _fs_mod=$(basename $1)
+  msg "Disabling module ${_fs_mod} in modules.conf.xml"
+  sed -i -e "s|^\(\s*\)\(<load module=\"${_fs_mod}\"/>\)|\1<\!-- \2 -->|" \
+    "${pkgdir}/etc/freeswitch/autoload_configs/modules.conf.xml"
+}
+
+package() {
+  mkdir -p /var/tmp/bin
+  ln -s /usr/bin/python2 /var/tmp/bin/python
+  PATH="/var/tmp/bin:${PATH}"
+  cd "${srcdir}/${_pkgname}"
+  make DESTDIR="${pkgdir}/" install
+  make DESTDIR="${pkgdir}/" ${_sounds}moh-install
+  make DESTDIR="${pkgdir}/" ${_sounds}sounds-install
+  PATH=${_pathorig}
+  rm -rf /var/tmp/bin/python
+  rmdir /var/tmp/bin
+
+  cd ${pkgdir} # MUY IMPORTANT, $PWD is $pkgdir from here on out
+  # Mangle freeswitch's installed dirs into a more compliant structure,
+  # leaving symlinks in their place so freeswitch doesn't notice.
+  ln -s /var/log/freeswitch var/lib/freeswitch/log
+  ln -s /var/spool/freeswitch/db var/lib/freeswitch/db
+  ln -s /var/spool/freeswitch/recordings var/lib/freeswitch/recordings
+  install -D -m 0755 -d var/spool/freeswitch/storage && \
+    ln -s /var/spool/freeswitch/storage var/lib/freeswitch/storage
+  rm usr/lib/freeswitch/mod/*.la 2>/dev/null|| true
+  rm usr/lib/freeswitch/*.la 2>/dev/null || true
+  ln -s /usr/lib/freeswitch/mod var/lib/freeswitch/mod
+  install -D -m 0644 ${srcdir}/freeswitch.service usr/lib/systemd/system/freeswitch.service
+  install -D -m 0644 "${srcdir}/freeswitch.conf.d" etc/conf.d/freeswitch
+  install -D -m 0644 "${srcdir}/README.freeswitch" usr/share/doc/freeswitch/README
+  cp -a "${srcdir}/${_pkgname}/docs" usr/share/doc/freeswitch
+  install -D -m 0755 -d usr/share/doc/freeswitch/support-d
+  cp -a "${srcdir}/${_pkgname}/support-d" usr/share/doc/freeswitch/
+  install -D -m 0755 -d usr/share/doc/freeswitch/scripts
+  cp -a "${srcdir}/${_pkgname}/scripts" usr/share/doc/freeswitch/
+  # Copy upstream confs 
+  install -D -m 0755 -d usr/share/doc/freeswitch/examples/conf.default
+  install -D -m 0755 -d usr/share/doc/freeswitch/examples/conf.archlinux
+  mkdir etc/freeswitch/private
+  echo '<X-PRE-PROCESS cmd="include" data="private/passwords.xml"/>' >> etc/freeswitch/vars.xml
+  echo "<X-PRE-PROCESS cmd=\"set\" data=\"default_password=$(tr -dc 0-9 < /dev/urandom | head -c10)\"/>" > etc/freeswitch/private/passwords.xml
+  chmod 700 etc/freeswitch/private
+  chmod 600 etc/freeswitch/private/passwords.xml
+  ln -s /etc/freeswitch var/lib/freeswitch/conf
+  cp -a etc/freeswitch/* usr/share/doc/freeswitch/examples/conf.default/
+
+  for _mod in ${_enabled_modules[@]};do
+    enable_mod_xml $_mod
+  done
+
+  for _mod in ${_disabled_modules[@]};do
+    disable_mod_xml $_mod
+  done
+
+  mv etc/freeswitch/* usr/share/doc/freeswitch/examples/conf.archlinux/
+  rmdir etc/freeswitch
+  install -D -m0755 -d usr/share/freeswitch/conf
+  install -D -m 0755 "${srcdir}/run.freeswitch" usr/share/freeswitch/run
+  install -D -m 0755 "${srcdir}/run_log.freeswitch" usr/share/freeswitch/log/run
+  install -D -m 0644 "${srcdir}/conf_log.freeswitch" usr/share/freeswitch/log/conf
+} 
+md5sums=('SKIP'
+	 'f674b302edeb1895bbefcaf7bb8510ca'
+         'bfa0c6c70c8173bc78fd228bd42a98ef'
+         '4126dcbe4e1e4f689230a0fe40edcb68'
+         'e9f0bdde366bca6fd29a9202818f3591'
+         'e6411d793501c29ec4afd6d54018de1b'
+         '31cd89e02ec3cc52769489a30ccf6c9b')

--- a/aur/freeswitch/PKGBUILD
+++ b/aur/freeswitch/PKGBUILD
@@ -83,7 +83,9 @@ depends=('curl'
          'libvorbis'
          'speex'
          'libjpeg-turbo'
-         'postgresql-libs')
+         'postgresql-libs'
+         'ldns'
+         'libedit')
 # per https://wiki.freeswitch.org/wiki/FreeSwitch_Dependencies, dependencies are downloaded and built *from upstream*, so thankfully the deps are pretty minimal.
 makedepends=('git'
              'libjpeg'
@@ -91,7 +93,9 @@ makedepends=('git'
              'python2'
              'unixodbc'
              'sed'
-             'make')
+             'make'
+             'ldns'
+             'libedit')
 # per https://aur.archlinux.org/packages/freeswitch-fixed/ 2014-08-13 14:02 comment, enable this when freetdm is packaged.
 # freetdm will require libsangoma, wanpipe, libsng_isdn, libpri. see http://wiki.freeswitch.org/wiki/FreeTDM#Dependencies ; links below
 # http://wiki.sangoma.com/wanpipe-linux-drivers

--- a/aur/freeswitch/README.freeswitch
+++ b/aur/freeswitch/README.freeswitch
@@ -1,0 +1,228 @@
+== USAGE ==
+
+Start the freeswitch daemon with /etc/rc.d/freeswitch.
+Add 'freeswitch' to DAEMONS in /etc/rc.conf and it will start at boot time.
+All configuration is done in /etc/freeswitch/.  
+/usr/bin/fs_cli will bring up the console to freeswitch once it's running.
+
+== SUPPORT ==
+
+See http://wiki.freeswitch.org for up-to-date configuration documentation.
+Official (paid) support available through http://freeswitch.org or 
+consulting at freeswitch dot org.
+#freeswitch on Freenode IRC network.
+
+== DESCRIPTION ==
+
+From http://freeswitch.org:
+
+Welcome To FreeSWITCH
+The World's First Cross-Platform Scalable FREE Multi-Protocol Soft Switch
+
+FreeSWITCH is a scalable open source cross-platform telephony platform designed to route and
+interconnect popular communication protocols using audio, video, text or any other form of media.
+It was created in 2006 to fill the void left by proprietary commercial solutions. FreeSWITCH also
+provides a stable telephony platform on which many telephony applications can be developed using
+a wide range of free tools.
+
+FreeSWITCH was originally designed and implemented by Anthony Minessale with the help of Brian West
+and Michael Jerris. All 3 are former developers of the popular Asterisk open source PBX.  The project
+was initiated to focus on several design goals including modularity, cross-platform support,
+scalability and stability. Today, many more developers and users contribute to the project on a daily
+basis.
+
+We support various communication technologies such as Skype, SIP, H.323 and GoogleTalk making it easy
+to interface with other open source PBX systems such as sipXecs, Call Weaver, Bayonne, YATE or
+Asterisk.
+
+FreeSWITCH supports many advanced SIP features such as presence/BLF/SLA as well as TCP TLS and sRTP.
+It also can be used as a transparent proxy with and without media in the path to act as a SBC
+(session border controller) and proxy T.38 and other end to end protocols. 
+
+FreeSWITCH supports both wide and narrow band codecs making it an ideal solution to bridge legacy
+devices to the future. The voice channels and the conference bridge module all can operate at 8, 12,
+16, 24, 32 or 48 kilohertz and can bridge channels of different rates. The G.729 codec is also
+available under a commercial license.
+
+FreeSWITCH builds natively and runs standalone on several operating systems including Windows,
+Mac OS X, Linux, BSD and Solaris on both 32 and 64 bit platforms.
+
+FreeSWITCH supports FAX, both over audio and T.38, and can gateway between the two.
+
+Our developers are heavily involved in open source and have donated code and other resources to other
+telephony projects including openSER, sipXecs, The Asterisk Open Source PBX and Call Weaver. 
+
+== FEATURES ==
+
+From http://wiki.freeswitch.org/wiki/Specsheet:
+
+Possible Uses
+
+ * Rating & Routing Server
+ * Transcoding B2BUA
+ * IVR & Announcement Server
+ * Conference Server
+ * Voicemail Server
+ * SBC (Session Border Controller)
+ * Basic Topology Hiding Session Border Controller
+ * Zaptel, Sangoma, Rhino, PIKA Hardware Support (Analog and PRI), and Khomp Brazilian telephony hardware manufacturer
+ * Fax server
+ * T.38 gateway, termination, and origination mode
+ * T.30 to T.38 and T.38 to T.30 gateway
+  See also: mod_spandsp
+  And, of course, a PBX
+
+Features
+
+ * Centralized User/Domain Directory (directory.xml)
+ * Nano Second CDR granularity
+ * Call recording (In Stereo caller/callee left/right)
+ * High Performance Multi-Threaded Core engine
+ * Configuration via cURL to your HTTP server (mod_xml_curl).
+ * XML Config files for easy parsing.
+ * Protocol Agnostic
+ * ZRTP support for transparent RTP based key exchange and encryption
+ * Configurable RFC 2833 Payload type
+ * Inband DTMF generation and detection.
+ * Software based Conference (no hardware requirement)
+ * Wideband Conferencing
+ * Media / No Media modes
+ * Proper ENUM/ISN dialing built in
+ * Detailed CDR in XML
+ * Radius CDR
+ * Subscription server
+ * Shared Line Appearances
+ * Bridged Line Appearances
+ * Enterprise/Carrier grade Eventing Engine. (XML Events, Name Value Events, Multicast Events)
+ * Loadable File formats and streaming
+ * Stream to and play from Shoutcast and Icecast
+ * Multi-lingual Speech Phrase Interface
+ * ASR/TTS support (native and via MRCP)
+ * Basic IP/PBX features
+ * Automated Attendant
+ * Custom Ring Back Tones (early_media)
+ * XML-RPC support
+ * Multiple format CDRs supported
+ * SQL Engine provides session persistence
+ * Thread Isolation
+ * Parallel Hunting
+ * Serial Hunting
+ * Mozilla Public License
+ * Support
+ * Paid support available
+ * Free support via IRC & E-mail
+ * Many supported codecs
+ * CELT (32 kHz ahd 48 kHz)
+ * G.722.1 (wideband)
+ * G.722.1C (wideband 32 kHz)
+ * G.722 (wideband)
+ * G.711
+ * G.726 (16k, 24k, 32k, 48k) AAL2 and RFC 3551
+ * G.723.1 (passthrough)
+ * G.729AB (Requires a license unless using passthrough)
+ * AMR (passthrough)
+ * iLBC
+ * Speex (narrow and wideband)
+ * LPC-10
+ * DVI4 (ADPCM) 8 kHz and 16 kHz
+ * SILK
+ * Video Codecs (passthrough):
+ * Theora
+ * H.261
+ * H.263
+ * H.264
+ * MP4
+ * More Codec Information: http://wiki.freeswitch.org/wiki/Codecs
+ * Live Migration of calls from one FreeSWITCH box to another. See 
+   http://wiki.freeswitch.org/wiki/Freeswitch_HA
+
+Applications
+
+ * Voicemail
+ * Multitenancy - Enterprise/Carrier configuration
+ * Time of Day Greetings
+ * Urgent Message Tagging
+ * E-mail Delivery
+ * Playback and Rerecord messages before delivery.
+ * Keys are templates so you can rearrange to fit your needs.
+ * Callback support from inside voicemail.
+ * Podcast of Voicemail (RSS)
+ * Message Waiting Indicator (MWI)
+ * Support for Queues (via mod_fifo or mod_callcenter)
+ * Parking (via mod_fifo)
+ * Conference
+ * Software based Conferencing without any hardware requirements.
+ * Wideband conferences.
+ * Multiple on-demand or scheduled conferences with entry/exit announcements
+ * Play files into the conference or a single member.
+ * Relationships
+ * TTS integration
+ * Transfers
+ * Outbound Calling
+ * Configurable Key Lay
+ * Volume, Gain and Energy level per call.
+ * Bridge to Conference transition
+ * Multi Party outbound dialing.
+ * Inbound Call Center Queues
+ * RSS Reader
+ * Fax endpoint, gateway and passthrough mode.
+ * T.30 (G.711) Audio Fax (via mod_spandsp) formerly known as mod_fax.
+ * T.38 faxing (gateway, endpoint and passthrough)
+
+Protocols
+
+ * SIP
+ * UDP, TCP, SCTP and TLS transports for full SIP compliance.
+ * IPv6 Support
+ * SIP Session timers
+ * RTP Timers
+ * RFC 3263 (SRV and NAPTR)
+ * SRTP via SDES (Works with Polycom, Snom, Linksys and Grandstream)
+ * Blind SIP Registration
+ * STUN Support
+ * Jitter buffer
+ * NAT Support
+ * Distributed SIP registrations
+ * Late Codec Negotiation
+ * Multiple SIP registrations per user account.
+ * Multitenancy - Multiple SIP UAs
+ * SIP Reinvites.
+ * Can act as an SBC (Session Border Controller)
+ * Manage Presence
+ * SIP/SIMPLE (can gateway to other chat protocols)
+ * SIP Multicast Paging support for Linksys and Snom
+ * Intercom/AutoAnswer support.
+ * Call features like Call Hold (Re-INVITE), Blind Transfer (REFER), Call Forward (302), etc.
+ * Jingle
+ * Interop with Google Talk, Google Voice, and Telepathy
+ * H.323 with mod_opal (opalvoip.org)
+ * mod_h323 - H.323 Endpoint module based on the h323plus library.
+ * mod_skinny - Skinny Call Control Protocol (SCCP)
+
+Languages
+
+ * JavaScript (Using the SpiderMonkey JavaScript engine.)
+ * ODBC Support from inside your JavaScript
+ * Extendable modules for JavaScript
+ * Tone Generation
+ * Python
+ * Perl
+ * Lua
+
+Cross Platform
+
+ * Builds native on Windows in MSVC
+ * Builds on Mac OS X, Linux, Solaris and *BSD.
+ * Minimum/Recommended System Requirements
+
+ * 32-bit OS (64-bit recommended)
+ * 512MB RAM (1GB recommended)
+ * 50MB of Disk Space
+ * System requirements depend on your deployment needs. We recommend you plan for 50% duty cycle.
+
+Performance
+
+ * Tested under load for over 100 hours
+ * 10,000,000+ calls
+ * At rates exceeding 50 CPS
+ * Performance will vary depending on application. You will need to test for your particular situation.

--- a/aur/freeswitch/conf_log.freeswitch
+++ b/aur/freeswitch/conf_log.freeswitch
@@ -1,0 +1,1 @@
+USERGROUP=freeswitch:daemon

--- a/aur/freeswitch/freeswitch.conf.d
+++ b/aur/freeswitch/freeswitch.conf.d
@@ -1,0 +1,3 @@
+# options to start freeswitch with
+# We default to -nonat, if you need nat, remove it
+FREESWITCH_OPTS="-nonat"

--- a/aur/freeswitch/freeswitch.install
+++ b/aur/freeswitch/freeswitch.install
@@ -1,0 +1,48 @@
+pre_install() {
+  getent group freeswitch > /dev/null
+  if [ $? -ne 0 ];then
+    echo 'Adding group freeswitch'
+    groupadd  -r freeswitch
+  fi
+  id freeswitch > /dev/null
+  if [ $? -ne 0 ];then
+    echo 'Adding user freeswitch'
+    useradd -d /usr/share/freeswitch -r -g freeswitch freeswitch
+  fi
+}
+
+post_install() {
+  echo 'FreeSWITCH is installed!'
+  echo '<<<WARNING>>> You MUST change the default_password in /etc/freeswitch/private/passwords.xml
+        Failure to do so will leave your default extension 1000 vulnerable'
+  echo 'The FreeSWITCH default configuration is available in
+        /usr/share/doc/freeswitch/examples/conf.default, with Arch-specific modifications
+        version in /usr/share/doc/freeswitch/examples/conf.archlinux
+	(these may be the same).'
+  post_upgrade
+}
+
+post_upgrade() {
+  if [ -d /etc/freeswitch -a ! -L /etc/freeswitch ];then
+    echo "Moving your old configs (/etc/freeswitch) to /usr/share/freeswitch/conf/local"
+    mv /etc/freeswitch /usr/share/freeswitch/conf/local
+    ln -s /usr/share/freeswitch/conf/local /etc/freeswitch
+  fi
+  [ -d /usr/share/freeswitch/conf/pbx ] || cp -a /usr/share/doc/freeswitch/examples/conf.archlinux/ /usr/share/freeswitch/conf/pbx
+  chown -R freeswitch:freeswitch /usr/share/freeswitch/conf/pbx
+  if [ ! -L /etc/freeswitch ];then
+    echo "Linking /usr/share/freeswitch/conf/pbx to /etc/freeswitch"
+    ln -s /usr/share/freeswitch/conf/pbx /etc/freeswitch
+  fi
+  chown -R freeswitch:freeswitch /var/{run,spool,log}/freeswitch
+  chown -R freeswitch:freeswitch /usr/share/freeswitch
+  echo "The running configuration directory is symlinked as /etc/freeswitch"
+}
+
+post_remove() {
+  rm  -rf /etc/freeswitch
+  echo 'Not removing /usr/share/freeswitch/conf/ config directories!!  If you do not want to keep them, rm -rf them away'
+  userdel -rf freeswitch
+  getent group freeswitch &> /dev/null && groupdel freeswitch
+  true
+}

--- a/aur/freeswitch/freeswitch.service
+++ b/aur/freeswitch/freeswitch.service
@@ -1,0 +1,25 @@
+; Original Author: Travis Cross <tc@traviscross.com>
+; Adapted for AUR/Arch by Brent Saner <brent (dot) saner (at) gmail (dot) com>
+; fetched from https://raw.github.com/FreeSWITCH/FreeSWITCH/8099af65647d01dc5e2d65a50626a4299fc7d70c/debian/freeswitch-systemd.freeswitch.service
+
+[Unit]
+Description=freeswitch
+After=syslog.target network.target local-fs.target
+
+[Service]
+; service
+Type=forking
+PIDFile=/run/freeswitch/freeswitch.pid
+PermissionsStartOnly=true
+ExecStartPre=/bin/mkdir -p /run/freeswitch
+ExecStartPre=/bin/chown freeswitch:freeswitch /run/freeswitch
+ExecStart=/usr/bin/freeswitch -nc -nonat
+TimeoutSec=45s
+Restart=always
+; exec
+User=freeswitch
+Group=freeswitch
+UMask=0007
+
+[Install]
+WantedBy=multi-user.target

--- a/aur/freeswitch/run.freeswitch
+++ b/aur/freeswitch/run.freeswitch
@@ -1,0 +1,19 @@
+#!/bin/sh -e
+. /etc/conf.d/freeswitch
+[ -d /run/freeswitch ] || mkdir /run/freeswitch
+chown freeswitch /run/freeswitch
+ulimit -c unlimited # The maximum size of core files created.
+ulimit -d unlimited # The maximum size of a process's data segment.
+ulimit -f unlimited # The maximum size of files created by the shell (default option)
+ulimit -i unlimited # The maximum number of pending signals
+ulimit -n 999999    # The maximum number of open file descriptors.
+ulimit -q unlimited # The maximum POSIX message queue size
+ulimit -u unlimited # The maximum number of processes available to a single user.
+ulimit -v unlimited # The maximum amount of virtual memory available to the process.
+ulimit -x unlimited # ???
+ulimit -l unlimited # The maximum size that may be locked into memory.
+ulimit -s 240      # The maximum stack size
+ulimit -a           # All current limits are reported.
+echo "Starting Freeswitch with ${FREESWITCH_OPTS}"
+exec chpst -u freeswitch:daemon /usr/bin/freeswitch -u freeswitch -g daemon -nf -nc ${FREESWITCH_OPTS} 2>&1
+

--- a/aur/freeswitch/run_log.freeswitch
+++ b/aur/freeswitch/run_log.freeswitch
@@ -1,0 +1,29 @@
+#!/bin/sh -e
+if [ $0 != "./run" ];then
+  echo "This script meant to be linked as ./run in a service/log directory only!"
+  exit 1
+fi
+logdir=$(basename $(pwd))
+if [ "$logdir" != "log" ];then
+  echo "This script meant to be run from a service/log directory only!"
+  exit 1
+fi
+if [ -w /var/log ];then
+  if [ -f ./conf ];then
+    source ./conf
+  fi
+  user_group=${USERGROUP:-daemon:adm}
+  service=$(basename $(dirname $(pwd)))
+  [ -d "/var/log/$service" ] || mkdir -p "/var/log/$service"
+  [ -L ./main ] || [ -d ./main ] || ln -s "/var/log/$service" ./main
+  [ -L ./current ] || ln -s main/current
+  usergroup=$(stat -c "%U:%G" "/var/log/$service")
+  if [ "$usergroup" != "$user_group" ];then
+    chown -R $user_group "/var/log/$service"
+  fi
+  echo Logging as $user_group to /var/log/$service
+  exec chpst -u $user_group svlogd -t ./main
+else
+  echo Logging in $PWD
+  exec svlogd -t ./
+fi


### PR DESCRIPTION
Dear ALARM crew,

FreeSwitch is a next-gen cleaned-up Asterisk.

Personally, I think FreeSWITCH is to Asterisk as nginx is to apache.

I can see it go far on small, cheap, low-power devices such as the OlinuXino A20 I'm about to deploy it on. Unfortunately, it also takes hours to build on said devices. IMHO, if Asterisk is here, FreeSWITCH should here, as well :-) That would make it a snap to use on those cute little boards, and a hell of a platform for smaller organisations.

I think sanerb is doing a good job maintaining this on the AUR, so it should not be any extra work to keep this here.

Tested only on armv7h, but did not change *anything* as compared to the AUR, by analogy with other PKGBUILDs e.g. Asterisk.add buildarch. It just builds with makepkg -sriA

Prethanks,
-f