### PR TITLE
alarm/libcec-rpi: fix compilation in non-git paths

### DIFF
--- a/alarm/libcec-rpi/PKGBUILD
+++ b/alarm/libcec-rpi/PKGBUILD
@@ -11,7 +11,7 @@ buildarch=20
 pkgname=libcec-rpi
 _pkgname=libcec
 pkgver=3.0.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Pulse-Eight's libcec for the Pulse-Eight USB-CEC adapter (Raspberry Pi)"
 arch=('i686' 'x86_64')
 url="http://libcec.pulse-eight.com/"
@@ -20,8 +20,15 @@ makedepends=('cmake')
 depends=('udev' 'lockdev' 'libplatform' 'libxrandr' 'raspberrypi-firmware')
 provides=('libcec')
 conflicts=('libcec')
-source=("$_pkgname-$pkgver.tar.gz::https://github.com/Pulse-Eight/$_pkgname/archive/$_pkgname-$pkgver.tar.gz")
-sha256sums=('7e3670c8949a1964d6e5481f56dfff838857da10bdc60b506f6e9b7f117e253e')
+source=("$_pkgname-$pkgver.tar.gz::https://github.com/Pulse-Eight/$_pkgname/archive/$_pkgname-$pkgver.tar.gz"
+        'https://github.com/Pulse-Eight/libcec/commit/2f32a9debc1f148b5dfcfc463480f1432bb71725.patch')
+sha256sums=('7e3670c8949a1964d6e5481f56dfff838857da10bdc60b506f6e9b7f117e253e'
+            '83ca3b742831aa2e05297d11e238a0b0d1035a6404f60a6610acc8381d1c17ea')
+
+prepare() {
+  cd "$_pkgname-$_pkgname-$pkgver"
+  patch -Np1 -i "$srcdir/2f32a9debc1f148b5dfcfc463480f1432bb71725.patch"
+}
 
 build() {
     cd "$_pkgname-$_pkgname-$pkgver"


### PR DESCRIPTION
This fixes https://github.com/Pulse-Eight/libcec/issues/112 via https://github.com/Pulse-Eight/libcec/commit/2f32a9debc1f148b5dfcfc463480f1432bb71725 .

Same as for other platform from https://github.com/archlinuxarm/PKGBUILDs/pull/1276

Problems without this patch and pkgrel bump:
```
$ cec-client -l
cec-client: symbol lookup error: /usr/lib/libcec.so.3.0: undefined symbol: _ZN11StringUtils6FormatEPKcz
$
```

Build testet directly on Raspberry Pi 2, there was need for 'arch=('armv7h') ':
==> Finished making: libcec-rpi 3.0.1-3 (Thu Dec 17 23:31:49 CET 2015)

The 'cec-client -l' is again working:
```
$ cec-client -l
libCEC version: 3.0.1, git revision: <unknown>, compiled on Thu Dec 17 22:25:46 UTC 2015 by crow@vdrrpi on Linux 4.1.15-1-ARCH (armv7l), features: P8_USB, P8_detect, randr, 'RPi'
Found devices: 1

device:              1
com port:            RPI
vendor id:           2708
product id:          1001
firmware version:    1
type:                Raspberry Pi
$
```