### PR TITLE
core/linux-odroid-xu3: Add patch to exynos-ss for build under gcc6

### DIFF
--- a/core/linux-odroid-xu3/PKGBUILD
+++ b/core/linux-odroid-xu3/PKGBUILD
@@ -9,19 +9,24 @@ _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="ODROID-XU3"
 pkgver=3.10.96
-pkgrel=6
+pkgrel=7
 arch=('armv7h')
 url="https://github.com/hardkernel/linux"
 license=('GPL2')
 makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'git')
 options=('!strip')
 source=("https://github.com/hardkernel/linux/archive/${_commit}.tar.gz"
-        'config')
+        'config'
+        'exynos-gcc6.patch')
 md5sums=('3c02ec6f384ea70aaf000a6fd99f04ba'
-         'df97c8caa1791d330a38e22f04b7a9e0')
+         'df97c8caa1791d330a38e22f04b7a9e0'
+         'd4c327797fb7124076541859ac3d4e90')
 
 prepare() {
   cd "${srcdir}/${_srcname}"
+
+  # Patch for GCC 6 compatibility
+  patch -Np1 <../exynos-gcc6.patch
 
   cat "${srcdir}/config" > ./.config
 

--- a/core/linux-odroid-xu3/exynos-gcc6.patch
+++ b/core/linux-odroid-xu3/exynos-gcc6.patch
@@ -1,0 +1,35 @@
+diff -aur linux-ae5b5f99f06f936382edda30522787bdde1248bd-pristine/arch/arm/mach-exynos/exynos-ss.c 
+linux-ae5b5f99f06f936382edda30522787bdde1248bd-new/arch/arm/mach-exynos/exynos-ss.c
+--- linux-ae5b5f99f06f936382edda30522787bdde1248bd-pristine/arch/arm/mach-exynos/exynos-ss.c	2016-06-15 
+21:48:59.000000000 +0000
++++ linux-ae5b5f99f06f936382edda30522787bdde1248bd-new/arch/arm/mach-exynos/exynos-ss.c	2016-08-17 
+16:01:16.095003127 +0000
+@@ -238,6 +238,13 @@
+ 	struct exynos_ss_hook info_hook;
+ };
+ 
++enum ess_cause_emerg_events {
++	CAUSE_INVALID_DUMP = 0x00000000,
++	CAUSE_KERNEL_PANIC = 0x00000001,
++	CAUSE_FORCE_DUMP   = 0x0000000D,
++	CAUSE_FORCE_REBOOT = 0x000000FF,
++};
++
+ extern void (*arm_pm_restart)(char str, const char *cmd);
+ #if LINUX_VERSION_CODE <= KERNEL_VERSION(3,5,00)
+ extern void register_hook_logbuf(void (*)(const char));
+@@ -493,13 +500,6 @@
+ }
+ #endif
+ 
+-enum ess_cause_emerg_events {
+-	CAUSE_INVALID_DUMP = 0x00000000,
+-	CAUSE_KERNEL_PANIC = 0x00000001,
+-	CAUSE_FORCE_DUMP   = 0x0000000D,
+-	CAUSE_FORCE_REBOOT = 0x000000FF,
+-};
+-
+ static void exynos_ss_scratch_reg(unsigned int val)
+ {
+ 	__raw_writel(val, S5P_VA_SS_SCRATCH);
+


### PR DESCRIPTION
This kernel currently doesn't build under gcc6 due to the position of an enum declaration in `exynos-ss.c`. This patch resolves the issue, and the kernel builds successfully under gcc 6.1.1.