### PR TITLE
core/linux-raspberrypi: Support automatically generating initrd.

### DIFF
--- a/core/linux-raspberrypi/linux-raspberrypi.install
+++ b/core/linux-raspberrypi/linux-raspberrypi.install
@@ -13,11 +13,23 @@ disable_cma() {
   fi
 }
 
+generate_initramfs() {
+  kernel_version=$1
+  if [[ -f /boot/config.txt ]]; then
+    initramfs_line=($(grep '^initramfs' /boot/config.txt))
+    if [[ -n "${initramfs_line[1]}" ]]; then
+      echo ">>> Regenerating initramfs..."
+      mkinitcpio -g "/boot/${initramfs_line[1]}" -k ${kernel_version}
+    fi
+  fi
+}
+
 post_install () {
   # updating module dependencies
   echo ">>> Updating module dependencies. Please wait ..."
   depmod ${KERNEL_VERSION}
   disable_cma
+  generate_initramfs ${KERNEL_VERSION}
 }
 
 post_upgrade() {
@@ -33,6 +45,7 @@ post_upgrade() {
   depmod ${KERNEL_VERSION}
 
   disable_cma
+  generate_initramfs ${KERNEL_VERSION}
 
   if [ "$(vercmp $2 3.18.3)" -lt 0 ]; then
     echo "________________________________________________________________________________"


### PR DESCRIPTION
Checks `/boot/config.txt` for an `initramfs <initramfs file>` line and generates `<initramfs file>` using `mkinitcpio`.
Without this, people using initramfs have to remember to regenerate the initramfs manually after a kernel update, because they can otherwise end up with an unbootable system.