### PR TITLE
core/linux-odroid: cleanup headers package namespace

### DIFF
--- a/core/linux-odroid/PKGBUILD
+++ b/core/linux-odroid/PKGBUILD
@@ -4,11 +4,11 @@
 buildarch=4
 
 pkgbase=linux-odroid
-pkgname=('linux-odroid-x' 'linux-odroid-x2' 'linux-odroid-u2' 'linux-headers-odroid')
+pkgname=('linux-odroid-x' 'linux-odroid-x2' 'linux-odroid-u2' 'linux-odroid-headers')
 _kernelname=${pkgname#linux}
 _basekernel=3.8
 pkgver=${_basekernel}.13.30
-pkgrel=5
+pkgrel=5.1
 arch=('armv7h')
 url="http://github.com/hardkernel/linux/"
 license=('GPL2')
@@ -196,11 +196,11 @@ package_linux-odroid-u2() {
   mv "$pkgdir/lib" "$pkgdir/usr"
 }
 
-package_linux-headers-odroid() {
+package_linux-odroid-headers() {
   pkgdesc="Header files and scripts for building modules for linux kernel - ODROID-X/X2/U2"
   provides=("linux-headers=${pkgver}")
-  conflicts=('linux-headers-odroidx')
-  replaces=('linux-headers-odroidx')
+  conflicts=('linux-headers-odroidx' 'linux-headers-odroid')
+  replaces=('linux-headers-odroidx' 'linux-headers-odroid')
 
   install -dm755 "${pkgdir}/usr/lib/modules/${_kernver}"
 

--- a/core/linux-odroid/linux-odroid.install
+++ b/core/linux-odroid/linux-odroid.install
@@ -1,7 +1,7 @@
 # arg 1:  the new package version
 # arg 2:  the old package versio
 
-KERNEL_VERSION=3.8.13.30-4-ARCH
+KERNEL_VERSION=3.8.13.30-5.1-ARCH
 
 post_install () {
   # updating module dependencies


### PR DESCRIPTION
follow the rule in ALARM with linux kernel headers: package_name-headers,
and not the reverse

Signed-off-by: Jérôme Benoit <jerome.benoit@piment-noir.org>