### PR TITLE
 MongoDB: Force mmapv1 to be compiled in

### DIFF
--- a/community/mongodb/PKGBUILD
+++ b/community/mongodb/PKGBUILD
@@ -10,9 +10,12 @@
 #  - patches
 #  - specify mmapv1 as the default storage engine in mongodb.conf
 
+# ALARM: Thomas P. <tpxp@live.fr>
+#  - force mmapv1 to be compiled in the build
+
 pkgname=mongodb
 pkgver=3.2.6
-pkgrel=1
+pkgrel=1.1
 pkgdesc='A high-performance, open source, schema-free document-oriented database'
 arch=('i686' 'x86_64')
 url='http://www.mongodb.org'
@@ -54,6 +57,8 @@ _scons_args=(
   --use-sasl-client
   --ssl
   --disable-warnings-as-errors
+  --mmapv1=on
+  # Force mmapv1 to be compiled in - By default mmapv1 is disabled due to this commit : https://github.com/mongodb/mongo/commit/ff8061cd1d97e99f141b02a7fe36e83f302b909c
   # --use-system-asio     # https://jira.mongodb.org/browse/SERVER-21839
   # --use-system-v8       # Doesn't compile
   # --use-system-tcmalloc # Disabled as upstream suggests in https://jira.mongodb.org/browse/SERVER-17447?focusedCommentId=841890&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-841890


### PR DESCRIPTION
By default, MongoDB 3.2.5 dropped the only storage engine that was available on 32-bits ARM platforms : `mmapv1`. This prevents MongoDB from working properly as seen [on the forums](https://archlinuxarm.org/forum/viewtopic.php?f=15&t=10236).

This commit forces mmapv1 to be included on all ARM platforms, so that MongoDB works properly even straight out of the box. Indeed, on first start, MongoDB will try to initialize the database using the storage engine in the configuration file (`mmapv1`), which was not included by default.