### PR TITLE
alarm/uboot-cubox-i: build fix for gcc6

### DIFF
--- a/alarm/uboot-cubox-i/PKGBUILD
+++ b/alarm/uboot-cubox-i/PKGBUILD
@@ -15,6 +15,7 @@ option=('!strip')
 _commit=408544d61f230060f18ffe2e06565deadbcf3451
 source=("uboot-${_commit}.tar.gz::https://github.com/SolidRun/u-boot-imx6/archive/${_commit}.tar.gz"
         'kernel-add-support-for-gcc-5.patch'
+        'kernel-add-support-for-gcc-6.patch'
         'arm_board_use_weak.patch'
         'leds_missing_include.patch'
         'remove_unnecessary_inits.patch'
@@ -23,7 +24,8 @@ source=("uboot-${_commit}.tar.gz::https://github.com/SolidRun/u-boot-imx6/archiv
         'common-main.c-make-show_boot_progress-__weak.patch'
         'arch-linux-arm-modifications.patch')
 md5sums=('8dc15f4cf0b244a8d9598a2ce93056a4'
-         '721a46867e189d8dedc6b6f86a536a34'
+	 '721a46867e189d8dedc6b6f86a536a34'
+	 '840a69592300bf7cbc3ad317e8100114'
          'b8cd082b76224d157d55404d0bc87831'
          'cf823fe2da67b8db5b9de9352a815f91'
          '6f3d537701904f0244e6d857e2545c5d'
@@ -31,10 +33,12 @@ md5sums=('8dc15f4cf0b244a8d9598a2ce93056a4'
          '629d34349b5652e2d4274ad89e1c4481'
          '8087672256020417438b12ec4946e1cf'
          '5352b85da1ee65eb4565d375d72b253c')
+
 prepare() {
   cd u-boot-imx6-${_commit}
 
   patch -Np1 -i ../kernel-add-support-for-gcc-5.patch
+  patch -Np1 -i ../kernel-add-support-for-gcc-6.patch
   patch -Np1 -i ../arm_board_use_weak.patch
   patch -Np1 -i ../leds_missing_include.patch
   patch -Np1 -i ../remove_unnecessary_inits.patch

--- a/alarm/uboot-cubox-i/kernel-add-support-for-gcc-6.patch
+++ b/alarm/uboot-cubox-i/kernel-add-support-for-gcc-6.patch
@@ -1,0 +1,71 @@
+--- /dev/null
++++ b/include/linux/compiler-gcc6.h
+@@ -0,0 +1,66 @@
++#ifndef __LINUX_COMPILER_H
++#error "Please don't include <linux/compiler-gcc5.h> directly, include <linux/compiler.h> instead."
++#endif
++
++#define __used				__attribute__((__used__))
++#define __must_check			__attribute__((warn_unused_result))
++#define __compiler_offsetof(a, b)	__builtin_offsetof(a, b)
++
++/* Mark functions as cold. gcc will assume any path leading to a call
++   to them will be unlikely.  This means a lot of manual unlikely()s
++   are unnecessary now for any paths leading to the usual suspects
++   like BUG(), printk(), panic() etc. [but let's keep them for now for
++   older compilers]
++
++   Early snapshots of gcc 4.3 don't support this and we can't detect this
++   in the preprocessor, but we can live with this because they're unreleased.
++   Maketime probing would be overkill here.
++
++   gcc also has a __attribute__((__hot__)) to move hot functions into
++   a special section, but I don't see any sense in this right now in
++   the kernel context */
++#define __cold			__attribute__((__cold__))
++
++#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
++
++#ifndef __CHECKER__
++# define __compiletime_warning(message) __attribute__((warning(message)))
++# define __compiletime_error(message) __attribute__((error(message)))
++#endif /* __CHECKER__ */
++
++/*
++ * Mark a position in code as unreachable.  This can be used to
++ * suppress control flow warnings after asm blocks that transfer
++ * control elsewhere.
++ *
++ * Early snapshots of gcc 4.5 don't support this and we can't detect
++ * this in the preprocessor, but we can live with this because they're
++ * unreleased.  Really, we need to have autoconf for the kernel.
++ */
++#define unreachable() __builtin_unreachable()
++
++/* Mark a function definition as prohibited from being cloned. */
++#define __noclone	__attribute__((__noclone__))
++
++/*
++ * Tell the optimizer that something else uses this function or variable.
++ */
++#define __visible __attribute__((externally_visible))
++
++/*
++ * GCC 'asm goto' miscompiles certain code sequences:
++ *
++ *   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58670
++ *
++ * Work it around via a compiler barrier quirk suggested by Jakub Jelinek.
++ * Fixed in GCC 4.8.2 and later versions.
++ *
++ * (asm goto is automatically volatile - the naming reflects this.)
++ */
++#define asm_volatile_goto(x...)	do { asm goto(x); asm (""); } while (0)
++
++#ifdef CONFIG_ARCH_USE_BUILTIN_BSWAP
++#define __HAVE_BUILTIN_BSWAP32__
++#define __HAVE_BUILTIN_BSWAP64__
++#define __HAVE_BUILTIN_BSWAP16__
++#endif /* CONFIG_ARCH_USE_BUILTIN_BSWAP */
+-- 
+1.9.1


### PR DESCRIPTION
No version bump to avoid useless compilation and reflashing.

Signed-off-by: Jérôme Benoit <jerome.benoit@piment-noir.org>