### PR TITLE
core/linux-imx6: Fix CEC for first Wandboard Quad Revision

### DIFF
--- a/core/linux-imx6/PKGBUILD
+++ b/core/linux-imx6/PKGBUILD
@@ -12,7 +12,7 @@ _srcname=linux-fslc-sr-${_commit}
 _kernelname=${pkgname#linux}
 _basekernel=3.14
 pkgver=${_basekernel}.66
-pkgrel=1
+pkgrel=2
 cryptodev_commit=bc67142c57eadc0aafd0323ec527849012786643
 
 arch=('armv7h')

--- a/core/linux-imx6/fix_cec_revb1.patch
+++ b/core/linux-imx6/fix_cec_revb1.patch
@@ -1,0 +1,13 @@
+diff -ruN a/arch/arm/boot/dts/imx6q-wandboard.dts b/a/arch/arm/boot/dts/imx6q-wandboard.dts
+--- a/arch/arm/boot/dts/imx6q-wandboard.dts       2016-04-11 16:29:53.056465812 +0200
++++ b/arch/arm/boot/dts/imx6q-wandboard.dts       2016-04-11 16:30:14.772737499 +0200
+@@ -46,3 +46,9 @@
+ &sata {
+        status = "okay";
+ };
++
++&hdmi_cec {
++       pinctrl-names = "default";
++       pinctrl-0 = <&pinctrl_hdmi_cec_2>;
++       status = "okay";
++};


### PR DESCRIPTION
To enable CEC on Rev B1 follow this guide: https://project-insanity.org/blog/2014/01/24/wandboard-with-hdmi-cec-and-xbmc/