### PR TITLE
Update community/docker to 1.9.0

### DIFF
--- a/community/docker/PKGBUILD
+++ b/community/docker/PKGBUILD
@@ -2,8 +2,8 @@
 # Maintainer: Sébastien "Seblu" Luttringer
 
 pkgname=docker
-pkgver=1.7.1
-pkgrel=2
+pkgver=1.9.0
+pkgrel=1
 epoch=1
 pkgdesc='Pack, ship and run any application as a lightweight container'
 arch=('x86_64')


### PR DESCRIPTION
Works for me. 

Note I am using an experimental 4.2 kernel on ODROID-XU4 with the (non-default) overlayfs driver. This should probably be tested by someone with an older kernel as well.