### PR TITLE
alarm/uboot-odroid: Use generic distro configuration

### DIFF
--- a/alarm/uboot-odroid/0001-arch-linux-arm-modifications.patch
+++ b/alarm/uboot-odroid/0001-arch-linux-arm-modifications.patch
@@ -1,14 +1,24 @@
-From def7823985d4a7b7670c1ed6eea8a28482ae4642 Mon Sep 17 00:00:00 2001
-From: Kevin Mihelich <kevin@archlinuxarm.org>
-Date: Fri, 22 Aug 2014 17:51:41 -0600
-Subject: [PATCH 1/2] arch linux arm modifications
+From 667549a1624dc76e631a0db1b3abc6fee115e80e Mon Sep 17 00:00:00 2001
+From: Zoltan Tombol <zoltan.tombol@gmail.com>
+Date: Mon, 19 Sep 2016 19:42:57 +0200
+Subject: [PATCH] odroid: Add generic distro configuration
 
 ---
- include/configs/odroid.h | 173 ++++++++++++++++++-----------------------------
- 1 file changed, 64 insertions(+), 109 deletions(-)
+ configs/odroid_defconfig |   1 +
+ include/configs/odroid.h | 142 +++++++++++------------------------------------
+ 2 files changed, 34 insertions(+), 109 deletions(-)
 
+diff --git a/configs/odroid_defconfig b/configs/odroid_defconfig
+index 76ab144..f994f2a 100644
+--- a/configs/odroid_defconfig
++++ b/configs/odroid_defconfig
+@@ -47,3 +47,4 @@ CONFIG_G_DNL_MANUFACTURER="Samsung"
+ CONFIG_G_DNL_VENDOR_NUM=0x04e8
+ CONFIG_G_DNL_PRODUCT_NUM=0x6601
+ CONFIG_ERRNO_STR=y
++CONFIG_DISTRO_DEFAULTS=y
 diff --git a/include/configs/odroid.h b/include/configs/odroid.h
-index 12b7dc5..306ff07 100644
+index 12b7dc5..35c4ab6 100644
 --- a/include/configs/odroid.h
 +++ b/include/configs/odroid.h
 @@ -14,6 +14,7 @@
@@ -19,15 +29,7 @@ index 12b7dc5..306ff07 100644
  #define CONFIG_SYS_L2CACHE_OFF
  #ifndef CONFIG_SYS_L2CACHE_OFF
  #define CONFIG_SYS_L2_PL310
-@@ -35,6 +36,7 @@
- #define CONFIG_SYS_MEMTEST_END		(CONFIG_SYS_SDRAM_BASE + 0x5E00000)
- #define CONFIG_SYS_LOAD_ADDR		(CONFIG_SYS_SDRAM_BASE + 0x3E00000)
- #define CONFIG_SYS_TEXT_BASE		0x43e00000
-+#define CONFIG_LOADADDR 		0x40007FC0
- 
- #include <linux/sizes.h>
- 
-@@ -46,10 +48,6 @@
+@@ -46,10 +47,6 @@
  #define CONFIG_SYS_CONSOLE_INFO_QUIET
  #define CONFIG_SYS_CONSOLE_IS_IN_ENV
  
@@ -38,7 +40,7 @@ index 12b7dc5..306ff07 100644
  #define CONFIG_SYS_INIT_SP_ADDR	(CONFIG_SYS_LOAD_ADDR \
  					- GENERATED_GBL_DATA_SIZE)
  
-@@ -61,34 +59,7 @@
+@@ -61,34 +58,34 @@
  #define CONFIG_ENV_OFFSET		(SZ_1K * 1280) /* 1.25 MiB offset */
  #define CONFIG_ENV_OVERWRITE
  
@@ -70,11 +72,38 @@ index 12b7dc5..306ff07 100644
 -	"bl1 raw 0x1 0x1e;" \
 -	"bl2 raw 0x1f 0x1d;" \
 -	"tzsw raw 0x83f 0x138\0"
