### PR TITLE
extra/mesa: Build vc4 gallium driver on aarch64

### DIFF
--- a/extra/mesa/PKGBUILD
+++ b/extra/mesa/PKGBUILD
@@ -40,7 +40,7 @@ prepare() {
 build() {
   cd ${srcdir}/?esa-*
 
-  [[ $CARCH == "armv7h" || $CARCH == "armv6h" ]] && VC4=',vc4'
+  [[ $CARCH == "armv7h" || $CARCH == "armv6h" || $CARCH == "aarch64" ]] && VC4=',vc4'
 
   ./configure --prefix=/usr \
     --sysconfdir=/etc \


### PR DESCRIPTION
This change extends sha # de39dc2, adding aarch64 to the array of
platforms which build the Raspberry Pi's vc4 driver. I have tested the
driver on the Arch aarch64 rootfs and can confirm that it is functional
and usable in its current state.

This patch should be merged so that when a Raspberry Pi 3 is booted with a functional kernel and the Arch aarch64 rootfs, mesa should be immediately usable for EGL/OpenGL ES 2 applications. It present one has to rebuild mesa in order to successfully get mesa based hardware acceleration on the Raspberry Pi 3.
