### PR TITLE
community/mythtv: Fix libudfread compilation error

### DIFF
--- a/community/mythtv/0001-fix_libudfread.patch
+++ b/community/mythtv/0001-fix_libudfread.patch
@@ -1,0 +1,13 @@
+diff --git a/mythtv/external/libudfread/libudfread.pro b/mythtv/external/libudfread/libudfread.pro
+index 14a9af3..169aabd 100644
+--- a/mythtv/external/libudfread/libudfread.pro
++++ b/mythtv/external/libudfread/libudfread.pro
+@@ -14,6 +14,8 @@ win32-msvc* {
+ 
+     # needed for nmake
+     QMAKE_CFLAGS   += "/FI ../../libs/libmythbase/compat.h"
++} else {
++    DEFINES += HAVE_PTHREAD_H
+ }
+ 
+ QMAKE_CLEAN += $(TARGET)

--- a/community/mythtv/PKGBUILD
+++ b/community/mythtv/PKGBUILD
@@ -11,7 +11,7 @@
 
 pkgname=mythtv
 pkgver=0.28
-pkgrel=3
+pkgrel=4
 epoch=1
 pkgdesc="A Homebrew PVR project"
 arch=('i686' 'x86_64')
@@ -31,14 +31,16 @@ conflicts=('myththemes' 'mythplugins-mythvideo')
 replaces=('myththemes' 'mythplugins-mythvideo')
 install='mythtv.install'
 source=("$pkgname-$pkgver.tar.gz::https://github.com/MythTV/$pkgname/archive/v$pkgver.tar.gz"
-        'mythbackend.service' '99-mythbackend.rules')
-sha256sums=('3b0028c8f86e1cdeb722ac54f9e0aa6e72d30f2e94fd8ae0a2c177d7bc1e1216'
+        'mythbackend.service' '99-mythbackend.rules' '0001-fix_libudfread.patch')
+sha256sums=('7b3476c0ec0fc17d6b734f0440383815e81850a70b78c12ee40d61a408eba340'
             'ecfde779ded8332cc62c86fac6b432b09cbf5d254135798287ada688af9a1302'
-            'ecfd02bbbef5de9773f4de2c52e9b2b382ce8137735f249d7900270d304fd333')
+            'ecfd02bbbef5de9773f4de2c52e9b2b382ce8137735f249d7900270d304fd333'
+            '135d08996e327e916e50294260d96894968f59bb9f71b10a7fbb722e28697d95')
 
 prepare() {
   cd $pkgname-$pkgver/$pkgname
 
+  patch -Np2 -i ${srcdir}/0001-fix_libudfread.patch
   find 'bindings/python' 'contrib' 'programs/scripts' -type f | xargs sed -i 's@^#!.*python$@#!/usr/bin/python2@'
 }
 

--- a/community/mythtv/PKGBUILD
+++ b/community/mythtv/PKGBUILD
@@ -11,7 +11,7 @@
 
 pkgname=mythtv
 pkgver=0.28
-pkgrel=4
+pkgrel=3
 epoch=1
 pkgdesc="A Homebrew PVR project"
 arch=('i686' 'x86_64')


### PR DESCRIPTION
Fix the following error:
udfread.c:104:3: error: #error no atomic operation support

Inspired by mythtv/external/libmythbluray/libmythbluray.pro.
Also, the upstream tarball seems to have changed, so its checksum had to be updated.
