### PR TITLE
Disabled kodi showing dmesg messages

### DIFF
--- a/alarm/kodi-imx/PKGBUILD
+++ b/alarm/kodi-imx/PKGBUILD
@@ -20,7 +20,7 @@ pkgbase=kodi
 pkgname=('kodi-imx' 'kodi-imx-eventclients')
 pkgver=15.1
 _codename=Isengard
-pkgrel=1
+pkgrel=2
 arch=('armv7h')
 url="http://kodi.tv"
 license=('GPL2')
@@ -46,7 +46,7 @@ source=(
 sha256sums=('72b2610d8fbff807128d74429f25bf6716ba880c27c2c5d9fad012ec7fc70705'
             '6d9822d97b9e1268c04078f6c9b6316eb013f95f96f90034b51fa7473b9752ff'
             '0e16e4d2ec0c0e1810fe1ad6a7c4dee99d6fc0f49502f0e836210f5dd537d92d'
-            '39bed05cf8fa63b871232e1f53146ce5aa755c99dbe161a3e88040bb45894fd9'
+            'd88c0220aea777883378c2f8897186b6c068dadd5a4f2696afdabda63641b65d'
             '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96'
             'db6372248015fa4e663bf789e4f7121b5a9ade323f361994bbd6f135ce169123')
 prepare() {

--- a/alarm/kodi-imx/kodi.service
+++ b/alarm/kodi-imx/kodi.service
@@ -6,9 +6,12 @@ After = remote-fs.target
 User = kodi
 Group = kodi
 Type = simple
+PermissionsStartOnly = true
+ExecStartPre = /bin/sh -c "dmesg -D"
 ExecStartPre = /bin/sh -c "echo 0 > /sys/class/graphics/fbcon/cursor_blink"
 ExecStart = /usr/bin/kodi-standalone -l /run/lirc/lircd
 ExecStopPost = /bin/sh -c "echo 1 > /sys/class/graphics/fbcon/cursor_blink"
+ExexStopPost = /bin/sh -c "dmesg -E"
 Restart = on-failure
 
 [Install]


### PR DESCRIPTION
When messages are added to dmesg they're shown in kodi as overlay. In order to disable this behaviour the service script disable dmesg console logging before start of kodi and reenable console logging after. Since this operation needs root rights the PermissionsStartOnly was set to true.