### PR TITLE
extra/mesa: new package mesa-wayland-egl

### DIFF
--- a/extra/mesa/PKGBUILD
+++ b/extra/mesa/PKGBUILD
@@ -9,8 +9,12 @@
 #  - Build vc4 gallium driver for v6/v7
 #  - Keep prepare function for older llvm (remove when llvm is fixed)
 
+# ALARM: Michael Serpieri <mickybart@pygoscelis.org>
+#  - Move libwayland-egl library to a new package mesa-wayland-egl
+#    to support different providers for libwayland-egl (eg: libhybris) in the same way than libgl
+
 pkgbase=mesa
-pkgname=('mesa' 'mesa-libgl' 'libva-mesa-driver')
+pkgname=('mesa' 'mesa-libgl' 'mesa-wayland-egl' 'libva-mesa-driver')
 pkgver=11.2.2
 pkgrel=1.1
 arch=('i686' 'x86_64')
@@ -105,17 +109,18 @@ package_mesa() {
   cp -rv ${srcdir}/fakeinstall/usr/lib/d3d  ${pkgdir}/usr/lib
   cp -rv ${srcdir}/fakeinstall/usr/lib/lib{gbm,glapi}.so* ${pkgdir}/usr/lib/
   cp -rv ${srcdir}/fakeinstall/usr/lib/libOSMesa.so* ${pkgdir}/usr/lib/
-  cp -rv ${srcdir}/fakeinstall/usr/lib/libwayland*.so* ${pkgdir}/usr/lib/
 
   cp -rv ${srcdir}/fakeinstall/usr/include ${pkgdir}/usr
   cp -rv ${srcdir}/fakeinstall/usr/lib/pkgconfig ${pkgdir}/usr/lib/
-  rm ${pkgdir}/usr/lib/pkgconfig/{egl,gl,glesv1_cm,glesv2}.pc
+  rm ${pkgdir}/usr/lib/pkgconfig/{egl,gl,glesv1_cm,glesv2,wayland-egl}.pc
 
   install -m755 -d ${pkgdir}/usr/lib/mesa
   # move libgl/EGL/glesv*.so to not conflict with blobs - may break .pc files ?
   cp -rv ${srcdir}/fakeinstall/usr/lib/libGL.so* 	${pkgdir}/usr/lib/mesa/
   cp -rv ${srcdir}/fakeinstall/usr/lib/libEGL.so* 	${pkgdir}/usr/lib/mesa/
   cp -rv ${srcdir}/fakeinstall/usr/lib/libGLES*.so*	${pkgdir}/usr/lib/mesa/
+  # move libwayland*.so* to not conflict with other providers like libhybris - may break .pc files ?
+  cp -rv ${srcdir}/fakeinstall/usr/lib/libwayland*.so* ${pkgdir}/usr/lib/mesa/
 
   install -m755 -d "${pkgdir}/usr/share/licenses/mesa"
   install -m644 "${srcdir}/LICENSE" "${pkgdir}/usr/share/licenses/mesa/"
@@ -123,7 +128,7 @@ package_mesa() {
 
 package_mesa-libgl() {
   pkgdesc="Mesa 3-D graphics library"
-  depends=('mesa')
+  depends=('mesa' 'mesa-wayland-egl')
   provides=('libgl')
   replaces=('libgl')
 
@@ -153,3 +158,18 @@ package_mesa-libgl() {
   install -m755 -d "${pkgdir}/usr/share/licenses/mesa-libgl"
   install -m644 "${srcdir}/LICENSE" "${pkgdir}/usr/share/licenses/mesa-libgl/"
 }
+
+package_mesa-wayland-egl() {
+  pkgdesc="Mesa 3-D wayland library"
+  depends=('mesa')
+  provides=('libwayland-egl')
+  replaces=('libwayland-egl')
+
+  install -m755 -d ${pkgdir}/usr/lib/pkgconfig
+  cp ${srcdir}/fakeinstall/usr/lib/pkgconfig/wayland-egl.pc ${pkgdir}/usr/lib/pkgconfig
+
+  ln -s /usr/lib/mesa/libwayland-egl.so.1.0.0 ${pkgdir}/usr/lib/libwayland-egl.so.1.0.0
+  ln -s libwayland-egl.so.1.0.0 ${pkgdir}/usr/lib/libwayland-egl.so.1
+  ln -s libwayland-egl.so.1.0.0 ${pkgdir}/usr/lib/libwayland-egl.so
+}
+


### PR DESCRIPTION
Package mesa-wayland-egl handles libwayland-egl.so library in the same way than mesa-libgl.
This permit installation of another libwayland-egl.so provider like libhybris.

For transparency, mesa-wayland-egl is a dependency of mesa-libgl.