### PR TITLE
Configure nodejs for vfpv3-d16 FPUs.

### DIFF
--- a/community/nodejs/PKGBUILD
+++ b/community/nodejs/PKGBUILD
@@ -36,7 +36,7 @@ set_flags_for_arm() {
     GYPFLAGS="-Darm_thumb -Darm_float_abi=hard -Darm_version=6 -Darm_fpu=vfpv2"
   fi
   if [ "$CARCH" == "armv7h" ]; then
-    CONFIG="--with-arm-float-abi=hard"
+    CONFIG="--with-arm-float-abi=hard --with-arm-fpu=vfpv3-d16"
     GYPFLAGS="-Darm_thumb -Darm_float_abi=hard -Darm_version=7 -Darm_fpu=vfpv3-d16"
   fi
   export CXXFLAGS


### PR DESCRIPTION
On my Marvell Armada 370 based NAS nodejs was crashing with Illegal instruction error.
Investigating with gdb I identified the problem to be the Armada 370 FPU. The Armada 370 has a 16 register vfpv3-d16 compatible FPU. This updates the nodejs config to be compatible with vdpv3-d16 CPUs. Tested on my Armada 370 device.



$ gdb node
...
(gdb) disassemble $pc,$pc+8
Dump of assembler code from 0x22f0a214 to 0x22f0a21c:
=> 0x22f0a214:    vpushne    {d16-d31}
   0x22f0a218:    subeq    sp, sp, #128    ; 0x80
