### PR TITLE
community/boinc fix boinc-alt-platform name

### DIFF
--- a/community/boinc/PKGBUILD
+++ b/community/boinc/PKGBUILD
@@ -11,7 +11,7 @@ pkgbase=boinc
 pkgname=(boinc boinc-nox)
 pkgver=7.6.32
 _tag="client_release/7.6/$pkgver"
-pkgrel=1
+pkgrel=2
 arch=('i686' 'x86_64')
 url="http://boinc.berkeley.edu/"
 license=('LGPL')
@@ -45,9 +45,9 @@ prepare() {
 
 build() {
   if [[ $CARCH == "arm" ]]; then
-    CONFIG="--with-boinc-alt-platform=arm-linux-gnueabisf"
+    CONFIG="--with-boinc-alt-platform=arm-unknown-linux-gnueabisf"
   else
-    CONFIG="--with-boinc-alt-platform=arm-linux-gnueabihf"
+    CONFIG="--with-boinc-alt-platform=arm-unknown-linux-gnueabihf"
   fi
 
   cd "$srcdir"/$pkgbase


### PR DESCRIPTION
According to the boinc wiki [1] mentioned in the PKGBUILD, boinc-alt-platform should be

`arm-unknown-linux-gnueabisf` or `arm-unknown-linux-gnueabihf`

Otherwise Boinc projects that support these platforms (e.g. seti@home and einstein@home) will not work.

For example seti@home:
The boinc application provided by the project will not be downloaded. Instead there is a message that the project does not support the platform (armv7l-unknown-linux-gnueabihf in case of the Raspberry Pi 2).

With the changes in this PR both projects (seti, einstein) download their boinc-app to `/var/lib/boinc/projects/<project_url>/` as expected.

[1] https://boinc.berkeley.edu/trac/wiki/BoincPlatforms