### PR TITLE
[pulseaudio] Disable pthread priority inheritance

### DIFF
--- a/extra/pulseaudio/PKGBUILD
+++ b/extra/pulseaudio/PKGBUILD
@@ -4,15 +4,18 @@
 # Contributor: Corrado Primier <bardo@aur.archlinux.org>
 # Contributor: William Rea <sillywilly@gmail.com>
 
-# ALARM: Kevin Mihelich <kevin@archlinuxarm.org>
+# ALARM:
+# Kevin Mihelich <kevin@archlinuxarm.org>
 #  - added --disable-neon-opt to configure
 #  - removed xen pieces
+# Maximilian Güntner <maximilian.guentner@gmail.com>
+#  - added disable_pthread_inherit.patch
 
 pkgbase=pulseaudio
 pkgname=(pulseaudio libpulse pulseaudio-{gconf,zeroconf,lirc,jack,bluetooth,equalizer})
 pkgdesc="A featureful, general-purpose sound server"
 pkgver=7.1
-pkgrel=1
+pkgrel=2
 arch=(i686 x86_64)
 url="http://www.freedesktop.org/wiki/Software/PulseAudio"
 license=(LGPL)
@@ -22,12 +25,15 @@ makedepends=(libasyncns libcap attr libxtst libsm libsndfile libtool rtkit libso
              check)
 options=(!emptydirs)
 source=(http://freedesktop.org/software/$pkgbase/releases/$pkgbase-$pkgver.tar.xz
-        padsp-lib32.patch)
+        padsp-lib32.patch
+        disable_pthread_inherit.patch)
 sha256sums=('e667514a28328f92aceea754a224a0150dddfe7e9a71b4c6d31489220153b9d9'
-            '7832fc59df76538ff10aedd297c03cb7ff117235da8bfad26082994bb5b84332')
+            '7832fc59df76538ff10aedd297c03cb7ff117235da8bfad26082994bb5b84332'
+            'c1a21bb189ca30817666fe975a4a5038cbd60c8f8f701f3a3d5c2a0afee2c89a')
 
 prepare() {
   cd $pkgbase-$pkgver
+  patch -p1 < ../disable_pthread_inherit.patch
 }
 
 build() {

--- a/extra/pulseaudio/disable_pthread_inherit.patch
+++ b/extra/pulseaudio/disable_pthread_inherit.patch
@@ -1,0 +1,44 @@
+--- a/configure 2015-09-26 17:47:07.442036579 +0200
++++ b/configure 2015-09-26 17:46:52.632072622 +0200
+@@ -21527,40 +21527,7 @@
+             PTHREAD_CFLAGS="$flag $PTHREAD_CFLAGS"
+         fi
+ 
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for PTHREAD_PRIO_INHERIT" >&5
+-$as_echo_n "checking for PTHREAD_PRIO_INHERIT... " >&6; }
+-if ${ax_cv_PTHREAD_PRIO_INHERIT+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-
+-                cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-                    #include <pthread.h>
+-int
+-main ()
+-{
+-int i = PTHREAD_PRIO_INHERIT;
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-if ac_fn_c_try_link "$LINENO"; then :
+-  ax_cv_PTHREAD_PRIO_INHERIT=yes
+-else
+-  ax_cv_PTHREAD_PRIO_INHERIT=no
+-fi
+-rm -f core conftest.err conftest.$ac_objext \
+-    conftest$ac_exeext conftest.$ac_ext
+-
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_PTHREAD_PRIO_INHERIT" >&5
+-$as_echo "$ax_cv_PTHREAD_PRIO_INHERIT" >&6; }
+-        if test "x$ax_cv_PTHREAD_PRIO_INHERIT" = "xyes"; then :
+-
+-$as_echo "#define HAVE_PTHREAD_PRIO_INHERIT 1" >>confdefs.h
+-
+-fi
++$as_echo "#undef HAVE_PTHREAD_PRIO_INHERIT" >>confdefs.h
+ 
+         LIBS="$save_LIBS"
+         CFLAGS="$save_CFLAGS"


### PR DESCRIPTION
On multicore platforms (e.g. rpi 2 / cubieboard 2),
some clients like mopidy with gstreamer cause an
assertion error like this one:

> Assertion 'pthread_mutex_unlock(&m->mutex) == 0' failed at
> pulsecore/mutex-posix.c:108, function pa_mutex_unlock(). Aborting.

Disabling the priority inheritance support solves the
problem.

However, the root cause for the problem should be
investigated as more applications could be affected -
maybe a compiler/kernel bug?

Signed-off-by: Maximilian Güntner maximilian.guentner@gmail.com
