### PR TITLE
mpv: Enable egl video output

### DIFF
--- a/community/mpv/PKGBUILD
+++ b/community/mpv/PKGBUILD
@@ -9,7 +9,7 @@
 pkgname=mpv
 epoch=1
 pkgver=0.11.0
-pkgrel=1
+pkgrel=1.1
 pkgdesc='Video player based on MPlayer/mplayer2'
 arch=('i686' 'x86_64')
 license=('GPL')
@@ -42,7 +42,8 @@ build() {
     --confdir=/etc/mpv \
     --enable-zsh-comp \
     --enable-libmpv-shared \
-    --enable-cdda
+    --enable-cdda \
+    --enable-egl-x11
 
   ./waf build
 }


### PR DESCRIPTION
mpv supports egl video output but it has to be specifically enabled by configure.
Since version 0.10.0 the 'x11' video output module has been removed.
On an odroid at least the 'xv' video output module does not work so without the egl module no video output seems possible.

The actual command line switch to enable the egl video output is not that easy to find and I considered adding a message in the .install file. I can add it if you like.
For the record it is
`--vo=opengl:backend=x11egl:es`

I've tested this with the (Mali) egl/gles libraries removed from my device, and it does still build. In fact the egl output still works (via mesa, with poor quality). So this pull release should have no impact on devices without egl/gles.