### PR TITLE
encapsulate dependency on llvm 3.5

### DIFF
--- a/community/ghc/PKGBUILD
+++ b/community/ghc/PKGBUILD
@@ -23,7 +23,7 @@ pkgdesc='The Glasgow Haskell Compiler'
 arch=('i686' 'x86_64')
 url='http://www.haskell.org/ghc/'
 license=('custom')
-depends=('perl' 'gmp' 'gcc' 'libffi' 'llvm35')
+depends=('perl' 'gmp' 'gcc' 'libffi' 'ghc-llvm')
 makedepends=('ghc' 'perl' 'libxslt' 'docbook-xsl')
 provides=('haskell-array=0.5.1.0'
           'haskell-base=4.8.2.0'


### PR DESCRIPTION
As there is no open issue tracker for ALARM I'm abusing a PR.
Thanks for reintroducing ```ghc```. But the dependency on llvm35 leads to a conflict with an installed llvm. I propose to add Tom Hall's [```ghc-llvm```](https://github.com/Thra11/PKGBUILDS) which would allow ```ghc``` to coexist with an up-to-date ```llvm```

see also:
https://thra11.github.io/posts/2015-09-07-GHC-On-Arch-Linux-Arm.html