### PR TITLE
Add getty.target to kodi systemd service

### DIFF
--- a/alarm/kodi-rbp/kodi.service
+++ b/alarm/kodi-rbp/kodi.service
@@ -1,6 +1,6 @@
 [Unit]
 Description = Starts an instance of Kodi
-After = remote-fs.target
+After = remote-fs.target getty.target
 
 [Service]
 User = kodi


### PR DESCRIPTION
When running the kodi systemd service at boot and you play a movie with blackborders (or wait for the screenscaver dimm) you can see the console login still in the background. With a manual start of the service this does not happen. You need to wait for the getty to finish.

The service was tested with and without the setting multiple times to veryfy that it works.
This patch should possibly get applied to kodi-rbp-git too (not tried).