### PR TITLE
[cryptodev-dkms] Properly set DKMS kernel target

### DIFF
--- a/alarm/cryptodev-dkms/dkms.conf
+++ b/alarm/cryptodev-dkms/dkms.conf
@@ -1,6 +1,6 @@
 PACKAGE_NAME="@_PKGNAME@"
 PACKAGE_VERSION="@PKGVER@"
-MAKE[0]="make -s build"
+MAKE[0]="make -s build KERNEL_DIR=/lib/modules/$kernelver/build"
 CLEAN="make -s clean"
 BUILT_MODULE_NAME[0]="@_PKGNAME@"
 DEST_MODULE_LOCATION[0]="/extra"


### PR DESCRIPTION
cryptodev would only have been built for the currently running kernel, since the environment variable wasn't being overridden to specify the target kernel