### PR TITLE
fixed passthrough in kodi when using hifiberry-digi+ card

### DIFF
--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -12,7 +12,7 @@ pkgbase=kodi-rbp
 pkgname=('kodi-rbp' 'kodi-rbp-eventclients')
 pkgver=16.1
 _codename=Jarvis
-pkgrel=3
+pkgrel=4
 pkgdesc="A software media player and entertainment hub for digital media for the Raspberry Pi"
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
@@ -28,13 +28,15 @@ source=("https://github.com/xbmc/xbmc/archive/$pkgver-$_codename.tar.gz"
         'kodi.service'
         'polkit.rules'
         'gcc6_fix.patch'
-        'fix_libdvd.patch')
+        'fix_libdvd.patch'
+        'hifiberry_digi.patch')
 
 sha256sums=('7d82c8aff2715c83deecdf10c566e26105bec0473af530a1356d4c747ebdfd10'
             '5235068d5800d69f0287087815990e7fe8d6572733d60c8800546d35f608e87f'
             '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96'
             'b0fe75d10b2678894d1dec48f3258c0bec2a4a170f33d76a9a8334bb1969b18f'
-            '3b27148d2eda685f8f3c91bfc1b22376416ac710a8df192e34da0d4f059eb390')
+            '3b27148d2eda685f8f3c91bfc1b22376416ac710a8df192e34da0d4f059eb390'
+            '0b9d951911a8576c26dec8a31f394282677e48afff49b9579448121d27b8509e')
 prepare() {
   cd "$srcdir/xbmc-$pkgver-$_codename"
 
@@ -49,6 +51,7 @@ install:' -i tools/EventClients/Makefile.in
 
   patch -Np1 -i ${srcdir}/gcc6_fix.patch
   [[ $CARCH == "armv6h" ]] && patch -Np0 -i ${srcdir}/fix_libdvd.patch
+  patch -Np1 -i ${srcdir}/hifiberry_digi.patch
 }
 
 build() {

--- a/alarm/kodi-rbp/hifiberry_digi.patch
+++ b/alarm/kodi-rbp/hifiberry_digi.patch
@@ -1,0 +1,14 @@
+diff -rupN a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp	2016-04-24 07:48:30.000000000 +0100
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp	2016-07-06 23:15:14.851453568 +0100
+@@ -1342,6 +1342,10 @@ void CAESinkALSA::EnumerateDevice(AEDevi
+     if (snd_card_get_name(cardNr, &cardName) == 0)
+       info.m_displayName = cardName;
+ 
++    /* hifiberry digi doesn't correctly report as iec958 device. Needs fixing in kernel driver */
++    if (info.m_displayName == "snd_rpi_hifiberry_digi")
++        info.m_deviceType = AE_DEVTYPE_IEC958;
++
+     if (info.m_deviceType == AE_DEVTYPE_HDMI && info.m_displayName.size() > 5 &&
+         info.m_displayName.substr(info.m_displayName.size()-5) == " HDMI")
+     {


### PR DESCRIPTION
The HiFiBerry Digi+ is a S/PDIF/Toslink output board for the Raspberry Pi (rPi2 and rPi3).

For years (I found forum topics going back to 2014) kodi is not able to use it as pass-through device for audio output. What that means is, you are not able to get DTS or DolbyD signal in your amp.

It looks OpenELEC and Osmc already applied the patch, or rather workaround for that issue.
More info here:
https://support.hifiberry.com/hc/en-us/community/posts/201845791-Kodi-no-passthrough
and here
http://forum.kodi.tv/showthread.php?tid=261778

Kodi won't apply the patch as in their eyes the problem should be fixed in kernel or by Hifiberry.
I really doubt it will be fixed upstream in the near future (judging on the sheer amount of topics/issues which are open all over the web).

It's worth applying that patch to save time and headache to arm arch users.

It works perfectly, without side effects, in my home setup for quite some time now.