### PR TITLE
[kodi-imx] [kodi-rbp-git] [kodi-rbp] directory permissions differ on /usr/share/polkit-1/rules.d/

### DIFF
--- a/alarm/kodi-imx/PKGBUILD
+++ b/alarm/kodi-imx/PKGBUILD
@@ -159,7 +159,6 @@ package_kodi-imx() {
   install -Dm0644 $srcdir/kodi.service $pkgdir/usr/lib/systemd/system/kodi.service
   install -Dm0644 $srcdir/kodi.conf $pkgdir/etc/tmpfiles.d/kodi.conf
   install -Dm0644 $srcdir/polkit.rules $pkgdir/usr/share/polkit-1/rules.d/10-kodi.rules
-  chmod 0700 $pkgdir/usr/share/polkit-1/rules.d/
 }
 
 package_kodi-imx-eventclients() {

--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -135,7 +135,6 @@ package_kodi-rbp-git() {
 
   install -Dm0644 $srcdir/kodi.service $pkgdir/usr/lib/systemd/system/kodi.service
   install -Dm0644 $srcdir/polkit.rules $pkgdir/usr/share/polkit-1/rules.d/10-kodi.rules
-  chmod 0700 $pkgdir/usr/share/polkit-1/rules.d/
 }
 
 package_kodi-rbp-git-eventclients() {

--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -143,7 +143,6 @@ package_kodi-rbp() {
 
   install -Dm0644 $srcdir/kodi.service $pkgdir/usr/lib/systemd/system/kodi.service
   install -Dm0644 $srcdir/polkit.rules $pkgdir/usr/share/polkit-1/rules.d/10-kodi.rules
-  chmod 0700 $pkgdir/usr/share/polkit-1/rules.d/
 }
 
 package_kodi-rbp-eventclients() {


### PR DESCRIPTION
I just tried to install kodi-rbp-git and got this message from pacman
`(21/21) installing kodi-rbp-git        [###############] 100%
warning: directory permissions differ on /usr/share/polkit-1/rules.d/
filesystem: 750  package: 700`
In the PKGBUILDs of those 3 kodi packages, the permission is explicitely changed to 0700, which differs from the filesystem.

This is just a warning and the permissions didn't change, but I consider this a bug.

But why were those lines included in the first place?