### PR TITLE
core/linux-odroid-c1 to 3.10.96-6

### DIFF
--- a/core/linux-odroid-c1/PKGBUILD
+++ b/core/linux-odroid-c1/PKGBUILD
@@ -4,12 +4,12 @@
 buildarch=4
 
 pkgbase=linux-odroid-c1
-_commit=1d4f9e928a1c56a977bbf2d08dacc73a4161b5ff
+_commit=7d72e44de168f2f7e85b070ada029bbd25f7ba43
 _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="ODROID-C1"
 pkgver=3.10.96
-pkgrel=5
+pkgrel=6
 arch=('armv7h')
 url="https://github.com/hardkernel/linux"
 license=('GPL2')


### PR DESCRIPTION
This adds hardkernel/linux#197 and hardkernel/linux@43863e1417013a174e0c7cebcb32a8346c622cc6.