### PR TITLE
Add LFS for PHP on 32-bit

### DIFF
--- a/extra/php-lfs/PKGBUILD
+++ b/extra/php-lfs/PKGBUILD
@@ -1,0 +1,369 @@
+# $Id: PKGBUILD 261071 2016-03-06 10:48:44Z pierre $
+# Maintainer: Pierre Schmitz <pierre@archlinux.de>
+# Compiled with large file support for 32-bit ARM platforms
+# Incompatible with Apache, so php-apache removed
+
+pkgbase=php
+pkgname=('php-lfs'
+         'php-lfs-cgi'
+         'php-lfs-fpm'
+         'php-lfs-embed'
+         'php-lfs-phpdbg'
+         'php-lfs-dblib'
+         'php-lfs-enchant'
+         'php-lfs-gd'
+         'php-lfs-imap'
+         'php-lfs-intl'
+         'php-lfs-mcrypt'
+         'php-lfs-odbc'
+         'php-lfs-pgsql'
+         'php-lfs-pspell'
+         'php-lfs-snmp'
+         'php-lfs-sqlite'
+         'php-lfs-tidy'
+         'php-lfs-xsl')
+pkgver=7.0.4
+pkgrel=1
+arch=('armv5' 'armv6h' 'armv7h')
+buildarch=22 # only for 32-bit ARM platforms
+license=('PHP')
+url='http://www.php.net'
+makedepends=('aspell' 'c-client' 'db' 'enchant' 'gd' 'gmp' 'icu' 'libmcrypt' 'libxslt' 'libzip' 'net-snmp'
+             'postgresql-libs' 'sqlite' 'systemd' 'tidy' 'unixodbc' 'curl' 'libtool' 'postfix' 'freetds')
+checkdepends=('procps-ng')
+source=("https://www.php.net/distributions/${pkgbase}-${pkgver}.tar.xz"{,.asc}
+        'php-fpm.patch' 'php-fpm.tmpfiles' 'php.ini.patch')
+sha256sums=('584e0e374e357a71b6e95175a2947d787453afc7f9ab7c55651c10491c4df532'
+            'SKIP'
+            '136e197384255420c73678aef812e70aa86320f6dbefcc5a952df1a65fdd53fa'
+            '640dba0d960bfeaae9ad38d2826d3f6b5d6c175a4d3e16664eefff29141faad5'
+            '3ee1d4696ccbc8850db19dbf3ac1275ce40debea3b2402c7316d86f7028407da')
+validpgpkeys=('1A4E8B7277C42E53DBA9C7B9BCAA30EA9C0D5763'
+              '6E4F6AB321FDC07F2C332E3AC2BF0BC433CFC8B3')
+
+prepare() {
+	cd ${srcdir}/${pkgbase}-${pkgver}
+
+	patch -p0 -i ${srcdir}/php-fpm.patch
+	patch -p0 -i ${srcdir}/php.ini.patch
+}
+
+build() {
+	local _phpconfig="--srcdir=../${pkgbase}-${pkgver} \
+		--config-cache \
+		--prefix=/usr \
+		--sbindir=/usr/bin \
+		--sysconfdir=/etc/php \
+		--localstatedir=/var \
+		--with-layout=GNU \
+		--with-config-file-path=/etc/php \
+		--with-config-file-scan-dir=/etc/php/conf.d \
+		--disable-rpath \
+		--mandir=/usr/share/man \
+		--without-pear \
+		--enable-zend-signals \
+		"
+
+	local _phpextensions="\
+		--enable-bcmath=shared \
+		--enable-calendar=shared \
+		--enable-dba=shared \
+		--enable-exif=shared \
+		--enable-ftp=shared \
+		--enable-gd-native-ttf \
+		--enable-intl=shared \
+		--enable-mbstring \
+		--enable-shmop=shared \
+		--enable-soap=shared \
+		--enable-sockets=shared \
+		--enable-sysvmsg=shared \
+		--enable-sysvsem=shared \
+		--enable-sysvshm=shared \
+		--enable-zip=shared \
+		--with-bz2=shared \
+		--with-curl=shared \
+		--with-db4=/usr \
+		--with-enchant=shared,/usr \
+		--with-freetype-dir=/usr \
+		--with-gd=shared,/usr \
+		--with-gdbm \
+		--with-gettext=shared \
+		--with-gmp=shared \
+		--with-iconv=shared \
+		--with-imap-ssl \
+		--with-imap=shared \
+		--with-kerberos=/usr \
+		--with-ldap=shared \
+		--with-ldap-sasl \
+		--with-libzip \
+		--with-mcrypt=shared \
+		--with-mhash \
+		--with-mysql-sock=/run/mysqld/mysqld.sock \
+		--with-mysqli=shared,mysqlnd \
+		--with-openssl \
+		--with-pcre-regex=/usr \
+		--with-pdo-dblib=shared,/usr \
+		--with-pdo-mysql=shared,mysqlnd \
+		--with-pdo-odbc=shared,unixODBC,/usr \
+		--with-pdo-pgsql=shared \
+		--with-pdo-sqlite=shared,/usr \
+		--with-pgsql=shared \
+		--with-pspell=shared \
+		--with-readline \
+		--with-snmp=shared \
+		--with-sqlite3=shared,/usr \
+		--with-tidy=shared \
+		--with-unixODBC=shared,/usr \
+		--with-xmlrpc=shared \
+		--with-xsl=shared \
+		--with-zlib \
+		--enable-pcntl \
+		"
+
+	EXTENSION_DIR=/usr/lib/php/modules
+	export EXTENSION_DIR
+
+	# Enable large file support
+	export CFLAGS="$CFLAGS -D_FILE_OFFSET_BITS=64"
+
+	mkdir ${srcdir}/build
+	cd ${srcdir}/build
+	ln -s ../${pkgbase}-${pkgver}/configure
+	./configure ${_phpconfig} \
+		--enable-cgi \
+		--enable-fpm \
+		--with-fpm-systemd \
+		--with-fpm-acl \
+		--with-fpm-user=http \
+		--with-fpm-group=http \
+		--enable-embed=shared \
+		${_phpextensions}
+	make
+
+	# phpdbg
+	cp -a ${srcdir}/build ${srcdir}/build-phpdbg
+	cd ${srcdir}/build-phpdbg
+	./configure ${_phpconfig} \
+		--enable-phpdbg \
+		${_phpextensions}
+	make
+}
+
+check() {
+	cd ${srcdir}/${pkgbase}-${pkgver}
+
+	# Check if sendmail was configured correctly (FS#47600)
+	${srcdir}/build/sapi/cli/php -n -r 'echo ini_get("sendmail_path");' | grep -q '/usr/bin/sendmail'
+
+	export REPORT_EXIT_STATUS=1
+	export NO_INTERACTION=1
+	export SKIP_ONLINE_TESTS=1
+	export SKIP_SLOW_TESTS=1
+
+	${srcdir}/build/sapi/cli/php -n run-tests.php -n -P {tests,Zend}
+}
+
+package_php-lfs() {
+	pkgdesc='A general-purpose scripting language that is especially suited to web development'
+	depends=('libxml2' 'curl' 'libzip')
+	replaces=('php-ldap' 'php')
+	conflicts=('php-ldap' 'php')
+	provides=("php=${pkgver}" "php-ldap=${pkgver}")
+	backup=('etc/php/php.ini')
+
+	cd ${srcdir}/build
+	make -j1 INSTALL_ROOT=${pkgdir} install-{modules,cli,build,headers,programs,pharcmd}
+	install -D -m644 ${srcdir}/${pkgbase}-${pkgver}/php.ini-production ${pkgdir}/etc/php/php.ini
+	install -d -m755 ${pkgdir}/etc/php/conf.d/
+
+	# remove static modules
+	rm -f ${pkgdir}/usr/lib/php/modules/*.a
+	# remove modules provided by sub packages
+	rm -f ${pkgdir}/usr/lib/php/modules/{enchant,gd,imap,intl,mcrypt,odbc,pdo_dblib,pdo_odbc,pgsql,pdo_pgsql,pspell,snmp,sqlite3,pdo_sqlite,tidy,xsl}.so
+	# remove empty directory
+	rmdir ${pkgdir}/usr/include/php/include
+}
+
+package_php-lfs-cgi() {
+	pkgdesc='CGI and FCGI SAPI for PHP'
+	depends=('php-lfs')
+	replaces=('php-cgi')
+	conflicts=('php-cgi')
+	provides=("php-cgi=${pkgver}")
+
+	cd ${srcdir}/build
+	make -j1 INSTALL_ROOT=${pkgdir} install-cgi
+}
+
+package_php-lfs-fpm() {
+	pkgdesc='FastCGI Process Manager for PHP'
+	depends=('php-lfs' 'systemd')
+	replaces=('php-fpm')
+	conflicts=('php-fpm')
+	provides=("php-fpm=${pkgver}")
+	backup=('etc/php/php-fpm.conf' 'etc/php/php-fpm.d/www.conf')
+	install='php-fpm.install'
+	options=('!emptydirs')
+
+	cd ${srcdir}/build
+	make -j1 INSTALL_ROOT=${pkgdir} install-fpm
+	install -D -m644 sapi/fpm/php-fpm.service ${pkgdir}/usr/lib/systemd/system/php-fpm.service
+	install -D -m644 ${srcdir}/php-fpm.tmpfiles ${pkgdir}/usr/lib/tmpfiles.d/php-fpm.conf
+}
+
+package_php-lfs-embed() {
+	pkgdesc='Embedded PHP SAPI library'
+	depends=('php-lfs' 'libsystemd')
+	replaces=('php-embed')
+	conflicts=('php-embed')
+	provides=("php-embed=${pkgver}")
+	options=('!emptydirs')
+
+	cd ${srcdir}/build
+	make -j1 INSTALL_ROOT=${pkgdir} PHP_SAPI=embed install-sapi
+}
+
+package_php-lfs-phpdbg() {
+	pkgdesc='Interactive PHP debugger'
+	depends=('php-lfs')
+	replaces=('php-phpdbg')
+	conflicts=('php-phpdbg')
+	provides=("php-phpdbg=${pkgver}")
+	options=('!emptydirs')
+
+	cd ${srcdir}/build-phpdbg
+	make -j1 INSTALL_ROOT=${pkgdir} install-phpdbg
+}
+
+package_php-lfs-dblib() {
+	pkgdesc='dblib module for PHP'
+	depends=('php-lfs' 'freetds')
+	replaces=('php-dblib')
+	conflicts=('php-dblib')
+	provides=("php-dblib=${pkgver}")
+
+	install -D -m755 ${srcdir}/build/modules/pdo_dblib.so ${pkgdir}/usr/lib/php/modules/pdo_dblib.so
+}
+
+package_php-lfs-enchant() {
+	pkgdesc='enchant module for PHP'
+	depends=('php-lfs' 'enchant')
+	replaces=('php-enchant')
+	conflicts=('php-enchant')
+	provides=("php-enchant=${pkgver}")
+
+	install -D -m755 ${srcdir}/build/modules/enchant.so ${pkgdir}/usr/lib/php/modules/enchant.so
+}
+
+package_php-lfs-gd() {
+	pkgdesc='gd module for PHP'
+	depends=('php-lfs' 'gd')
+	replaces=('php-gd')
+	conflicts=('php-gd')
+	provides=("php-gd=${pkgver}")
+
+	install -D -m755 ${srcdir}/build/modules/gd.so ${pkgdir}/usr/lib/php/modules/gd.so
+}
+
+package_php-lfs-imap() {
+	pkgdesc='imap module for PHP'
+	depends=('php-lfs' 'c-client')
+	replaces=('php-imap')
+	conflicts=('php-imap')
+	provides=("php-imap=${pkgver}")
+
+	install -D -m755 ${srcdir}/build/modules/imap.so ${pkgdir}/usr/lib/php/modules/imap.so
+}
+
+package_php-lfs-intl() {
+	pkgdesc='intl module for PHP'
+	depends=('php-lfs' 'icu')
+	replaces=('php-intl')
+	conflicts=('php-intl')
+	provides=("php-intl=${pkgver}")
+
+	install -D -m755 ${srcdir}/build/modules/intl.so ${pkgdir}/usr/lib/php/modules/intl.so
+}
+
+package_php-lfs-mcrypt() {
+	pkgdesc='mcrypt module for PHP'
+	depends=('php-lfs' 'libmcrypt' 'libtool')
+	replaces=('php-mcrypt')
+	conflicts=('php-mcrypt')
+	provides=("php-mcrypt=${pkgver}")
+
+	install -D -m755 ${srcdir}/build/modules/mcrypt.so ${pkgdir}/usr/lib/php/modules/mcrypt.so
+}
+
+package_php-lfs-odbc() {
+	pkgdesc='ODBC modules for PHP'
+	depends=('php-lfs' 'unixodbc')
+	replaces=('php-odbc')
+	conflicts=('php-odbc')
+	provides=("php-odbc=${pkgver}")
+
+	install -D -m755 ${srcdir}/build/modules/odbc.so ${pkgdir}/usr/lib/php/modules/odbc.so
+	install -D -m755 ${srcdir}/build/modules/pdo_odbc.so ${pkgdir}/usr/lib/php/modules/pdo_odbc.so
+}
+
+package_php-lfs-pgsql() {
+	pkgdesc='PostgreSQL modules for PHP'
+	depends=('php-lfs' 'postgresql-libs')
+	replaces=('php-pgsql')
+	conflicts=('php-pgsql')
+	provides=("php-pgsql=${pkgver}")
+
+	install -D -m755 ${srcdir}/build/modules/pgsql.so ${pkgdir}/usr/lib/php/modules/pgsql.so
+	install -D -m755 ${srcdir}/build/modules/pdo_pgsql.so ${pkgdir}/usr/lib/php/modules/pdo_pgsql.so
+}
+
+package_php-lfs-pspell() {
+	pkgdesc='pspell module for PHP'
+	depends=('php-lfs' 'aspell')
+	replaces=('php-pspell')
+	conflicts=('php-pspell')
+	provides=("php-pspell=${pkgver}")
+
+	install -D -m755 ${srcdir}/build/modules/pspell.so ${pkgdir}/usr/lib/php/modules/pspell.so
+}
+
+package_php-lfs-snmp() {
+	pkgdesc='snmp module for PHP'
+	depends=('php-lfs' 'net-snmp')
+	replaces=('php-snmp')
+	conflicts=('php-snmp')
+	provides=("php-snmp=${pkgver}")
+
+	install -D -m755 ${srcdir}/build/modules/snmp.so ${pkgdir}/usr/lib/php/modules/snmp.so
+}
+
+package_php-lfs-sqlite() {
+	pkgdesc='sqlite module for PHP'
+	depends=('php-lfs' 'sqlite')
+	replaces=('php-sqlite')
+	conflicts=('php-sqlite')
+	provides=("php-sqlite=${pkgver}")
+
+	install -D -m755 ${srcdir}/build/modules/sqlite3.so ${pkgdir}/usr/lib/php/modules/sqlite3.so
+	install -D -m755 ${srcdir}/build/modules/pdo_sqlite.so ${pkgdir}/usr/lib/php/modules/pdo_sqlite.so
+}
+
+package_php-lfs-tidy() {
+	pkgdesc='tidy module for PHP'
+	depends=('php-lfs' 'tidy')
+	replaces=('php-tidy')
+	conflicts=('php-tidy')
+	provides=("php-tidy=${pkgver}")
+
+	install -D -m755 ${srcdir}/build/modules/tidy.so ${pkgdir}/usr/lib/php/modules/tidy.so
+}
+
+package_php-lfs-xsl() {
+	pkgdesc='xsl module for PHP'
+	depends=('php-lfs' 'libxslt')
+	replaces=('php-xsl')
+	conflicts=('php-xsl')
+	provides=("php-xsl=${pkgver}")
+
+	install -D -m755 ${srcdir}/build/modules/xsl.so ${pkgdir}/usr/lib/php/modules/xsl.so
+}

--- a/extra/php-lfs/generate_patches
+++ b/extra/php-lfs/generate_patches
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+. PKGBUILD
+
+makepkg -o --nodeps --noprepare --skipinteg
+
+pushd src/${pkgbase}-${pkgver}
+
+sed 's/.conf.default/.conf/g' -i.orig sapi/fpm/Makefile.frag
+
+sed \
+	-e 's#run/php-fpm.pid#/run/php-fpm/php-fpm.pid#' \
+	-e 's#^;error_log =.*#error_log = syslog#' \
+	-i.orig sapi/fpm/php-fpm.conf.in
+
+sed \
+	-e 's#^listen =.*#listen = /run/php-fpm/php-fpm.sock#' \
+	-e 's#^;listen.owner =#listen.owner =#' \
+	-e 's#^;listen.group =#listen.group =#' \
+	-e 's#^;chdir =.*#;chdir = /srv/http#' \
+	-i.orig sapi/fpm/www.conf.in
+
+sed \
+	-e 's#^PIDFile=.*#PIDFile=/run/php-fpm/php-fpm.pid#' \
+	-i.orig sapi/fpm/php-fpm.service.in
+
+extensions=";extension=bcmath.so\n;extension=bz2.so\n;extension=calendar.so\nextension=curl.so\n;extension=dba.so\n;extension=enchant.so\n;extension=exif.so\n;extension=ftp.so\n;extension=gd.so\n;extension=gettext.so\n;extension=gmp.so\n;extension=iconv.so\n;extension=imap.so\n;extension=intl.so\n;extension=ldap.so\n;extension=mcrypt.so\n;extension=mysqli.so\n;extension=odbc.so\n;zend_extension=opcache.so\n;extension=pdo_dblib.so\n;extension=pdo_mysql.so\n;extension=pdo_odbc.so\n;extension=pdo_pgsql.so\n;extension=pdo_sqlite.so\n;extension=pgsql.so\n;extension=pspell.so\n;extension=shmop.so\n;extension=snmp.so\n;extension=soap.so\n;extension=sockets.so\n;extension=sqlite3.so\n;extension=sysvmsg.so\n;extension=sysvsem.so\n;extension=sysvshm.so\n;extension=tidy.so\n;extension=xmlrpc.so\n;extension=xsl.so\nextension=zip.so\n"
+
+sed \
+	-r ":a;N;\$!ba;s/; Windows Extensions\n.+;?extension=php_[a-z]+\.dll\n/${extensions}/g" \
+	-i.orig php.ini-production
+sed \
+	-e 's#^; extension_dir = "\./"$#extension_dir = "/usr/lib/php/modules/"#g' \
+	-i php.ini-production
+
+diff -u sapi/fpm/Makefile.frag.orig sapi/fpm/Makefile.frag | filterdiff --clean --remove-timestamps > ../../php-fpm.patch
+diff -u sapi/fpm/php-fpm.conf.in.orig sapi/fpm/php-fpm.conf.in | filterdiff --clean --remove-timestamps >> ../../php-fpm.patch
+diff -u sapi/fpm/www.conf.in.orig sapi/fpm/www.conf.in | filterdiff --clean --remove-timestamps >> ../../php-fpm.patch
+diff -u sapi/fpm/php-fpm.service.in.orig sapi/fpm/php-fpm.service.in | filterdiff --clean --remove-timestamps >> ../../php-fpm.patch
+
+diff -u php.ini-production.orig php.ini-production | filterdiff --clean --remove-timestamps > ../../php.ini.patch
+
+popd

--- a/extra/php-lfs/php-fpm.install
+++ b/extra/php-lfs/php-fpm.install
@@ -1,0 +1,9 @@
+post_install() {
+	if [[ ! -d run/php-fpm ]]; then
+		usr/bin/systemd-tmpfiles --create php-fpm.conf
+	fi
+}
+
+post_upgrade() {
+	post_install
+}

--- a/extra/php-lfs/php-fpm.patch
+++ b/extra/php-lfs/php-fpm.patch
@@ -1,0 +1,74 @@
+--- sapi/fpm/Makefile.frag.orig
++++ sapi/fpm/Makefile.frag
+@@ -12,8 +12,8 @@
+ 
+ 	@echo "Installing PHP FPM config:        $(INSTALL_ROOT)$(sysconfdir)/" && \
+ 	$(mkinstalldirs) $(INSTALL_ROOT)$(sysconfdir)/php-fpm.d || :
+-	@$(INSTALL_DATA) sapi/fpm/php-fpm.conf $(INSTALL_ROOT)$(sysconfdir)/php-fpm.conf.default || :
+-	@$(INSTALL_DATA) sapi/fpm/www.conf $(INSTALL_ROOT)$(sysconfdir)/php-fpm.d/www.conf.default || :
++	@$(INSTALL_DATA) sapi/fpm/php-fpm.conf $(INSTALL_ROOT)$(sysconfdir)/php-fpm.conf || :
++	@$(INSTALL_DATA) sapi/fpm/www.conf $(INSTALL_ROOT)$(sysconfdir)/php-fpm.d/www.conf || :
+ 
+ 	@echo "Installing PHP FPM man page:      $(INSTALL_ROOT)$(mandir)/man8/"
+ 	@$(mkinstalldirs) $(INSTALL_ROOT)$(mandir)/man8
+--- sapi/fpm/php-fpm.conf.in.orig
++++ sapi/fpm/php-fpm.conf.in
+@@ -14,14 +14,14 @@
+ ; Pid file
+ ; Note: the default prefix is @EXPANDED_LOCALSTATEDIR@
+ ; Default Value: none
+-;pid = run/php-fpm.pid
++;pid = /run/php-fpm/php-fpm.pid
+ 
+ ; Error log file
+ ; If it's set to "syslog", log is sent to syslogd instead of being written
+ ; in a local file.
+ ; Note: the default prefix is @EXPANDED_LOCALSTATEDIR@
+ ; Default Value: log/php-fpm.log
+-;error_log = log/php-fpm.log
++error_log = syslog
+ 
+ ; syslog_facility is used to specify what type of program is logging the
+ ; message. This lets syslogd specify that messages from different facilities
+--- sapi/fpm/www.conf.in.orig
++++ sapi/fpm/www.conf.in
+@@ -33,7 +33,7 @@
+ ;                            (IPv6 and IPv4-mapped) on a specific port;
+ ;   '/path/to/unix/socket' - to listen on a unix socket.
+ ; Note: This value is mandatory.
+-listen = 127.0.0.1:9000
++listen = /run/php-fpm/php-fpm.sock
+ 
+ ; Set listen(2) backlog.
+ ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
+@@ -44,8 +44,8 @@
+ ; BSD-derived systems allow connections regardless of permissions.
+ ; Default Values: user and group are set as the running user
+ ;                 mode is set to 0660
+-;listen.owner = @php_fpm_user@
+-;listen.group = @php_fpm_group@
++listen.owner = @php_fpm_user@
++listen.group = @php_fpm_group@
+ ;listen.mode = 0660
+ ; When POSIX Access Control Lists are supported you can set them using
+ ; these options, value is a comma separated list of user/group names.
+@@ -352,7 +352,7 @@
+ ; Chdir to this directory at the start.
+ ; Note: relative path can be used.
+ ; Default Value: current directory or / when chroot
+-;chdir = /var/www
++;chdir = /srv/http
+ 
+ ; Redirect worker stdout and stderr into main error log. If not set, stdout and
+ ; stderr will be redirected to /dev/null according to FastCGI specs.
+--- sapi/fpm/php-fpm.service.in.orig
++++ sapi/fpm/php-fpm.service.in
+@@ -4,7 +4,7 @@
+ 
+ [Service]
+ Type=@php_fpm_systemd@
+-PIDFile=@localstatedir@/run/php-fpm.pid
++PIDFile=/run/php-fpm/php-fpm.pid
+ ExecStart=@sbindir@/php-fpm --nodaemonize --fpm-config @sysconfdir@/php-fpm.conf
+ ExecReload=/bin/kill -USR2 $MAINPID
+ 

--- a/extra/php-lfs/php-fpm.tmpfiles
+++ b/extra/php-lfs/php-fpm.tmpfiles
@@ -1,0 +1,1 @@
+d /run/php-fpm 755 root root

--- a/extra/php-lfs/php.ini.patch
+++ b/extra/php-lfs/php.ini.patch
@@ -1,0 +1,96 @@
+--- php.ini-production.orig
++++ php.ini-production
+@@ -719,7 +719,7 @@
+ 
+ ; Directory in which the loadable extensions (modules) reside.
+ ; http://php.net/extension-dir
+-; extension_dir = "./"
++extension_dir = "/usr/lib/php/modules/"
+ ; On windows:
+ ; extension_dir = "ext"
+ 
+@@ -857,46 +857,44 @@
+ ; If you only provide the name of the extension, PHP will look for it in its
+ ; default extension directory.
+ ;
+-; Windows Extensions
+-; Note that ODBC support is built in, so no dll is needed for it.
+-; Note that many DLL files are located in the extensions/ (PHP 4) ext/ (PHP 5+)
+-; extension folders as well as the separate PECL DLL download (PHP 5+).
+-; Be sure to appropriately set the extension_dir directive.
+-;
+-;extension=php_bz2.dll
+-;extension=php_curl.dll
+-;extension=php_fileinfo.dll
+-;extension=php_gd2.dll
+-;extension=php_gettext.dll
+-;extension=php_gmp.dll
+-;extension=php_intl.dll
+-;extension=php_imap.dll
+-;extension=php_interbase.dll
+-;extension=php_ldap.dll
+-;extension=php_mbstring.dll
+-;extension=php_exif.dll      ; Must be after mbstring as it depends on it
+-;extension=php_mysqli.dll
+-;extension=php_oci8_12c.dll  ; Use with Oracle Database 12c Instant Client
+-;extension=php_openssl.dll
+-;extension=php_pdo_firebird.dll
+-;extension=php_pdo_mysql.dll
+-;extension=php_pdo_oci.dll
+-;extension=php_pdo_odbc.dll
+-;extension=php_pdo_pgsql.dll
+-;extension=php_pdo_sqlite.dll
+-;extension=php_pgsql.dll
+-;extension=php_shmop.dll
+-
+-; The MIBS data available in the PHP distribution must be installed.
+-; See http://www.php.net/manual/en/snmp.installation.php
+-;extension=php_snmp.dll
+-
+-;extension=php_soap.dll
+-;extension=php_sockets.dll
+-;extension=php_sqlite3.dll
+-;extension=php_tidy.dll
+-;extension=php_xmlrpc.dll
+-;extension=php_xsl.dll
++;extension=bcmath.so
++;extension=bz2.so
++;extension=calendar.so
++extension=curl.so
++;extension=dba.so
++;extension=enchant.so
++;extension=exif.so
++;extension=ftp.so
++;extension=gd.so
++;extension=gettext.so
++;extension=gmp.so
++;extension=iconv.so
++;extension=imap.so
++;extension=intl.so
++;extension=ldap.so
++;extension=mcrypt.so
++;extension=mysqli.so
++;extension=odbc.so
++;zend_extension=opcache.so
++;extension=pdo_dblib.so
++;extension=pdo_mysql.so
++;extension=pdo_odbc.so
++;extension=pdo_pgsql.so
++;extension=pdo_sqlite.so
++;extension=pgsql.so
++;extension=pspell.so
++;extension=shmop.so
++;extension=snmp.so
++;extension=soap.so
++;extension=sockets.so
++;extension=sqlite3.so
++;extension=sysvmsg.so
++;extension=sysvsem.so
++;extension=sysvshm.so
++;extension=tidy.so
++;extension=xmlrpc.so
++;extension=xsl.so
++extension=zip.so
+ 
+ ;;;;;;;;;;;;;;;;;;;
+ ; Module Settings ;


### PR DESCRIPTION
On 32-bit architectures, glibc will use 32-bit integers for filesizes, which have a maximum limit of ~2GB. Compiling programs with `-D_FILE_OFFSET_BITS=64` allows a program to use 64-bit integers instead, with no other code changes. However, it seems that this change is incompatible with Apache, and will cause it to hang. This PR brings a new set of packages, `php-lfs-*`, which are compiled with the 64-bit flag and replace the standard `php-*` packages with the appropriate `replaces`, `conflicts` and `provides` options. There is no `php-lfs-apache` for obvious reasons, but all other packages are mirrored in this way.

I haven't performed the clean chroot build test yet, will update with the progress (and whether this flag actually works or not)