### PR TITLE
Adds opencascade that builds for armv7h

### DIFF
--- a/community/freecad/PKGBUILD
+++ b/community/freecad/PKGBUILD
@@ -1,0 +1,77 @@
+# Maintainer: Florian Pritz <bluewind@xinu.at>
+# Contributor: Jonas Heinrich <onny@project-insanity.org>
+# Contributor: Jonas Heinrich <onny@project-insanity.org>
+# Contributor: Jordi De Groof <jordi (dot) degroof (at) gmail (dot) com>
+# Contributor: mickele
+# Contributor: manwithgrenade
+# Contributor: bricem13
+# Contributor: gborzi
+
+# ALARM: Fredrik Söderström <tirithen@gmail.com>
+#  - Adds armv7h to arch array
+
+pkgname=freecad
+pkgver=0.15.4671
+pkgrel=3
+pkgdesc='A general purpose 3D CAD modeler'
+arch=('i686' 'x86_64' 'armv7h')
+url='http://www.freecadweb.org/'
+license=('LGPL')
+depends=('boost-libs' 'curl' 'opencascade>=6.6.0' 'python2-pivy' 'xerces-c'
+         'libspnav' 'shared-mime-info' 'hicolor-icon-theme'
+         'python2-matplotlib' 'python2-shiboken' 'python2-pyside-tools' 'pyside-tools-common' 'qtwebkit')
+makedepends=('boost' 'eigen' 'gcc-fortran' 'swig' 'xerces-c' 'desktop-file-utils' 'cmake' 'coin>=3.1.3-9')
+# TODO add reasons
+optdepends=('python2-matplotlib' 'pycollada-git' 'python2-pyqt4')
+install=freecad.install
+source=("http://downloads.sourceforge.net/sourceforge/free-cad/freecad_${pkgver}.tar.gz"
+	"${pkgname}.desktop"
+	"${pkgname}.xml")
+md5sums=('7afa95d3e8cd845bef83202e76db7f24'
+         '382cd66757dae635b53105d207679fce'
+         'c2f4154c8e4678825411de8e7fa54c6b')
+
+prepare() {
+  sed -i \
+    -e "46i\\\tModDir = '/usr/share/freecad/Mod'" \
+    -e "50i\\\tLibDir = '/usr/lib/freecad'" \
+    "${srcdir}/freecad-${pkgver}/src/App/FreeCADInit.py"
+
+  sed -i \
+	  -e 's|\bpyside-uic\b|python2-pyside-uic|' \
+	  $srcdir/freecad-$pkgver/cMake/FindPySideTools.cmake
+}
+
+build() {
+  cd "${srcdir}/freecad-${pkgver}/"
+  cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX:PATH="/usr" \
+    -DCMAKE_INSTALL_DOCDIR:PATH="share/freecad/doc" \
+    -DCMAKE_INSTALL_DATADIR:PATH="share/freecad" \
+    -DCMAKE_INSTALL_LIBDIR:PATH="lib/freecad" \
+    -DOCC_INCLUDE_DIR:PATH=/opt/opencascade/inc/ \
+    -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python2 \
+    -DFREECAD_USE_EXTERNAL_PIVY:BOOL=ON
+  make
+}
+
+package() {
+  cd "${srcdir}/freecad-${pkgver}"
+  make DESTDIR="${pkgdir}" install
+
+  # Symlink to /usr/bin
+  ln -sf "FreeCAD" "${pkgdir}/usr/bin/freecad"
+  ln -sf "FreeCADCmd" "${pkgdir}/usr/bin/freecadcmd"
+
+  cp -ra "${pkgdir}/usr/Mod" "${pkgdir}/usr/share/freecad/"
+  rm -r "${pkgdir}/usr/Mod"
+
+  # Install pixmaps and desktop shortcut
+  desktop-file-install \
+    --dir="${pkgdir}/usr/share/applications" \
+    "${srcdir}/${pkgname}.desktop"
+
+  # Mime info
+  install -D -m644 "${srcdir}/${pkgname}.xml" "${pkgdir}/usr/share/mime/packages/${pkgname}.xml"
+}