-+#define CONFIG_SUPPORT_RAW_INITRD
++/* Generic distro config. See `doc/README.distro' for details. */
++#ifndef CONFIG_SPL_BUILD
++
++#define CONFIG_LOADADDR		0x40007FC0
++
++/*
++ * Memory layout. Addresses where various images are loaded.
++ *
++ *   fdt_addr_r     - Flattened Device Tree
++ *   ramdisk_addr_r - Initial Ramdisk
++ *   kernel_addr_r  - Kernel
++ *   pxefile_addr_r - PXE configuration file and `extlinux.conf'
++ *   scriptaddr     - Boot script `boot.scr'
++ */
++#define MEM_LAYOUT_ENV_SETTINGS \
++	"fdt_addr_r=0x40800000\0"                          \
++	"ramdisk_addr_r=0x42000000\0"                      \
++	"kernel_addr_r=" __stringify(CONFIG_LOADADDR) "\0" \
++	"pxefile_addr_r=0x42000000\0"                      \
++	"scriptaddr=0x42000000\0"
++
++#include <config_distro_defaults.h>
++
++#define BOOT_TARGET_DEVICES(func) \
++	func(MMC, mmc, 0)    \
++	func(MMC, mmc, 1)
++
++#include <config_distro_bootcmd.h>
  
  /*
   * Bootable media layout:
-@@ -98,85 +69,69 @@
+@@ -98,85 +95,12 @@
   * UBOOT   63   62
   * TZSW  2111 2110
   * ENV   2560 2560(part user)
@@ -157,70 +186,13 @@ index 12b7dc5..306ff07 100644
 -	"initrdaddr=42000000\0" \
 -	"scriptaddr=0x42000000\0" \
 -	"fdtaddr=40800000\0"
-+	"bootfile=zImage\0" \
-+	"bootdir=/boot\0" \
-+	"console=ttySAC1,115200\0" \
-+	"rdaddr=42000000\0" \
-+	"rdfile=initramfs-linux.img\0" \
-+	"fdtaddr=40800000\0" \
-+	"fdtfile=\0" \
-+	"fdtdir=/boot/dtbs\0" \
-+	"optargs=\0" \
-+	"mmcdev=0\0" \
-+	"mmcroot=/dev/mmcblk0p1 rw rootwait\0" \
-+	"mmcargs=setenv bootargs console=${console} " \
-+		"${optargs} " \
-+		"root=${root} " \
-+		"video=${video}\0" \
-+	"loadimage=load ${devtype} ${bootpart} ${loadaddr} ${bootdir}/${bootfile}\0" \
-+	"loadrd=load ${devtype} ${bootpart} ${rdaddr} ${bootdir}/${rdfile}\0" \
-+	"loadfdt=echo loading ${fdtdir}/${fdtfile} ...; load ${devtype} ${bootpart} ${fdtaddr} ${fdtdir}/${fdtfile}\0" \
-+	"mmcboot=usb start;" \
-+		"for devtype in mmc usb; do " \
-+			"setenv devnum 0;" \
-+			"while ${devtype} dev ${devnum}; do " \
-+				"echo ${devtype} found on device ${devnum};" \
-+				"setenv bootpart ${devnum}:1;" \
-+				"part uuid ${devtype} ${bootpart} uuid;" \
-+				"setenv root PARTUUID=${uuid} rw rootwait;" \
-+				"echo Checking for: ${bootdir}/uEnv.txt ...;" \
-+				"if test -e ${devtype} ${bootpart} ${bootdir}/uEnv.txt; then " \
-+					"load ${devtype} ${bootpart} ${loadaddr} ${bootdir}/uEnv.txt;" \
-+					"env import -t ${loadaddr} ${filesize};" \
-+					"echo Loaded environment from ${bootdir}/uEnv.txt;" \
-+					"echo Checking if uenvcmd is set ...;" \
-+					"if test -n ${uenvcmd}; then " \
-+						"echo Running uenvcmd ...;" \
-+						"run uenvcmd;" \
-+					"fi;" \
-+				"fi;" \
-+				"if run loadimage; then " \
-+					"run mmcargs;" \
-+					"if run loadfdt; then " \
-+						"if run loadrd; then " \
-+							"bootz ${loadaddr} ${rdaddr}:${filesize} ${fdtaddr};" \
-+						"else " \
-+							"bootz ${loadaddr} - ${fdtaddr};" \
-+						"fi;" \
-+					"else " \
-+						"if run loadrd; then " \
-+							"bootz ${loadaddr} ${rdaddr}:${filesize};" \
-+						"else " \
-+							"bootz ${loadaddr};" \
-+						"fi;" \
-+					"fi;" \
-+				"else " \
-+					"echo No kernel found;" \
-+				"fi;" \
-+				"setexpr devnum ${devnum} + 1;" \
-+			"done;" \
-+		"done;\0"
++	MEM_LAYOUT_ENV_SETTINGS \
++	BOOTENV
 +
-+#define CONFIG_BOOTCOMMAND \
-+        "run mmcboot;"
++#endif /* CONFIG_SPL_BUILD */
  
  /* I2C */
  #define CONFIG_SYS_I2C_S3C24X0
 -- 
