### PR TITLE
build 64 bit package for swt when on aarch64

### DIFF
--- a/extra/swt/PKGBUILD
+++ b/extra/swt/PKGBUILD
@@ -16,10 +16,17 @@ license=('EPL')
 depends=('java-runtime>=6' 'gtk2>=2.20.1' 'libxtst')
 optdepends=('libgnomeui' 'glu' 'webkitgtk2')
 makedepends=('java-environment' 'libxtst' 'glu' 'libgnomeui' 'unzip' 'pkgconfig' 'webkitgtk2' 'apache-ant')
-source=(http://download.eclipse.org/eclipse/downloads/drops4/R-${pkgver}-${_date}/swt-${pkgver}-gtk-linux-x86.zip
-        build-swt.xml)
-sha256sums=('180cf993af914726e6da9abe669a636b057e9353058e76be7644b31955feb00e'
-            '6bb48007a95e3d8c6b577cc9cc4b61a51ce928b04f4fcd393cf72f8f727fe923')
+source=(build-swt.xml)
+sha256sums=('6bb48007a95e3d8c6b577cc9cc4b61a51ce928b04f4fcd393cf72f8f727fe923')
+
+if [ "$CARCH" = "aarch64" ]; then
+        source+=(http://download.eclipse.org/eclipse/downloads/drops4/R-${pkgver}-${_date}/swt-${pkgver}-gtk-linux-x86_64.zip)
+		sha256sums+=('ce89cb9dea5bef927873cbc377a81b5d9f1995622e42402bd9600043a9bc00e3')
+else
+		source+=(http://download.eclipse.org/eclipse/downloads/drops4/R-${pkgver}-${_date}/swt-${pkgver}-gtk-linux-x86.zip)
+		sha256sums+=('180cf993af914726e6da9abe669a636b057e9353058e76be7644b31955feb00e')
+fi
+	
 
 # These examples don't even run anymore (Try Tux Guitar instead)!
 # http://www.eclipse.org/swt/examples.php#standaloneOutsideEclipse


### PR DESCRIPTION
On aarch64 swt can not been loaded because it is built for 32 bit architecture. 
Example output when trying to load it:

`Exception in thread "main" java.lang.UnsatisfiedLinkError: Cannot load 32-bit SWT libraries on 64-bit JVM
	at org.eclipse.swt.internal.Library.loadLibrary(Unknown Source)
	at org.eclipse.swt.internal.Library.loadLibrary(Unknown Source)
	at org.eclipse.swt.internal.C.<clinit>(Unknown Source)
	at org.eclipse.swt.internal.Converter.wcsToMbcs(Unknown Source)
	at org.eclipse.swt.internal.Converter.wcsToMbcs(Unknown Source)
	at org.eclipse.swt.widgets.Display.<clinit>(Unknown Source)
	at de.willuhn.jameica.gui.GUI.getDisplay(GUI.java:956)
	at de.willuhn.jameica.gui.SplashScreen.<init>(SplashScreen.java:86)
	at de.willuhn.jameica.system.ApplicationCallbackSWT.getStartupMonitor(ApplicationCallbackSWT.java:175)
	at de.willuhn.jameica.system.Application.init(Application.java:100)
	at de.willuhn.jameica.system.Application.newInstance(Application.java:90)
	at de.willuhn.jameica.Main.main(Main.java:78)
`