### PR TITLE
add community/dart

### DIFF
--- a/community/dart/PKGBUILD
+++ b/community/dart/PKGBUILD
@@ -1,0 +1,76 @@
+# $Id$
+# Maintainer: Alexander Rødseth <rodseth@gmail.com>
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+# Contributor: T. Jameson Little <t.jameson.little at gmail dot com>
+# Contributor: Usagi Ito <usagi@WonderRabbitProject.net>
+# Contributor: siasia <http://pastebin.com/qsBEmNCw>
+# Contributor: Julien Nicoulaud <julien.nicoulaud@gmail.com>
+# Contributor: Jacob Bang <julemand101gmail.com>
+
+# Arch Linux ARM changes:
+# - changed URL's from downloading latest to specific $pkgver
+# - added source and sha512 for ARMv7h build of Dart
+# - added buildarch
+
+buildarch=4 # Not sure if this package works with ARMv8
+
+pkgname=dart
+pkgver=1.19.1
+pkgrel=1
+pkgdesc='The dart programming language SDK'
+arch=('x86_64' 'i686' 'armv7h')
+url='http://www.dartlang.org/'
+license=('BSD')
+makedepends=('setconf')
+options=('!strip')
+source_x86_64+=("$pkgname-$pkgver-64.zip::http://storage.googleapis.com/dart-archive/channels/stable/release/$pkgver/sdk/dartsdk-linux-x64-release.zip")
+source_i686+=("$pkgname-$pkgver-32.zip::http://storage.googleapis.com/dart-archive/channels/stable/release/$pkgver/sdk/dartsdk-linux-ia32-release.zip")
+source_armv7h+=("$pkgname-$pkgver-arm.zip::http://storage.googleapis.com/dart-archive/channels/stable/release/$pkgver/sdk/dartsdk-linux-arm-release.zip")
+sha512sums_x86_64=('1ed3515afe30d20446503d7367a57c1a35a7fdeedb315565dc2bbeaf9b8568a5591f830a65005390347fa95de6e90c16954521ce657c17efb1aaab5710340e7b')
+sha512sums_i686=('7a606e8be8b8c00a9a7ebdcba57131183821e4e7dfd6d224b270618dae9b2a2bf7c12d374be4b535f81a052898dc8721e021e246d0517be4085849bed434fc55')
+sha512sums_armv7h=('11b9d81a12aac42c1adffb87a21da896067fa892808f6da3b33fcb7aaeb80e2162f503810030d142f602c8d53590616e635475523f5deaf8d68c178165b67817')
+
+prepare() {
+  # Fix permissions
+  find "$pkgname-sdk" -type d -exec chmod 0755 '{}' + \
+    -or -type f -exec chmod 0644 '{}' +
+  chmod +x "$pkgname-sdk/bin/"*
+
+  cd "$pkgname-sdk/bin"
+
+  # Configure paths
+  setconf dart2js BIN_DIR "/opt/$pkgname-sdk/bin"
+  setconf dart2js PROG_NAME "/opt/$pkgname-sdk/bin/dart2js"
+  setconf dartanalyzer SCRIPT_DIR "/opt/$pkgname-sdk/bin"
+  setconf pub BIN_DIR "/opt/$pkgname-sdk/bin"
+  setconf pub SDK_DIR "/opt/$pkgname-sdk/"
+  setconf dartfmt BIN_DIR "/opt/$pkgname-sdk/bin"
+  setconf dartfmt SDK_DIR "/opt/$pkgname-sdk/"
+
+  # Extract license (AUTHORS and LICENSE files are missing)
+  head -n5 "../include/dart_api.h" > ../../LICENSE
+}
+
+package() {
+  # Create directories
+  install -d "$pkgdir"{"/opt/$pkgname-sdk",/usr/{bin,"share/doc/$pkgname-sdk"}}
+
+  # Package the files
+  cp -a "$pkgname-sdk/"* "$pkgdir/opt/$pkgname-sdk/"
+
+  # Set up symbolic links for the executables
+  for f in dart dart2js dartanalyzer pub dartfmt dartdevc; do
+    ln -s "/opt/$pkgname-sdk/bin/$f" "$pkgdir/usr/bin/$f"
+  done
+
+  # Package samples and documentation
+  for f in samples about.html about_files; do
+    echo mv "$pkgdir/opt/$pkgname-sdk/$f" "$pkgdir/usr/share/doc/$pkgname/"
+  done
+
+  # BSD License
+  install -Dm644 LICENSE \
+    "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+
+# vim:set ts=2 sw=2 et:


### PR DESCRIPTION
First time trying to commit to this project so if I am doing something wrong please tell me.

The Dart PKGBUILD in Arch Linux is not compatible with Arch Linux ARM because the PKGBUILD is downloading the binary files (x86/x86_64) directly from the Dart project.

This pull request changes the PKGBUILD to be able to download the ARMv7h version from the Dart project. I don't know if this version works with ARMv8 since I do not own such board so I have added "buildarch=4" to the PKGBUILD.

Tested on Beaglebone Black.