### PR TITLE
community/mpv: enable SDL2 video output

### DIFF
--- a/community/mpv/PKGBUILD
+++ b/community/mpv/PKGBUILD
@@ -9,7 +9,7 @@
 pkgname=mpv
 epoch=1
 pkgver=0.20.0
-pkgrel=1
+pkgrel=1.1
 _waf_version=1.8.12
 pkgdesc='a free, open source, and cross-platform media player'
 arch=('i686' 'x86_64')
@@ -46,6 +46,7 @@ build() {
     --enable-encoding \
     --enable-libmpv-shared \
     --enable-zsh-comp \
+    --enable-sdl2 \
     --enable-egl-x11
 
   ./waf build


### PR DESCRIPTION
This is needed on some ARM boards when there is no fully working hardware OpenGL driver; so mpv would be really slow using software emulated OpenGL, but ffplay would work fine instead because it's using direct software rendering through SDL.

Tested on ODROID-C2.

Cheers,
Vittorio
