### PR TITLE
alarm/libcec-imx6: fix compilation in non-git paths

### DIFF
--- a/alarm/libcec-imx6/PKGBUILD
+++ b/alarm/libcec-imx6/PKGBUILD
@@ -12,7 +12,7 @@ buildarch=4
 pkgname=libcec-imx6
 _pkgname=libcec
 pkgver=3.0.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Pulse-Eight's libcec for the Pulse-Eight USB-CEC adapter (IMX6)"
 arch=('armv7h')
 url="http://libcec.pulse-eight.com/"
@@ -23,17 +23,20 @@ provides=('libcec')
 conflicts=('libcec')
 source=("$_pkgname-$pkgver.tar.gz::https://github.com/Pulse-Eight/$_pkgname/archive/$_pkgname-$pkgver.tar.gz"
         '0001-add-imx-support-1.patch'
-        '0002-add-imx-support-2.patch')
+        '0002-add-imx-support-2.patch'
+        'https://github.com/Pulse-Eight/libcec/commit/2f32a9debc1f148b5dfcfc463480f1432bb71725.patch')
 
 sha256sums=('7e3670c8949a1964d6e5481f56dfff838857da10bdc60b506f6e9b7f117e253e'
             '1105f457f49c4caa0791de11a321dde11df086c06017c6a4a23c8a17502f01ef'
-            '5faf57652d8c0c83ca37fecc961c50b268f0f2b4092da31c56cc6874040593d9')
+            '5faf57652d8c0c83ca37fecc961c50b268f0f2b4092da31c56cc6874040593d9'
+            '83ca3b742831aa2e05297d11e238a0b0d1035a6404f60a6610acc8381d1c17ea')
 
 prepare() {
     cd "$_pkgname-$_pkgname-$pkgver"
 
     patch -Np1 -i ../0001-add-imx-support-1.patch
     patch -Np1 -i ../0002-add-imx-support-2.patch
+    patch -Np1 -i ../2f32a9debc1f148b5dfcfc463480f1432bb71725.patch
 }
 
 build() {


### PR DESCRIPTION
This fixes Pulse-Eight/libcec#112 via Pulse-Eigth/libcec@2f32a9debc1f148b5dfcfc463480f1432bb71725.

My initial patch was missing a PKGREL update, should be fixed now.