### PR TITLE
[linux-peach] fixed path for manual kernel update

### DIFF
--- a/core/linux-peach/linux-peach.install
+++ b/core/linux-peach/linux-peach.install
@@ -18,7 +18,7 @@ flash_kernel() {
     sync
   else
     echo "You can do this later by running:"
-    echo "# dd if=/boot/vmlinux.kpart of=/dev/${device}"
+    echo "# dd if=/boot/vmlinux.kpart of=${device}"
   fi
 }
 


### PR DESCRIPTION
There was a superfluous adding of the string "/dev/" to the output path for the manual instructions to dd the new kernel in place.
I did not bump pkver/pkrel as I think this change does not warrant a new release. (It does not affect people that already installed the package.)

Old erroneous behavious for reference:

```
6/8) Aktualisiere linux-peach                                                                       [############################################################] 100%
>>> Updating module dependencies. Please wait ...
A new kernel version needs to be flashed onto /dev/mmcblk0p1.
Do you want to do this now? [y|N]
N
You can do this later by running:
# dd if=/boot/vmlinux.kpart of=/dev//dev/mmcblk0p1
```