### PR TITLE
glibc: sync install script with Arch Linux [core]

### DIFF
--- a/core/glibc/PKGBUILD
+++ b/core/glibc/PKGBUILD
@@ -16,7 +16,7 @@ noautobuild=1
 
 pkgname=glibc
 pkgver=2.22
-pkgrel=4
+pkgrel=4.1
 pkgdesc="GNU C Library"
 arch=('i686' 'x86_64')
 url="http://www.gnu.org/software/libc"
@@ -101,7 +101,7 @@ build() {
   # build libraries with hardening disabled
   echo "build-programs=no" >> configparms
   make
-  
+
   # re-enable hardening for programs
   sed -i "/build-programs=/s#no#yes#" configparms
   echo "CC += -fstack-protector -D_FORTIFY_SOURCE=2" >> configparms

--- a/core/glibc/glibc.install
+++ b/core/glibc/glibc.install
@@ -2,21 +2,21 @@ infodir=usr/share/info
 filelist=(libc.info{,-1,-2,-3,-4,-5,-6,-7,-8,-9,-10,-11})
 
 post_upgrade() {
-  ldconfig -r .
-
-  if [[ $(vercmp 2.22-1 $2) = 1 ]]; then
+  #if [[ $(vercmp 2.22-3 $2) = 1 ]]; then
     locale-gen
-  fi
+  #fi
+
+  ldconfig -r .
   
-  [ -x usr/bin/install-info ] || return 0
+  [[ -x usr/bin/install-info ]] || return 0
   for file in ${filelist[@]}; do
-    usr/bin/install-info $infodir/$file.gz $infodir/dir 2> /dev/null
+    install-info $infodir/$file.gz $infodir/dir 2> /dev/null
   done
 }
 
 pre_remove() {
-  [ -x usr/bin/install-info ] || return 0
+  [[ -x usr/bin/install-info ]] || return 0
   for file in ${filelist[@]}; do
-    usr/bin/install-info --delete $infodir/$file.gz $infodir/dir 2> /dev/null
+    install-info --delete $infodir/$file.gz $infodir/dir 2> /dev/null
   done
 }


### PR DESCRIPTION
locale-gen is now called on each update. The update to 2.22-4 broke locales
so force an update by raising the pkgrel to 4.1.