### PR TITLE
alarm/*libgl: Fixed ldconfig prorities

### DIFF
--- a/alarm/marvell-libgfx/PKGBUILD
+++ b/alarm/marvell-libgfx/PKGBUILD
@@ -6,14 +6,14 @@ buildarch=4
 
 pkgname="marvell-libgfx"
 pkgver=0.2.0
-pkgrel=6
+pkgrel=7
 arch=('armv7h')
 url="http://archlinuxarm.org"
 license=('Proprietary')
 source=("http://archlinuxarm.org/builder/src/marvell-libgfx-0.2.0.tar.gz"
   "http://download.solid-run.com/pub/solidrun/cubox/packages/marvell-opengl/marvell-opengl-hardfp-debug.zip"
   "http://download.solid-run.com/pub/solidrun/cubox/packages/marvell-libgfx/marvell-libgfx-headers-20120713.tar.bz2"
-  "profile.sh"
+  "marvell-libgfx.conf"
 )
 provides=('libegl' 'libgles' 'khrplatform-devel')
 

--- a/alarm/marvell-libgfx/marvell-libgfx.conf
+++ b/alarm/marvell-libgfx/marvell-libgfx.conf
@@ -1,0 +1,2 @@
+/opt/marvell-libgfx/lib
+/usr/lib/mesa

--- a/alarm/marvell-libgfx/profile.sh
+++ b/alarm/marvell-libgfx/profile.sh
@@ -1,1 +1,0 @@
-export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/marvell-libgfx/lib"

--- a/alarm/odroid-c1-libgl/PKGBUILD
+++ b/alarm/odroid-c1-libgl/PKGBUILD
@@ -6,22 +6,21 @@ buildarch=4
 pkgbase=odroid-c1-libgl
 pkgname=("${pkgbase}-x11" "${pkgbase}-fb" "${pkgbase}-headers")
 pkgver=r5p0
-pkgrel=3
+pkgrel=4
 _commit=31d5c21180f4d2f160332c7018ec91f8e43ca8bf
 arch=('armv7h')
 url="http://www.hardkernel.com/"
 license=('Proprietary')
-depends=('mesa-libgl')
 makedepends=('git')
 source=("git+https://github.com/mdrjr/c1_mali_libs.git#commit=${_commit}"
         'mali-c1.conf')
 md5sums=('SKIP'
-         '40f5104200cfceb12b4623d219646d4e')
+         '0b2d7cfb2a6e03ba26799c0a574e4e92')
 
 package_odroid-c1-libgl-x11() {
   pkgdesc="ODROID-C1 Mali driver (X11)"
-  conflicts=('odroid-c1-libgl')
-  provides=('odroid-c1-libgl')
+  conflicts=('odroid-c1-libgl' 'mesa-libgl')
+  provides=('odroid-c1-libgl' 'libgl')
   replaces=('odroid-c1-libgl')
 
   install -d "${pkgdir}"/usr/lib/mali-egl
@@ -32,8 +31,8 @@ package_odroid-c1-libgl-x11() {
 
 package_odroid-c1-libgl-fb() {
   pkgdesc="ODROID-C1 Mali driver (framebuffer)"
-  conflicts=('odroid-c1-libgl')
-  provides=('odroid-c1-libgl')
+  conflicts=('odroid-c1-libgl' 'mesa-libgl')
+  provides=('odroid-c1-libgl' 'libgl')
 
   install -d "${pkgdir}"/usr/lib/mali-egl
   install -d "${pkgdir}"/etc/ld.so.conf.d

--- a/alarm/odroid-c1-libgl/mali-c1.conf
+++ b/alarm/odroid-c1-libgl/mali-c1.conf
@@ -1,1 +1,2 @@
 /usr/lib/mali-egl
+/usr/lib/mesa

--- a/alarm/odroid-c2-libgl/PKGBUILD
+++ b/alarm/odroid-c2-libgl/PKGBUILD
@@ -6,22 +6,21 @@ buildarch=8
 pkgbase=odroid-c2-libgl
 pkgname=("${pkgbase}-fb")
 pkgver=r5p1
-pkgrel=1
+pkgrel=2
 _commit=228b2e75bea3426661437d5642fbae3a376895fd
 arch=('aarch64')
 url="http://www.hardkernel.com/"
 license=('Proprietary')
-depends=('mesa-libgl')
 makedepends=('git')
 source=("git+https://github.com/mdrjr/c2_mali.git#commit=${_commit}"
         'mali-c2.conf')
 md5sums=('SKIP'
-         '40f5104200cfceb12b4623d219646d4e')
+         '0b2d7cfb2a6e03ba26799c0a574e4e92')
 
 package_odroid-c2-libgl-fb() {
   pkgdesc="ODROID-C2 Mali driver (framebuffer)"
-  conflicts=('odroid-c2-libgl')
-  provides=('odroid-c2-libgl')
+  conflicts=('odroid-c2-libgl' 'mesa-libgl')
+  provides=('odroid-c2-libgl' 'libgl')
 
   install -d "${pkgdir}"/usr/lib/mali-egl
   install -d "${pkgdir}"/etc/ld.so.conf.d

--- a/alarm/odroid-c2-libgl/mali-c2.conf
+++ b/alarm/odroid-c2-libgl/mali-c2.conf
@@ -1,1 +1,2 @@
 /usr/lib/mali-egl
+/usr/lib/mesa

--- a/alarm/odroid-libgl/PKGBUILD
+++ b/alarm/odroid-libgl/PKGBUILD
@@ -5,16 +5,17 @@ buildarch=4
 
 pkgname=odroid-libgl
 pkgver=r5p0
-pkgrel=1
+pkgrel=2
 arch=('armv7h')
 pkgdesc="ODROID-X/X2/U2/U3 Mali GL Driver"
 url="http://www.hardkernel.com/"
 license=('Proprietary')
-depends=('mesa-libgl')
+conflicts=('mesa-libgl')
+provides=('libgl' 'odroid-libgl')
 source=("http://archlinuxarm.org/builder/src/4412_r5p0_x11.tar.xz"
         'mali-odroid.conf')
 md5sums=('fd096d1fc0762fe8e799a9c78c259f36'
-         '40f5104200cfceb12b4623d219646d4e')
+         '0b2d7cfb2a6e03ba26799c0a574e4e92')
 
 package() {
   install -d "${pkgdir}"/usr/lib/mali-egl

--- a/alarm/odroid-libgl/mali-odroid.conf
+++ b/alarm/odroid-libgl/mali-odroid.conf
@@ -1,1 +1,2 @@
 /usr/lib/mali-egl
+/usr/lib/mesa

--- a/alarm/odroid-xu3-libgl/PKGBUILD
+++ b/alarm/odroid-xu3-libgl/PKGBUILD
@@ -6,22 +6,23 @@ buildarch=4
 pkgbase=odroid-xu3-libgl
 pkgname=("${pkgbase}-x11" "${pkgbase}-fb" "${pkgbase}-headers")
 pkgver=r9p0
-pkgrel=1
+pkgrel=2
 _commit=543eb787af5719224c2231490d5ebda71c1ec7a8
 arch=('armv7h')
 url="http://www.hardkernel.com/"
 license=('Proprietary')
-depends=('mesa-libgl')
+conflicts=('mesa-libgl')
+provides=('libgl' 'odroid-xu3-libgl')
 makedepends=('git')
 source=("git+https://github.com/mdrjr/5422_mali.git#commit=${_commit}"
         'mali-xu3.conf')
 md5sums=('SKIP'
-         '40f5104200cfceb12b4623d219646d4e')
+         '0b2d7cfb2a6e03ba26799c0a574e4e92')
 
 package_odroid-xu3-libgl-x11() {
   pkgdesc="ODROID-XU3/XU4 Mali driver (X11)"
-  conflicts=('odroid-xu3-libgl')
-  provides=('odroid-xu3-libgl')
+  conflicts=('odroid-xu3-libgl' 'mesa-libgl')
+  provides=('odroid-xu3-libgl' 'libgl')
 
   install -d "${pkgdir}"/usr/lib/mali-egl
   install -d "${pkgdir}"/etc/ld.so.conf.d
@@ -31,8 +32,8 @@ package_odroid-xu3-libgl-x11() {
 
 package_odroid-xu3-libgl-fb() {
   pkgdesc="ODROID-XU3/XU4 Mali driver (framebuffer)"
-  conflicts=('odroid-xu3-libgl')
-  provides=('odroid-xu3-libgl')
+  conflicts=('odroid-xu3-libgl' 'mesa-libgl')
+  provides=('odroid-xu3-libgl' 'libgl')
 
   install -d "${pkgdir}"/usr/lib/mali-egl
   install -d "${pkgdir}"/etc/ld.so.conf.d

--- a/alarm/odroid-xu3-libgl/mali-xu3.conf
+++ b/alarm/odroid-xu3-libgl/mali-xu3.conf
@@ -1,1 +1,2 @@
 /usr/lib/mali-egl
+/usr/lib/mesa

--- a/alarm/veyron-libgl/PKGBUILD
+++ b/alarm/veyron-libgl/PKGBUILD
@@ -5,17 +5,18 @@ buildarch=4
 
 pkgname=veyron-libgl
 pkgver=r5p0
-pkgrel=3
+pkgrel=4
 arch=('armv7h')
 pkgdesc="Veyron Chromebook Mali GL Driver"
 url="http://www.google.com/"
 license=('Proprietary')
-depends=('mesa-libgl')
+conflicts=('mesa-libgl')
+provides=('libgl' 'veyron-libgl')
 source=("http://commondatastorage.googleapis.com/chromeos-localmirror/distfiles/mali-drivers-veyron-x11-1.20-r26.run"
         'mali-veyron.conf'
         '50-mali.rules')
 md5sums=('39beb1579c9960e38faa462329eb83f2'
-         '40f5104200cfceb12b4623d219646d4e'
+         '0b2d7cfb2a6e03ba26799c0a574e4e92'
          'd22820a21496fe3d9ccbae99643aac96')
 
 prepare() {

--- a/alarm/veyron-libgl/mali-veyron.conf
+++ b/alarm/veyron-libgl/mali-veyron.conf
@@ -1,1 +1,2 @@
 /usr/lib/mali-egl
+/usr/lib/mesa


### PR DESCRIPTION
A while ago my egl (read: wobbly windows and other acceleration) stopped working on veyron_minnie, I finally got around to fixing it. Luckily I had an sd card with an old rootfs that still worked, so I compared the two:

Old rootfs, working: https://bpaste.net/show/6b6dafaa6482
New rootfs, broken: https://bpaste.net/show/376cbfd12f87

Note how the new one now tried to use /usr/lib/libGLESv2.so.2 (owned by `mesa-libgl`) instead of /usr/lib/mali-egl/libGLESv2.so.2 (`veyron-libgl`).

Here's my take at fixing it.

These commits totally replace `mesa-libgl` with the individual drivers (I mark `mesa-libgl` as a conflict) and just let the .so files in `mesa` as a fallback for libGL.so.

Note: the .so files in `mesa` and `libgl-mesa` match:

    alex@alex-veyron:~% pacman -Ql|grep libEGL.so.1.0.0
    mesa /usr/lib/mesa/libEGL.so.1.0.0
    mesa-libgl /usr/lib/libEGL.so.1.0.0
    alex@alex-veyron:~% md5sum /usr/lib/libEGL.so.1.0.0
    776281a4a4876d848bcf10abc1ab0009  /usr/lib/libEGL.so.1.0.0
    alex@alex-veyron:~% md5sum /usr/lib/mesa/libEGL.so.1.0.0
    776281a4a4876d848bcf10abc1ab0009  /usr/lib/mesa/libEGL.so.1.0.0

*Note: Please don't merge the second commit yet, still needs work.*

![PCMR: Wobbly windows are back](https://i.imgflip.com/14o2eu.jpg)