--- a/community/freecad/freecad.desktop
+++ b/community/freecad/freecad.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Version=1.0
+Encoding=UTF-8
+Name=FreeCAD
+Comment=A general purpose 3D CAD modeler
+GenericName=CAD Application
+Exec=/usr/bin/freecad %F
+Path=/usr/share/freecad
+Terminal=false
+Type=Application
+Icon=/usr/share/freecad/freecad.xpm
+Categories=Application;Science;Math;Education;
+StartupNotify=true
+MimeType=application/x-extension-fcstd;

--- a/community/freecad/freecad.install
+++ b/community/freecad/freecad.install
@@ -1,0 +1,15 @@
+post_install() {
+    xdg-icon-resource forceupdate --theme hicolor &> /dev/null
+    update-desktop-database -q
+    update-mime-database usr/share/mime
+}
+
+post_upgrade() {
+    post_install
+}
+
+post_remove() {
+    xdg-icon-resource forceupdate --theme hicolor &> /dev/null
+    update-desktop-database -q
+    update-mime-database usr/share/mime
+}

--- a/community/freecad/freecad.xml
+++ b/community/freecad/freecad.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+	<mime-type type="application/x-extension-fcstd">
+		<sub-class-of type="application/zip"/>
+		<comment>FreeCAD document</comment>
+		<glob pattern="*.fcstd"/>
+	</mime-type>
+</mime-info>

--- a/community/opencascade/PKGBUILD
+++ b/community/opencascade/PKGBUILD
@@ -1,0 +1,71 @@
+# Maintainer: Florian Pritz <bluewind@xinu.at>
+# Contributor: Giuseppe Borzi <gborzi@ieee.org>
+# Contributor: Brice M<E9>alier <mealier_brice@yahoo.fr>
+# Contributor: Michele Mocciola <mickele>
+
+# ALARM: Fredrik Söderström <tirithen@gmail.com>
+#  - Adds armv7h arch
+#  - Adds subdir-objects to all Makefile.am
+#  - Removes all mmmx, msse, msse2, mfpmath=sse options from configure.ac
+#  - Patch src/Standard/Standard.cxx to use malloc.h over mm_malloc.h (like Android config) since it's not avaliable on the system
+#  - Adds optimization -O2 to CPPFLAGS
+
+pkgname=opencascade
+pkgver=6.9.0
+pkgrel=1
+pkgdesc="Open CASCADE Technology, 3D modeling & numerical simulation"
+arch=('i686' 'x86_64' 'armv7h')
+url="http://www.opencascade.org"
+license=('custom')
+depends=('tk' 'mesa' 'java-runtime' 'libxmu' 'ftgl' 'vtk')
+makedepends=('java-environment')
+source=("http://files.opencascade.com/OCCT/OCC_${pkgver}_release/$pkgname-${pkgver}.tgz" "env.sh" "opencascade.sh" "opencascade.conf")
+md5sums=('ba87fe9f5ca47e3dfd62aad7223f0e7f'
+         'a96f28ee7f4273ae1771ee033a2a3af3'
+         'd9368b8d348ced3ec4462012977552d2'
+         '2924ecf57c95d25888f51071fdc72ad0')
+
+build() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  # Get rid of "but option 'subdir-objects' is disabled" warnings
+  find . -name "Makefile.am" -print0 | xargs -0 sed -i '1 i\AUTOMAKE_OPTIONS = subdir-objects'
+
+  # fix for automake 1.13
+  sed -i -e 's/AM_CONFIG_HEADER/AC_CONFIG_HEADERS/' configure.ac
+
+  # Remove mmmx msse msse2 mfpmath=sse from config files as not supported by arm
+  sed -i -e 's/ -\(mmmx\|msse2\|msse\|mfpmath=sse\)//g' configure.ac
+
+  # mm_malloc.h are missing on this system, define a constant in src/Standard/Standard.cxx to have it select malloc.h (same as Android)
+  STANDARD_FILENAME=src/Standard/Standard.cxx
+  sed -i '1 i\#ifndef __ARCH_ARMV7H__' $STANDARD_FILENAME
+  sed -i '2 i\#define __ARCH_ARMV7H__ 1' $STANDARD_FILENAME
+  sed -i '3 i\#endif' $STANDARD_FILENAME
+  sed -i -e 's/defined(__ANDROID__)/defined(__ANDROID__) || defined(__ARCH_ARMV7H__)/g' $STANDARD_FILENAME
+
+  # https://bbs.archlinux.org/viewtopic.php?id=182812
+  CPPFLAGS="$CPPFLAGS -O2"
+
+  ./build_configure
+  ./configure --disable-debug --enable-production \
+    --with-java-include=/usr/lib/jvm/default/include \
+    --with-vtk-library=/usr/lib/ --with-vtk-include=/usr/include/vtk-6.1/ \
+    --prefix=/opt/$pkgname
+  make
+}
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  # no DESTDIR support so use prefix. This has to suffix match the prefix in ./configure
+  make prefix="$pkgdir/opt/$pkgname" install
+  cp -r src/UnitsAPI/ "${pkgdir}/opt/$pkgname/src"
+  install -D -m644 "${srcdir}/opencascade.conf" "${pkgdir}/etc/ld.so.conf.d/opencascade.conf"
+  install -D -m 755 "${srcdir}/opencascade.sh" "${pkgdir}/etc/profile.d/opencascade.sh"
+  install -m 755 "${srcdir}/env.sh" "${pkgdir}/opt/$pkgname"
+  install -dm755 "$pkgdir/usr/share/licenses/$pkgname/"
+  install -m644 LICENSE_LGPL_21.txt OCCT_LGPL_EXCEPTION.txt "$pkgdir/usr/share/licenses/$pkgname"
+}
+
+# vim:set ts=2 sw=2 et:

