### PR TITLE
systemd: fix coredump on kernels < 3.12: revert replacement of %p with %P by upstream

### DIFF
--- a/core/systemd/PKGBUILD
+++ b/core/systemd/PKGBUILD
@@ -4,11 +4,12 @@
 # ALARM: Kevin Mihelich <kevin@archlinuxarm.org>
 #  - disable gold/LTO
 #  - removed makedepend on gnu-efi-libs, --enable-gnuefi configure option
+#  - reverted coredump config change not compatible with kernels < 3.12
 
 pkgbase=systemd
 pkgname=('systemd' 'libsystemd' 'systemd-sysvcompat')
 pkgver=230
-pkgrel=5
+pkgrel=5.1
 arch=('i686' 'x86_64')
 url="http://www.freedesktop.org/wiki/Software/systemd"
 makedepends=('acl' 'cryptsetup' 'docbook-xsl' 'gperf' 'lz4' 'xz' 'pam' 'libelf'
@@ -59,6 +60,10 @@ prepare() {
   if (( ${#_backports[*]} > 0 )); then
     git cherry-pick -n "${_backports[@]}"
   fi
+
+  # Make systemd-coredump work with kernels < 3.12 (no %P core_pattern field)
+  # Equivalent to (sans a conflict): git revert -n d1fcdcd87a4f0ffebfc98f404a7eae477dc3fd86
+  sed -i 's/\(kernel.core_pattern=.*\)%P\(.*\)/\1%p\2/' sysctl.d/50-coredump.conf.in
 
   ./autogen.sh
 }


### PR DESCRIPTION
This reverts d1fcdcd87a4f0ffebfc98f404a7eae477dc3fd86
to fix systemd-coredump for kernels < 3.12.

The %P template param -- PID as seen by initial PID namespace, as
opposed to the PID namespace in which the process resides (e.g. a
container) -- is not supported in kernels < 3.12, which causes
systemd-coredump to get wrong argument list and interpret fields
incorrectly.

Tested on Odroid U3:
before: `/var/lib/systemd/coredump/core..1000.0248f4640df74212878268fe7dcba48c.1000.bash000000`
(and `coredumpctl info` reports confused metadata, hampering matching)
after: `/var/lib/systemd/coredump/core.bash.1000.0248f4640df74212878268fe7dcba48c.32301.1468125769000000`

**Motivation**: Since manufacturers of platforms targeted by Arch Linux
ARM often stop updating the kernel (example: Odroid U3 frozen at 3.8),
it is useful to stay compatible with older kernel versions whenever this
is simple enough. Since most users are not using containers, but do want
working coredumps, the default should make the common case work, and
require one extra config step in the uncommon case when containers are
used. The current situation is the reverse.

**NOTE**: bumped pkgver from 5 -> 5.1 according to instructions, but not
sure if this is desired since the current pkgver is without decimals despite
having ALARM mods.