-2.8.3
+2.9.3
 

--- a/alarm/uboot-odroid/PKGBUILD
+++ b/alarm/uboot-odroid/PKGBUILD
@@ -11,7 +11,7 @@ arch=('armv7h')
 url='http://www.denx.de/wiki/U-Boot/WebHome'
 license=('GPL')
 install=$pkgname.install
-backup=('boot/extlinux/extlinux.conf')
+backup=('boot/extlinux/extlinux.conf' 'boot/uEnv.txt')
 makedepends=('bc' 'dtc' 'git')
 _commit=dd9a970aa4accf5d266d334c0f319c674e933027
 source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
@@ -21,15 +21,19 @@ source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
         "sd_fusing.sh"
         '0001-arch-linux-arm-modifications.patch'
         '0002-odroid-x-support.patch'
-        'extlinux.conf')
+        'extlinux.conf'
+        'boot.cmd'
+        'uEnv.txt')
 md5sums=('425a3fa610a7d972e5092a0e92276c70'
          '3ab6d3cc2061bc2590d60320254017c6'
          '841502de02bd42f2898e36c89c260b0f'
          'c38faafa02a6a1ae834457f378c82113'
          '17909ae93a0ae7b4c155234040105035'
-         '55eda80baf90fd36bfd568bfc4db8462'
+         '97f481b9d3d3b9b0ab668f95ead485a5'
          'f4f8c8b6217e6646b9659de642264a3f'
-         '1380273afdb6303b0c9cb58440076a26')
+         '1380273afdb6303b0c9cb58440076a26'
+         'b39fcf4cee1e120928a38eb6689c9646'
+         'a4377e502778ce2078748ae35a623792')
 
 prepare() {
   cd u-boot-${pkgver}
@@ -55,6 +59,9 @@ build() {
   make distclean
   make odroid_config
   make EXTRAVERSION=-${pkgrel}
+
+  ./tools/mkimage -A arm -T script -n 'Fallback boot script' \
+                  -d ../boot.cmd ../boot.scr
 }
 
 package_uboot-odroid() {
@@ -67,6 +74,9 @@ package_uboot-odroid() {
 
   mkdir -p ${pkgdir}/boot/extlinux
   cp ../extlinux.conf ${pkgdir}/boot/extlinux
+
+  cp ../boot.scr "${pkgdir}/boot"
+  cp ../uEnv.txt "${pkgdir}/boot"
 }
 
 package_uboot-odroid-x() {
@@ -79,4 +89,7 @@ package_uboot-odroid-x() {
 
   mkdir -p ${pkgdir}/boot/extlinux
   cp ../extlinux.conf ${pkgdir}/boot/extlinux
+
+  cp ../boot.scr "${pkgdir}/boot"
+  cp ../uEnv.txt "${pkgdir}/boot"
 }

--- a/alarm/uboot-odroid/PKGBUILD
+++ b/alarm/uboot-odroid/PKGBUILD
@@ -6,12 +6,12 @@ buildarch=4
 pkgbase=uboot-odroid
 pkgname=('uboot-odroid' 'uboot-odroid-x')
 pkgver=2016.07
-pkgrel=1
+pkgrel=2
 arch=('armv7h')
 url='http://www.denx.de/wiki/U-Boot/WebHome'
 license=('GPL')
 install=$pkgname.install
-backup=('boot/uEnv.txt')
+backup=('boot/extlinux/extlinux.conf')
 makedepends=('bc' 'dtc' 'git')
 _commit=dd9a970aa4accf5d266d334c0f319c674e933027
 source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
@@ -21,15 +21,15 @@ source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
         "sd_fusing.sh"
         '0001-arch-linux-arm-modifications.patch'
         '0002-odroid-x-support.patch'
-        'uEnv.txt')
+        'extlinux.conf')
 md5sums=('425a3fa610a7d972e5092a0e92276c70'
          '3ab6d3cc2061bc2590d60320254017c6'
          '841502de02bd42f2898e36c89c260b0f'
          'c38faafa02a6a1ae834457f378c82113'
          '17909ae93a0ae7b4c155234040105035'
-         'afe3b7a5b224e257b2ce7f5af03daa8d'
+         '55eda80baf90fd36bfd568bfc4db8462'
          'f4f8c8b6217e6646b9659de642264a3f'
-         'fb5c9ea3108afa298087549f0453b00f')
+         '1380273afdb6303b0c9cb58440076a26')
 
 prepare() {
   cd u-boot-${pkgver}
@@ -63,8 +63,10 @@ package_uboot-odroid() {
   cd u-boot-${pkgver}
   mkdir -p ${pkgdir}/boot
   cp ../u-boot-dtb.bin ${pkgdir}/boot/u-boot.bin
-  cp ../uEnv.txt ${pkgdir}/boot
   cp ../{{bl1,bl2,tzsw}.HardKernel,sd_fusing.sh} ${pkgdir}/boot
+
+  mkdir -p ${pkgdir}/boot/extlinux
+  cp ../extlinux.conf ${pkgdir}/boot/extlinux
 }
 
 package_uboot-odroid-x() {
@@ -73,6 +75,8 @@ package_uboot-odroid-x() {
   cd u-boot-${pkgver}
   mkdir -p ${pkgdir}/boot
   cp u-boot-dtb.bin ${pkgdir}/boot/u-boot.bin
-  cp ../uEnv.txt ${pkgdir}/boot
   cp ../{{bl1,bl2,tzsw}.HardKernel,sd_fusing.sh} ${pkgdir}/boot
+
+  mkdir -p ${pkgdir}/boot/extlinux
+  cp ../extlinux.conf ${pkgdir}/boot/extlinux
 }

--- a/alarm/uboot-odroid/boot.cmd
+++ b/alarm/uboot-odroid/boot.cmd
@@ -1,0 +1,218 @@
+#
+# Authors:
+#   Zoltan Tombol <zoltan dot tombol at gmail>
+#
+# boot.cmd
+# --------
+#
+# Boot script serving as a fallback when `extlinux.conf' is not
+# available.
+#
+# It supports booting multiple image formats and customising the
+# environment using a text file.
+#
+# Generate the loadable script using the following command.
+#
+#   ./tools/mkimage -A arm -T script -n 'Fallback boot script' \
+#                   -d boot.cmd boot.scr
+#
+#
+# Boot process
+# ------------
+#
+# First, the environment is imported from `uEnv.txt'. Then, the boot
+# images are tried one by one until one succeeds as shown below.
+#
+#   1. Load environment file `uEnv.txt'
+#   2. Attempt booting in the following order
+#     a. Flattened Image Tree `Image.itb'
+#     b. Compressed kernel image `zImage'
+#     c. Legacy `uImage'
+#
+# See `Environment' below to learn how to select the device tree and
+# initial ramdisk to load.
+#
+#
+# Environment
+# -----------
+#
+# The following variables are defined by the compiled-in environment.
+#
+#   Memory layout:
+#
+#     fdt_addr_r      - flattened device tree
+#     ramdisk_addr_r  - initial ramdisk
+#     kernel_addr_r   - kernel
+#     pxefile_addr_r  - PXE configuration file and `extlinux.conf'
+#     scriptaddr      - boot script `boot.scr'
+#     loadaddr        - default load address
+#
+#   Boot device and partition:
+#
+#     devtype         - device type, e.g. `mmc' or `usb'
+#     devnum          - device number, e.g. `0' for `mmc 0'
+#     distro_bootpart - partition number, e.g. `1' for `mmc 0:1'
+#     prefix          - boot directory path, e.g. `/' or `/boot/'
+#
+#
+# The following variables can be modified in `uEnv.txt' to customise the
+# boot process. The default values are shown in square brackets.
+#
+#   Kernel parameters:
+#
+#     root       - partition of root filesystem   [/dev/mmcblk0p1]
+#     console    - console settings               [ttySAC1,115200n8]
+#     optargs    - additional kernel parameters
+#     video      - video mode
+#
+#   Device tree and initial ramdisk:
+#
+#     initrdname - initial ramdisk file           [uInitrd]
+#     fdtdir     - directory of device tree files [dtbs]
+#     fdtfile    - name of device tree file       [exynos4412-odroid{x,x2,u3}.dtb]
+#
+#   Miscellaneous:
+#
+#     uenvcmd    - command to run after loading `uEnv.txt'
+#
+
+###############################################################################
+# Common command variables.
+###############################################################################
+
+setenv kernel_args "
+	setenv bootargs root='${root}' rootwait rw console='${console}'
+		video='${video}' '${optargs}';"
+
+setenv load_kernel "
+	load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r}
+		${prefix}'${kernelname}';"
+
+setenv load_dtb "
+	load ${devtype} ${devnum}:${distro_bootpart} ${fdt_addr_r}
+		${prefix}'${fdtdir}/${fdtfile}';"
+
+setenv check_dtb "
+	if run load_dtb; then
+		setenv fdtaddr ${fdt_addr_r};
+	else
+		setenv fdtaddr;
+	fi;"
+
+setenv load_initrd "
+	load ${devtype} ${devnum}:${distro_bootpart} ${ramdisk_addr_r}
+		${prefix}'${initrdname}';"
+
+setenv check_initrd "
+	if run load_initrd; then
+		setenv initrdaddr ${ramdisk_addr_r};
+	else
+		setenv initrdaddr -;
+	fi;"
+
+
+###############################################################################
+# Load environment from `uEnv.txt'.
+###############################################################################
+
+setenv load_bootenv "
+	load ${devtype} ${devnum}:${distro_bootpart} ${scriptaddr}
+		${prefix}uEnv.txt;"
+
+setenv import_bootenv "env import -t ${scriptaddr} '${filesize}';"
+
+setenv scan_dev_for_bootenv "
+	if test -e ${devtype}
+			${devnum}:${distro_bootpart}
+			${prefix}uEnv.txt; then
+		echo Found environment file ${prefix}uEnv.txt;
+		run load_bootenv;
+		run import_bootenv;
+		if test -n '${uenvcmd}'; then
+			echo Running uenvcmd ...;
+			run uenvcmd;
+		fi;
+	fi;"
+
+
+###############################################################################
+# Boot from Flattened Image Tree `Image.itb'.
+###############################################################################
+
+setenv boot_fit "
+	setenv kernel_addr_r ${scriptaddr};
+	setenv kernelname Image.itb;
+	run load_kernel;
+	run kernel_args;
+	bootm ${kernel_addr_r}#${boardname};"
+
+setenv scan_dev_for_fit "
+	if test -e ${devtype}
+			${devnum}:${distro_bootpart}
+			${prefix}Image.itb; then
+		echo Found FIT image ${prefix}Image.itb;
+		run boot_fit;
+		echo BOOTING FAILED: continuing...;
+	fi;"
+
+
+###############################################################################
+# Boot from compressed kernel image `zImage'.
+###############################################################################
+
+setenv boot_zimg "
+	setenv kernelname zImage;
+	run check_dtb;
+	run check_initrd;
+	run load_kernel;
+	run kernel_args;
+	bootz ${kernel_addr_r} '${initrdaddr}' '${fdtaddr}';"
+
+setenv scan_dev_for_zimg "
+	if test -e ${devtype}
+			${devnum}:${distro_bootpart}
+			${prefix}zImage; then
+		echo Found zImage ${prefix}zImage;
+		run boot_zimg;
+		echo BOOTING FAILED: continuing...;
+	fi;"
+
+
+###############################################################################
+# Boot from legacy `uImage'.
+###############################################################################
+
+setenv boot_uimg "
+	setenv kernelname uImage;
+	run check_dtb;
+	run check_initrd;
+	run load_kernel;
+	run kernel_args;
+	bootm ${kernel_addr_r} '${initrdaddr}' '${fdtaddr}';"
+
+setenv scan_dev_for_uimg "
+	if test -e ${devtype}
+			${devnum}:${distro_bootpart}
+			${prefix}uImage; then
+		echo Found legacy uImage ${prefix}uImage;
+		run boot_uimg;
+		echo BOOTING FAILED: continuing...;
+	fi;"
+
+
+###############################################################################
+# Main
+###############################################################################
+
+# Defaults.
+setenv root       '/dev/mmcblk0p1'
+setenv fdtdir     'dtbs'
+setenv initrdname 'uInitrd'
+
+setenv autoboot "
+	run scan_dev_for_bootenv;
+	run scan_dev_for_fit;
+	run scan_dev_for_zimg;
+	run scan_dev_for_uimg;"
+
+run autoboot

--- a/alarm/uboot-odroid/extlinux.conf
+++ b/alarm/uboot-odroid/extlinux.conf
@@ -1,0 +1,70 @@
+#
+# extlinux.conf
+# -------------
+#
+# Board and bootloader agnostic configuration file.
+#
+# Its syntax is based on Syslinux's EXTLINUX. The examples below should
+# cover most setups. For more information, see `doc/README.distro' in
+# U-Boot's source.
+#
+
+default arch
+
+label arch
+    linux ../zImage
+    append root=/dev/mmcblk0p1 rootwait rw console=ttySAC1,115200n8
+
+
+#-----------------------------------------------------------------------
+# Examples
+#-----------------------------------------------------------------------
+
+# Video modes can be specified as kernel parameters.
+#
+# Default : <none>
+#
+# Monnitor provided EDID information:
+#   1080p@60Hz (1080p-edid): video=HDMI-A-1:1920x1080@60
+#    720p@60Hz  (720p-edid): video=HDMI-A-1:1280x720@60
+#
+# Generic information:
+#   1080p@60Hz (1080p-noedid): drm_kms_helper.edid_firmware=edid/1920x1080.bin
+#    720p@60Hz  (720p-noedid): drm_kms_helper.edid_firmware=edid/1280x720.bin
+#     1024x768               : drm_kms_helper.edid_firmware=edid/1024x768.bin
+#
+#label arch
+#    linux ../zImage
+#    append root=/dev/mmcblk0p1 rootwait rw console=ttySAC1,115200n8 video=HDMI-A-1:1920x1080@60
+
+
+# Using an initial ramdisk.
+#
+# Directive : initrd
+# Default   : <none>
+#
+#label arch
+#    linux ../zImage
+#    initrd ../initramfs-linux.img
+
+
+# Specifying a device tree file.
+#
+# Directive : fdt
+# Default   : ${fdtdir}/exynos4412-odroidx.dtb  -> X
+#             ${fdtdir}/exynos4412-odroidx2.dtb -> X2
+#             ${fdtdir}/exynos4412-odroidu3.dtb -> U2/U3
+#
+#label arch
+#    linux ../zImage
+#    fdt ../dtbs/custom-device-tree.dtb
+
+
+# Loading default device tree file from a given directory.
+#
+# Directive : fdtdir
+# Default   : <none>
+#
+#label arch
+#    linux ../zImage
+#    fdtdir ../custom-dtbs

--- a/alarm/uboot-odroid/uEnv.txt
+++ b/alarm/uboot-odroid/uEnv.txt
@@ -1,23 +1,79 @@
-# Use this file to make modifications to the U-Boot environment.
+#
+# uEnv.txt
+# --------
+#
+# This file is used to customise the boot environment by defining new
+# and redefining existing environment variables.
+#
+# When using `extlinux.conf', customisation should be done through its
+# directives as this file is ignored.
+#
+# The default value of each variable is shown below.
+#
 
-### root filesystem device
-# root=/dev/... rw rootwait
+#-----------------------------------------------------------------------
+# Kernel Parameters
+#-----------------------------------------------------------------------
 
-### optargs (extra options to pass to the kernel)
-# optargs=
+# Partition where the root filesystem is located.
+#root=/dev/mmcblk0p1
 
-### video
-## 1920x1080 (1080P) with monitor provided EDID information. (1080p-edid)
-# video=HDMI-A-1:1920x1080@60
+# Additional kernel parameters.
+#optargs=
 
-## 1920x1080 (1080P) without monitor data using generic information (1080p-noedid)
-# optargs=drm_kms_helper.edid_firmware=edid/1920x1080.bin
+# Console settings.
+#console=ttySAC1,115200n8
 
-## 1280x720 (720P) with monitor provided EDID information. (720p-edid)
-# video=HDMI-A-1:1280x720@60
 
-## 1280x720 (720P) without monitor data using generic information (720p-noedid)
-# optargs=drm_kms_helper.edid_firmware=edid/1280x720.bin
+#-----------------------------------------------------------------------
+# Video mode
+#-----------------------------------------------------------------------
 
-## 1024x768 without monitor data using generic information
-# optargs=drm_kms_helper.edid_firmware=edid/1024x768.bin
+# Video mode.
+#
+# Monitor provided EDID information:
+#
+#   1080p@60Hz (1080p-edid) : video=HDMI-A-1:1920x1080@60
+#    720p@60Hz  (720p-edid) : video=HDMI-A-1:1280x720@60
+#
+# Generic information:
+#
+#   1080p@60Hz (1080p-noedid) : optargs=drm_kms_helper.edid_firmware=edid/1920x1080.bin
+#    720p@60Hz  (720p-noedid) : optargs=drm_kms_helper.edid_firmware=edid/1280x720.bin
+#     1024x768                : optargs=drm_kms_helper.edid_firmware=edid/1024x768.bin
+#
+#   NOTE: Make sure not to accidentally overwrite the previous value of
+#         `optargs' if previously assigned.
+#
+#video=
+
+
+#-----------------------------------------------------------------------
+# Initial Ramdisk
+#-----------------------------------------------------------------------
+
+# Name of initial ramdisk image.
+#initrdname=uInitrd
+
+
+#-----------------------------------------------------------------------
+# Device Tree
+#-----------------------------------------------------------------------
+
+# Device tree directory.
+#fdtdir=dtbs
+
+# Name of device tree file in `${fdtdir}'.
+#fdtfile=exynos4412-odroidx.dtb    # for X
+#fdtfile=exynos4412-odroidx2.dtb   # for X2
+#fdtfile=exynos4412-odroidu3.dtb   # for U2/U3
+
+
+#-----------------------------------------------------------------------
+# Custom Command
+#-----------------------------------------------------------------------
+
+# Execute the following command after sourcing this file. Useful in
+# making small adjustments to the boot process without having to replace
+# the entire boot script.
+#uenvcmd=


### PR DESCRIPTION
_This is a **WORK IN PROGRESS**. I wanted to gauge interest before I gather volunteers on the forums to test on boards that I don't own and fully test everything._

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

I'm aware that U-Boot's *generic distro config* has been [discussed before][alarm-prev-pr] and that at that time it wasn't accepted. I'm wondering if the stance has changed. Especially in light that in the meanwhile U-Boot has gained a flexible common implementation that supports falling back to a `boot.scr` for backward compatibility.

Merit:
- **Less code to maintain.** U-Boot implements the boot environment which is shared between all boards that enable this configuration method. Boards only have to define the memory addresses where various images should be loaded and the devices which should be searched for boot files. Modifying device order, boot prefixes, and customising network setup is supported too. This results in a smaller Arch Linux ARM specific patch.

- **Flexible runtime.** All partitions marked as bootable are searched for boot files. Defaults to the first partition if no such partition is found. Boot files may reside in `/` or `/boot/`, which allows using separate `boor` and `root` partitions out-of-the-box. Falls back to `boot.scr` if `extlinux.conf` is not found or cannot boot.
  
- **Simpler configuration.** _Some of this may be subjective._ The path of the kernel, initial ramdisk and device tree can be easily specified without having to look at the compiled-in environment. Kernel arguments are specified on a single line, rather than being concatenated from a number of environment variables, while the compiled-in environment adds a few more. Multiple configurations can be specified in a single file, and switching between them is as simple as editing one line.

In my opinion the main benefit is the user friendly, as in more familiar and transparent, configuration and the reduced maintenance cost. The expanded feature set is nice too, but I know it isn't important for Arch Linux ARM.

See [`doc/README.distro`][uboot-readme-distro] in U-Boot's source for more details. [My U-Boot branch][ztombol-uboot-odroid] implementing this for the boards supported by the `uboot-odroid` package.

Alternatives:
- If `extlinux.conf` is not something you like, it's still possible to reduce maintenance cost by utilising the boot file searching logic only and falling back to an Arch Linux ARM specific boot script. This saves only a couple of lines of code in this package. However, using the *generic distro config* provides the boot script a standard environment, which enables writing a boot script that is generic enough to be shared among other boards and thus reducing maintenance cost across multiple platforms. The second commit introduces such a script (still under testing). It supports Flattened Image Trees (`Image.itb`), compressed kernel images (`zImage`), and legacy `uImage`, as well as flattened device trees and initial ramdisks.

Implementation notes:
- As of `2016.07`, USB and Etherent (possibly because it's connected via USB) are broken in upstream U-Boot. On my U2, I couldn't bring up network as described in [`doc/README.odroid`][uboot-readme-odroid] and couldn't boot stock Arch Linux ARM from a USB drive either. Only eMMC and SD card boot is enabled at the moment.
- [`include/config_distro_defaults.h`][uboot-distro-defaults-h] already contains `CONFIG_SUPPORT_RAW_INITRD`, so it's not in the boards header.
- U-Boot [loads `extlinux.conf` at `scriptaddr`][uboot-extlinux-load] instead of [`pxefile_addr_r` as the documentation says][uboot-pxefile_addr_r]. This is a bug, but it doesn't matter, especially that in case of these boards those addresses are the same.
- `${fdtfile}` is automatically set for all boards (`exynos4412-odroid{x,x2,u2,u3}`). There's no need to set it to the empty string.

References:
- 2014-07-18 - [Previous discussion in #907][alarm-prev-pr]
- 2014-07-31 - [U-Boot adds generic $bootcmd][uboot-gen-bootcmd]
- 2015-01-22 - [U-Boot documents generic distro config][uboot-add-readme-distro]


<!-- REFERENCES -->

[alarm-prev-pr]: https://github.com/archlinuxarm/PKGBUILDs/pull/907
[uboot-readme-distro]: https://github.com/u-boot/u-boot/blob/v2016.07/doc/README.distro
[uboot-readme-odroid]: https://github.com/u-boot/u-boot/blob/v2016.07/doc/README.odroid
[ztombol-uboot-odroid]: https://github.com/ztombol/u-boot/tree/alarm-uboot-odroid-extlinux
[uboot-extlinux-load]: https://github.com/u-boot/u-boot/blob/v2016.07/include/config_distro_bootcmd.h#L336
[uboot-pxefile_addr_r]: https://github.com/u-boot/u-boot/blob/v2016.07/doc/README.distro#L252
[uboot-gen-bootcmd]: https://github.com/u-boot/u-boot/commit/2a43201a13bc690b5f15a1a998514d932db2f1b0
[uboot-add-readme-distro]: https://github.com/u-boot/u-boot/commit/ffb4f6f95a0b63a0e8eab81e006a26c9cd99ac5d
[uboot-distro-defaults-h]: https://github.com/u-boot/u-boot/blob/v2016.07/include/config_distro_defaults.h#L35