--- a/community/opencascade/env.sh
+++ b/community/opencascade/env.sh
@@ -1,0 +1,22 @@
+#!/bin/sh -f
+
+export PATH="$PATH:$CASROOT/bin"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$CASROOT/lib"
+
+export CSF_LANGUAGE=us
+export MMGT_CLEAR=1
+export CSF_EXCEPTION_PROMPT=1
+
+export CSF_SHMessage="$CASROOT"/src/SHMessage
+export CSF_MDTVTexturesDirectory="$CASROOT"/src/Textures
+export CSF_XSMessage="$CASROOT"/src/XSMessage
+export CSF_StandardDefaults="$CASROOT"/src/StdResource
+export CSF_PluginDefaults="$CASROOT"/src/StdResource
+export CSF_XCAFDefaults="$CASROOT"/src/StdResource
+export CSF_StandardLiteDefaults="$CASROOT"/src/StdResource
+export CSF_UnitsLexicon="$CASROOT"/src/UnitsAPI/Lexi_Expr.dat
+export CSF_UnitsDefinition="$CASROOT"/src/UnitsAPI/Units.dat
+export CSF_IGESDefaults="$CASROOT"/src/XSTEPResource
+export CSF_STEPDefaults="$CASROOT"/src/XSTEPResource
+export CSF_XmlOcafResource="$CASROOT"/src/XmlOcafResource
+export CSF_GraphicShr="$CASROOT"/lib/libTKOpenGl.so

--- a/community/opencascade/opencascade.conf
+++ b/community/opencascade/opencascade.conf
@@ -1,0 +1,1 @@
+/opt/opencascade/lib

--- a/community/opencascade/opencascade.sh
+++ b/community/opencascade/opencascade.sh
@@ -1,0 +1,2 @@
+export CASROOT=/opt/opencascade
+source /opt/opencascade/env.sh


### PR DESCRIPTION
I have modified and added a PKGBUILD (and unmodified env.sh, opencascade.conf, opencascade.sh) for opencascade (required by freecad). After some trial and error it does build and install on my armv7h (ODROID-XU4), added short description of the patching I've done in the top of PKGBUILD.

I have also added and modified freecad by just adding armv7h to the arch array inside PKGBUILD and tested compile, install and start the freecad program. It seem to be running fine. :)

This is the first time I do this so it might be a good idea to look through this, I have only done the simplest things to get it building and installing.

Would be great to be able to provide opencascade (takes several hours to build on the ODROID-XU4) and freecad as prebuilt packages.

I only have this arm so I could not try any of the other arm architectures.