### PR TITLE
libcec 3.1.0 does not include Exynos-specific files by default.

### DIFF
--- a/community/libcec/PKGBUILD
+++ b/community/libcec/PKGBUILD
@@ -10,7 +10,7 @@ buildarch=14
 
 pkgname=libcec
 pkgver=3.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Pulse-Eight's libcec for the Pulse-Eight USB-CEC adapter"
 arch=('i686' 'x86_64')
 url="http://libcec.pulse-eight.com/"
@@ -24,7 +24,8 @@ build() {
     cd "$pkgname-$pkgname-$pkgver"
 
     if [[ $CARCH == 'armv7h' ]]; then
-      CONFIG='-DHAVE_EXYNOS_API=1'
+      # It seems the HAVE_EXYNOS_API flag is discarded. Let's force it... Yes, that's a ugly hack, but still, it works!
+      sed -i 's/set(HAVE_EXYNOS_API 0)/set(HAVE_EXYNOS_API 1)/g' src/libcec/cmake/CheckPlatformSupport.cmake
     fi
 
     mkdir build
@@ -34,8 +35,7 @@ build() {
         -DBUILD_SHARED_LIBS=1 \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_INSTALL_LIBDIR=/usr/lib \
-        -DCMAKE_INSTALL_LIBDIR_NOARCH=/usr/lib \
-        ${CONFIG}
+        -DCMAKE_INSTALL_LIBDIR_NOARCH=/usr/lib
     make
 }
 


### PR DESCRIPTION
As a consequence, Exynos devices (Odroid-XU for example) do not work properly (try running `cec-client` on an Odroid-XU, it won't work).
This acts as a workaround. With this patch, libcec compiles in Exynos-specific files so that any program relying on this library (Kodi for example) works. Try running `cec-client` with this patch, it works properly (as root).

See https://github.com/Pulse-Eight/libcec/issues/201