### PR TITLE
alarm/uboot-odroid to 2016.09-1

### DIFF
--- a/alarm/uboot-odroid/PKGBUILD
+++ b/alarm/uboot-odroid/PKGBUILD
@@ -5,7 +5,7 @@ buildarch=4
 
 pkgbase=uboot-odroid
 pkgname=('uboot-odroid' 'uboot-odroid-x')
-pkgver=2016.07
+pkgver=2016.09
 pkgrel=1
 arch=('armv7h')
 url='http://www.denx.de/wiki/U-Boot/WebHome'
@@ -22,7 +22,7 @@ source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
         '0001-arch-linux-arm-modifications.patch'
         '0002-odroid-x-support.patch'
         'uEnv.txt')
-md5sums=('425a3fa610a7d972e5092a0e92276c70'
+md5sums=('2e69dda70eb28f8042d2f9fbeb1feaa1'
          '3ab6d3cc2061bc2590d60320254017c6'
          '841502de02bd42f2898e36c89c260b0f'
          'c38faafa02a6a1ae834457f378c82113'


### PR DESCRIPTION
Boots on the ODROID-U2. Though, I haven't checked the serial console output for warnings or errors (I don't have an adapter).