### PR TITLE
aur/cower to 14-3

### DIFF
--- a/aur/cower/PKGBUILD
+++ b/aur/cower/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=cower
 pkgver=14
-pkgrel=2
+pkgrel=3
 pkgdesc="A simple AUR agent with a pretentious name"
 arch=('i686' 'x86_64')
 url="http://github.com/falconindy/cower"


### PR DESCRIPTION
Since pacman 5 is transitioning from testing to core, cower needs to be rebuilt to avoid the usual libalpm error.
`libalpm.so.9: cannot open shared object file: No such file or directory`

Thanks.