### PR TITLE
added dub package manager for the D programming language

### DIFF
--- a/community/dub/PKGBUILD
+++ b/community/dub/PKGBUILD
@@ -1,0 +1,32 @@
+pkgname=dub
+pkgver=0.9.24
+pkgrel=1
+pkgdesc="Developer package manager for D programming language"
+arch=('armv7h')
+url="https://github.com/D-Programming-Language/dub"
+license=('MIT')
+makedepends=('gdc' 'git')
+depends=('gdc')
+conflicts=('dub-git')
+source=(
+  "git+https://github.com/D-Programming-Language/dub.git#tag=v$pkgver"
+)
+sha256sums=(
+  'SKIP'
+)
+
+build()
+{
+  # DC=`$srcdir/Arch-PKGBUILDs/d-compiler.sh`
+  DC=gdc
+  cd "${srcdir}/${pkgname}"
+  ./build-gdc.sh
+}
+
+package()
+{
+  cd "${srcdir}/${pkgname}"
+  install -D -m755 bin/dub "${pkgdir}/usr/bin/dub"
+  install -D -m644 scripts/bash-completion/dub.bash $pkgdir/usr/share/bash-completion/completions/dub
+  install -D -m644 LICENSE.txt "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.txt"
+}


### PR DESCRIPTION
dub should be specifically built for gdc, otherwise it won't be usable