### PR TITLE
[linux-odroid-c1] Install backports headers

### DIFF
--- a/core/linux-odroid-c1/PKGBUILD
+++ b/core/linux-odroid-c1/PKGBUILD
@@ -151,6 +151,9 @@ _package-headers() {
     media net pcmcia scsi sound trace uapi video xen; do
     cp -a include/${i} "${pkgdir}/usr/src/linux-${_kernver}/include/"
   done
+  
+  # copy backports includes (overwrite)
+  cp -a backports/include/* "${pkgdir}/usr/src/linux-${_kernver}/include/"
 
   # copy arch includes for external modules
   mkdir -p ${pkgdir}/usr/src/linux-${_kernver}/arch/$KARCH


### PR DESCRIPTION
The kernel is compiled with the backports tree enabled (previously known as wireless-compat, it's a backport of newer networking code to older kernels). However, headers were not being copied across, so compiling external modules would fail, often with 'Unknown symbol' when modprobing (abperiasamy/rtl8812AU_8821AU_linux#42). This patch copies those headers into the -headers package.

It's likely that other architectures, certainly at least the Hardkernel ones, also need this patch, but I've only submitted for Odroid C1 since that is the platform I'm running.
