### PR TITLE
[alarm/kodi-rbp-git] Apply CXX11_ABI to fix SIGBUS crash

### DIFF
--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -12,7 +12,7 @@ pkgname=('kodi-rbp-git' 'kodi-rbp-git-eventclients')
 pkgver=16.0b3.20151205
 
 _tag=16.0b3-Jarvis
-pkgrel=1
+pkgrel=2
 pkgdesc="A software media player and entertainment hub for digital media for the Raspberry Pi"
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
@@ -53,7 +53,7 @@ build() {
   # Configuring Kodi
   export PYTHON_VERSION=2  # external python v2
   # we need to compile for armv6 instead of armv5 to avoid problems compiling assembler code
-  FLAGS="-Ofast -fexcess-precision=fast -mfloat-abi=hard -mabi=aapcs-linux -pipe -fstack-protector --param=ssp-buffer-size=4 \
+  FLAGS="-Ofast -fexcess-precision=fast -mfloat-abi=hard -mabi=aapcs-linux -pipe -fstack-protector --param=ssp-buffer-size=4 -D_GLIBCXX_USE_CXX11_ABI=1 \
          -I/opt/vc/include/ -I/opt/vc/include/IL -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux"
   [[ $CARCH == "armv6h" ]] && export CFLAGS="$FLAGS -mcpu=arm1176jzf-s -mtune=arm1176jzf-s -mfpu=vfp" && export CXXFLAGS="$FLAGS -mcpu=arm1176jzf-s -mtune=arm1176jzf-s -mfpu=vfp"
   [[ $CARCH == "armv7h" ]] && export CFLAGS="$FLAGS -mcpu=cortex-a7 -mtune=cortex-a7 -mfpu=neon-vfpv4 -mvectorize-with-neon-quad" && export CXXFLAGS="$FLAGS -mcpu=cortex-a7 -mtune=cortex-a7 -mfpu=neon-vfpv4 -mvectorize-with-neon-quad"


### PR DESCRIPTION
This applies commit 6e7c288 to the kodi-rbp-git package to avoid the crash with a SIGBUS error as mentioned here: http://archlinuxarm.org/forum/viewtopic.php?f=15&t=9599.
Without this patch, this package is currently unusable on Armv7h as Kodi immediately crashes on startup.