### PR TITLE
gcc: switch gcc to the latest snapshot on the gcc-6-branch

### DIFF
--- a/core/gcc/PKGBUILD
+++ b/core/gcc/PKGBUILD
@@ -16,10 +16,11 @@
 noautobuild=1
 
 pkgname=('gcc' 'gcc-libs' 'gcc-fortran' 'gcc-objc' 'gcc-go')
+snapshot_datestamp=20161020
 pkgver=6.2.1
 _pkgver=6
-_islver=0.16.1
-pkgrel=1
+_islver=0.17
+pkgrel=1.1
 _commit=c2103c17
 pkgdesc="The GNU Compiler Collection"
 arch=('i686' 'x86_64')
@@ -28,17 +29,18 @@ url="http://gcc.gnu.org"
 makedepends=('binutils>=2.26' 'libmpc' 'doxygen')
 checkdepends=('dejagnu' 'inetutils')
 options=('!emptydirs' '!distcc')
-source=(https://github.com/gcc-mirror/gcc/archive/${_commit}.tar.gz
+source=(ftp://gcc.gnu.org/pub/gcc/snapshots/${_pkgver}-${snapshot_datestamp}/gcc-${_pkgver}-${snapshot_datestamp}.tar.bz2
         http://isl.gforge.inria.fr/isl-${_islver}.tar.bz2
         0001-ARMv5-disable-LDRD-STRD.patch)
-md5sums=('bfa1b0a973f829beb14fe96e8c14225c'
-         'ac1f25a0677912952718a51f5bc20f32'
+md5sums=('98f94210cbdc38f3e1e630b88cf17d7b'
+         '47dcb4fc963a9a625ccb47b72a167ffa'
          'a5165d78c473b487637d293a49e01740')
 
 _libdir="usr/lib/gcc/$CHOST/$pkgver"
 
 prepare() {
-  mv gcc-${_commit}* gcc
+  [ -d gcc ] && rm -fr gcc
+  mv gcc-${_pkgver}-${snapshot_datestamp} gcc
   cd ${srcdir}/gcc
 
   # link isl for in-tree build
@@ -59,7 +61,7 @@ prepare() {
   [[ $CARCH == "armv7h" ]] && CONFIGFLAG="--host=armv7l-unknown-linux-gnueabihf --build=armv7l-unknown-linux-gnueabihf --with-arch=armv7-a --with-float=hard --with-fpu=vfpv3-d16"
   [[ $CARCH == "aarch64" ]] && CONFIGFLAG="--host=aarch64-unknown-linux-gnu --build=aarch64-unknown-linux-gnu --with-arch=armv8-a"
 
-  mkdir ${srcdir}/gcc-build
+  [ ! -d ${srcdir}/gcc-build ] && mkdir ${srcdir}/gcc-build
 
   # Disable LDRD/STRD on ARMv5 (64-bit alignment issues)
   patch -p1 -i ../0001-ARMv5-disable-LDRD-STRD.patch


### PR DESCRIPTION
Signed-off-by: Jérôme Benoit <jerome.benoit@piment-noir.org>