### PR TITLE
add u-boot support for Mele A1000/A2000

### DIFF
--- a/alarm/uboot-sunxi/PKGBUILD
+++ b/alarm/uboot-sunxi/PKGBUILD
@@ -44,10 +44,10 @@ boards=('A10-OLinuXino-Lime'
         'Cubieboard'
         'Cubieboard2'
         'Cubietruck'
-        'Mele_A1000'
         'Linksprite_pcDuino'
         'Linksprite_pcDuino3'
-        'Linksprite_pcDuino3_Nano')
+        'Linksprite_pcDuino3_Nano'
+        'Mele_A1000')
 
 prepare() {
   cd u-boot-${pkgver}
@@ -199,20 +199,6 @@ package_uboot-cubieboard2() {
   install -Dm755 mkscr "${pkgdir}"/boot/mkscr
 }
 
-package_uboot-mele-a1000() {
-  pkgdesc="U-Boot for Mele A1000"
-  install=${pkgbase}.install
-  provides=('uboot-sunxi')
-  conflicts=('uboot-sunxi')
-
-  install -d "${pkgdir}"/boot
-  install -Dm644 bin_Mele_A1000/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot/u-boot-sunxi-with-spl.bin
-
-  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
-  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
-  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
-}
-
 package_uboot-cubietruck() {
   pkgdesc="U-Boot for Cubietruck"
   install=${pkgbase}.install
@@ -221,6 +207,20 @@ package_uboot-cubietruck() {
 
   install -d "${pkgdir}"/boot
   install -Dm644 bin_Cubietruck/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot/u-boot-sunxi-with-spl.bin
+
+  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
+  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
+  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
+}
+
+package_uboot-mele-a1000() {
+  pkgdesc="U-Boot for Mele A1000"
+  install=${pkgbase}.install
+  provides=('uboot-sunxi')
+  conflicts=('uboot-sunxi')
+
+  install -d "${pkgdir}"/boot
+  install -Dm644 bin_Mele_A1000/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot/u-boot-sunxi-with-spl.bin
 
   install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
   install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr

--- a/alarm/uboot-sunxi/PKGBUILD
+++ b/alarm/uboot-sunxi/PKGBUILD
@@ -14,6 +14,7 @@ pkgname=('uboot-a10-olinuxino-lime'
          'uboot-cubieboard'
          'uboot-cubieboard2'
          'uboot-cubietruck'
+         'uboot-mele-a1000'
          'uboot-pcduino'
          'uboot-pcduino3'
          'uboot-pcduino3-nano')
@@ -43,6 +44,7 @@ boards=('A10-OLinuXino-Lime'
         'Cubieboard'
         'Cubieboard2'
         'Cubietruck'
+        'Mele_A1000'
         'Linksprite_pcDuino'
         'Linksprite_pcDuino3'
         'Linksprite_pcDuino3_Nano')
@@ -191,6 +193,20 @@ package_uboot-cubieboard2() {
 
   install -d "${pkgdir}"/boot
   install -Dm644 bin_Cubieboard2/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot/u-boot-sunxi-with-spl.bin
+
+  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
+  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
+  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
+}
+
+package_uboot-mele-a1000() {
+  pkgdesc="U-Boot for Mele A1000"
+  install=${pkgbase}.install
+  provides=('uboot-sunxi')
+  conflicts=('uboot-sunxi')
+
+  install -d "${pkgdir}"/boot
+  install -Dm644 bin_Mele_A1000/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot/u-boot-sunxi-with-spl.bin
 
   install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
   install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr


### PR DESCRIPTION
Hi, please add support for boards Mele A100 (A1000 / A2000).
I have a A2000 running with uboot manually compiled and the latest image of http://archlinuxarm.org/os/ArchLinuxARM-armv7-latest.tar.gz
The instructions for install on SD card are the same to Cubieboard. Thanks.

PD: This modifications are already tested and they work fine.