### PR TITLE
alarm/uboot-odroid-c2 to 2015.01-12

### DIFF
--- a/alarm/uboot-odroid-c2/PKGBUILD
+++ b/alarm/uboot-odroid-c2/PKGBUILD
@@ -8,7 +8,7 @@ noautobuild=1
 
 pkgname=uboot-odroid-c2
 pkgver=2015.01
-pkgrel=11
+pkgrel=12
 pkgdesc="U-Boot for ODROID-C2"
 arch=('aarch64')
 url="https://github.com/hardkernel/u-boot"
@@ -22,7 +22,7 @@ source=("https://github.com/hardkernel/u-boot/archive/${_commit}.tar.gz"
         '0001-sd_fusing-tweaks.patch'
         '0002-arch-linux-arm-modifications.patch')
 md5sums=('ce59cbff0c5057d05847cc536dac4d8a'
-         '214ce8cebb21434152e1a2f1dcbc8bc0'
+         '5c464f1a0b57ce6bb5bce82e043a9840'
          '316b458415515edfc18abd54a52d43d4'
          'de51b9b3345954238c455214c5947ea3')
 

--- a/alarm/uboot-odroid-c2/boot.ini
+++ b/alarm/uboot-odroid-c2/boot.ini
@@ -98,6 +98,10 @@ setenv mesontimer "1"
 # This mode is ideal of server type usage. (Saves ~300Mb of RAM)
 setenv nographics "0"
 
+# Monitor output
+# Controls if HDMI PHY should output anything to the monitor
+setenv monitor_onoff "false" # true or false
+
 # CPU Frequency / Cores control
 ###########################################
 ### WARNING!!! WARNING!!! WARNING!!!
@@ -128,7 +132,7 @@ setenv max_freq "1536"  # 1.536GHz
 # Boot Arguments
 if test "${m}" = "custombuilt"; then setenv cmode "modeline=${modeline}"; fi
 
-setenv bootargs "root=/dev/mmcblk0p1 rootwait rw ${condev} no_console_suspend hdmimode=${m} ${cmode} m_bpp=${m_bpp} vout=${vout} fsck.repair=yes net.ifnames=0 elevator=noop disablehpd=${hpd} max_freq=${max_freq} maxcpus=${maxcpus}"
+setenv bootargs "root=/dev/mmcblk0p1 rootwait rw ${condev} no_console_suspend hdmimode=${m} ${cmode} m_bpp=${m_bpp} vout=${vout} fsck.repair=yes net.ifnames=0 elevator=noop disablehpd=${hpd} max_freq=${max_freq} maxcpus=${maxcpus} monitor_onoff=${monitor_onoff}"
 
 # Booting
 


### PR DESCRIPTION
Newer kernels allows controlling the HDMI PHY on/off state.