### PR TITLE
Add seperate uboot-odroid-xu4

### DIFF
--- a/alarm/uboot-odroid-xu4/PKGBUILD
+++ b/alarm/uboot-odroid-xu4/PKGBUILD
@@ -1,0 +1,33 @@
+# U-Boot: ODROID XU4
+# Maintainer: Kevin Mihelich <kevin@archlinuxarm.org>
+
+buildarch=4
+
+pkgname=uboot-odroid-xu4
+pkgver=2012.07
+pkgrel=3
+pkgdesc="U-Boot for ODROID-XU4"
+arch=('armv7h')
+url="https://github.com/hardkernel/linux/tree/odroidxu3-3.10.y"
+license=('GPL')
+install=$pkgname.install
+backup=('boot/boot.ini')
+_commit=814386d3e43b8ab8d81f04aa7fe402952503d8fe
+source=("https://github.com/hardkernel/linux/raw/${_commit}/tools/hardkernel/prebuilt_uboot/bl1.bin"
+        "https://github.com/hardkernel/linux/raw/${_commit}/tools/hardkernel/prebuilt_uboot/bl2.bin"
+        "https://github.com/hardkernel/linux/raw/${_commit}/tools/hardkernel/prebuilt_uboot/tzsw.bin"
+        "https://github.com/hardkernel/linux/raw/${_commit}/tools/hardkernel/prebuilt_uboot/u-boot.bin"
+        'sd_fusing.sh'
+        'boot.ini')
+md5sums=('3908379f82f972ece88ca1b5a280b5fd'
+         '8580c2b2701bf5936f42104b3cc5d725'
+         'fd01dda20b999e0b731c7063431a42b3'
+         '85ff8b8e20fe4c7639ed87781f473512'
+         'b5616d1971ac48e93e2f92f8cd8eeba8'
+         '9e3083f40a05692c41f92f0439be0243')
+
+package() {
+  mkdir -p "${pkgdir}"/boot
+  cp {bl{1,2},tzsw,u-boot}.bin sd_fusing.sh boot.ini "${pkgdir}"/boot
+  chmod +x "${pkgdir}"/boot/sd_fusing.sh
+}

--- a/alarm/uboot-odroid-xu4/boot.ini
+++ b/alarm/uboot-odroid-xu4/boot.ini
@@ -1,0 +1,46 @@
+ODROIDXU-UBOOT-CONFIG
+
+# U-Boot Parameters
+setenv initrd_high "0xffffffff"
+setenv fdt_high "0xffffffff"
+
+# Mac address configuration
+setenv macaddr "00:1e:06:61:7a:39"
+
+#------------------------------------------------------------------------------------------------------
+# Basic Arch Linux ARM Setup. Don't touch unless you know what you are doing.
+# --------------------------------
+setenv bootrootfs "console=tty1 console=ttySAC2,115200n8 root=/dev/mmcblk0p1 rootwait rw"
+
+# boot commands
+setenv bootcmd "ext4load mmc 0:1 0x40008000 /boot/zImage; ext4load mmc 0:1 0x44000000 /boot/dtbs/exynos5422-odroidxu3.dtb; bootz 0x40008000 - 0x44000000"
+
+# --- Screen Configuration for HDMI --- # 
+# ---------------------------------------
+# Uncomment only ONE line! Leave all commented for automatic selection.
+# Uncomment only the setenv line!
+# ---------------------------------------
+# ODROID-VU forced resolution
+# setenv videoconfig "video=HDMI-A-1:1280x800@60"
+# -----------------------------------------------
+# 1920x1080 (1080P) with monitor provided EDID information. (1080p-edid)
+# setenv videoconfig "video=HDMI-A-1:1920x1080@60"
+# -----------------------------------------------
+# 1920x1080 (1080P) without monitor data using generic information (1080p-noedid)
+# setenv videoconfig "drm_kms_helper.edid_firmware=edid/1920x1080.bin"
+# -----------------------------------------------
+# 1280x720 (720P) with monitor provided EDID information. (720p-edid)
+# setenv videoconfig "video=HDMI-A-1:1280x720@60"
+# -----------------------------------------------
+# 1280x720 (720P) without monitor data using generic information (720p-noedid)
+# setenv videoconfig "drm_kms_helper.edid_firmware=edid/1280x720.bin"
+# -----------------------------------------------
+# 1024x768 without monitor data using generic information
+# setenv videoconfig "drm_kms_helper.edid_firmware=edid/1024x768.bin"
+
+
+# final boot args
+setenv bootargs "${bootrootfs} ${videoconfig} r8152.macaddr=${macaddr}"
+# drm.debug=0xff
+# Boot the board
+boot

--- a/alarm/uboot-odroid-xu4/sd_fusing.sh
+++ b/alarm/uboot-odroid-xu4/sd_fusing.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/bash
+####################################
+#
+# Copyright (C) 2011 Samsung Electronics Co., Ltd.
+#              http://www.samsung.com/
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+####################################
+#
+# Modified for Arch Linux ARM package uboot-odroid-xu3
+#
+####################################
+
+if [ -z $1 ]
+then
+    echo "usage: ./sd_fusing.sh <SD Reader's device file>"
+    exit 0
+fi
+
+if [ -b $1 ]
+then
+    echo "$1 reader is identified."
+else
+    echo "$1 is NOT identified."
+    exit 0
+fi
+
+if [ -d /sys/block/${1##*/}boot0 ]; then
+    echo "$1 is an eMMC card, disabling ${1##*/}boot0 ro"
+    if ! echo 0 > /sys/block/${1##*/}boot0/force_ro; then
+	echo "Enabling r/w for $1boot0 failed"
+	exit 1
+    fi
+    emmc=1
+fi
+
+####################################
+# fusing images
+
+if [ -n "$emmc" ]; then
+    signed_bl1_position=0
+    bl2_position=30
+    uboot_position=62
+    tzsw_position=718
+    device=$1boot0
+else
+    signed_bl1_position=1
+    bl2_position=31
+    uboot_position=63
+    tzsw_position=719
+    device=$1
+fi
+
+#<BL1 fusing>
+echo "BL1 fusing"
+dd iflag=dsync oflag=dsync if=./bl1.bin of=$device seek=$signed_bl1_position
+
+#<BL2 fusing>
+echo "BL2 fusing"
+dd iflag=dsync oflag=dsync if=./bl2.bin of=$device seek=$bl2_position
+
+#<u-boot fusing>
+echo "u-boot fusing"
+dd iflag=dsync oflag=dsync if=./u-boot.bin of=$device seek=$uboot_position
+
+#<TrustZone S/W fusing>
+echo "TrustZone S/W fusing"
+dd iflag=dsync oflag=dsync if=./tzsw.bin of=$device seek=$tzsw_position
+
+####################################
+#<Message Display>
+echo "U-boot image is fused successfully."

--- a/alarm/uboot-odroid-xu4/uboot-odroid-xu4.install
+++ b/alarm/uboot-odroid-xu4/uboot-odroid-xu4.install
@@ -1,0 +1,54 @@
+sd_fuse() {
+  if [ ! -b /dev/mmcblk0 ]; then
+    echo "No MMC device to flash, exiting."
+    exit 0
+  fi
+
+  if [ -d /sys/block/mmcblk0boot0 ]; then
+    echo "/dev/mmcblk0 is an eMMC card, disabling read-only.."
+    if ! echo 0 > /sys/block/mmcblk0boot0/force_ro; then
+      echo "Disabling read-only for /dev/mmcblk0boot0 failed."
+      exit 1
+    fi
+    signed_bl1_position=0
+    bl2_position=30
+    uboot_position=62
+    tzsw_position=718
+    device=/dev/mmcblk0boot0
+  else
+    signed_bl1_position=1
+    bl2_position=31
+    uboot_position=63
+    tzsw_position=719
+    device=/dev/mmcblk0
+  fi
+
+  echo "BL1 fusing"
+  dd iflag=dsync oflag=dsync if=/boot/bl1.bin of=$device seek=$signed_bl1_position
+  echo "BL2 fusing"
+  dd iflag=dsync oflag=dsync if=/boot/bl2.bin of=$device seek=$bl2_position
+  echo "u-boot fusing"
+  dd iflag=dsync oflag=dsync if=/boot/u-boot.bin of=$device seek=$uboot_position
+  echo "TrustZone S/W fusing"
+  dd iflag=dsync oflag=dsync if=/boot/tzsw.bin of=$device seek=$tzsw_position
+}
+
+flash_uboot() {
+  echo "A new U-Boot version needs to be flashed onto /dev/mmcblk0."
+  echo "Do you want to do this now? [y|N]"
+  read -r shouldwe
+  if [[ $shouldwe =~ ^([yY][eE][sS]|[yY])$ ]]; then
+    sd_fuse
+  else
+    echo "You can do this later by running:"
+    echo "# cd /boot; ./sd_fusing.sh /dev/mmcblk0"
+  fi
+}
+
+post_install() {
+  flash_uboot
+}
+
+post_upgrade() {
+  flash_uboot
+}


### PR DESCRIPTION
XU4 has r8152 network driver, not smsc95xx (needed to set mac).

```patch
diff -ru uboot-odroid-xu3/boot.ini uboot-odroid-xu4/boot.ini
--- uboot-odroid-xu3/boot.ini   2016-01-08 09:54:41.725006814 +0100
+++ uboot-odroid-xu4/boot.ini   2016-05-12 13:22:43.376360459 +0200
@@ -40,7 +40,7 @@
 
 
 # final boot args
-setenv bootargs "${bootrootfs} ${videoconfig} smsc95xx.macaddr=${macaddr}"
+setenv bootargs "${bootrootfs} ${videoconfig} r8152.macaddr=${macaddr}"
 # drm.debug=0xff
 # Boot the board
 boot
diff -ru uboot-odroid-xu3/PKGBUILD uboot-odroid-xu4/PKGBUILD
--- uboot-odroid-xu3/PKGBUILD   2016-01-08 09:54:41.725006814 +0100
+++ uboot-odroid-xu4/PKGBUILD   2016-05-12 13:22:00.568915104 +0200
@@ -1,12 +1,12 @@
-# U-Boot: ODROID XU3
+# U-Boot: ODROID XU4
 # Maintainer: Kevin Mihelich <kevin@archlinuxarm.org>
 
 buildarch=4
 
-pkgname=uboot-odroid-xu3
+pkgname=uboot-odroid-xu4
 pkgver=2012.07
 pkgrel=3
-pkgdesc="U-Boot for ODROID-XU3"
+pkgdesc="U-Boot for ODROID-XU4"
 arch=('armv7h')
 url="https://github.com/hardkernel/linux/tree/odroidxu3-3.10.y"
 license=('GPL')
Only in uboot-odroid-xu3: uboot-odroid-xu3.install
Only in uboot-odroid-xu4: uboot-odroid-xu4.install
```

Another option could be to use this in uboot-odroid-xu3:
```ini
setenv bootargs "${bootrootfs} ${videoconfig} smsc95xx.macaddr=${macaddr} r8152.macaddr=${macaddr}"
```