### PR TITLE
alarm/kodi-rbp-git: add udev rules to allow video group access to play older files

### DIFF
--- a/alarm/kodi-rbp-git/99-kodi.rules
+++ b/alarm/kodi-rbp-git/99-kodi.rules
@@ -1,0 +1,3 @@
+SUBSYSTEM=="bcm2708_vcio",GROUP="video",MODE="0660"
+SUBSYSTEM=="vc-sm",GROUP="video",MODE="0660"
+SUBSYSTEM=="vchiq",GROUP="video",MODE="0660"

--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -12,7 +12,7 @@ pkgname=('kodi-rbp-git' 'kodi-rbp-git-eventclients')
 pkgver=17.0b5.20161029
 
 _tag=17.0b5-Krypton
-pkgrel=1
+pkgrel=2
 pkgdesc="A software media player and entertainment hub for digital media for the Raspberry Pi"
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
@@ -26,9 +26,11 @@ makedepends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libva'
              'udisks' 'upower' 'git' 'autoconf' 'java-environment' 'libcrossguid-git' 'dcadec' 'libpulse')
 source=("xbmc-${_tag}.tar.gz::https://github.com/xbmc/xbmc/archive/${_tag}.tar.gz"
         'kodi.service'
+        '99-kodi.rules'
         'polkit.rules')
 sha256sums=('e27d31c24de77f5f6b79f32d60c4e34787a2f98dcd7a15339ab6cf290f10a15d'
             '5235068d5800d69f0287087815990e7fe8d6572733d60c8800546d35f608e87f'
+            'ca60da5051475e0807d3f45ed638c15de5c04008f4c6776bb8ae4f2325d8ad23'
             '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96')
 
 prepare() {
@@ -36,7 +38,7 @@ prepare() {
 
   find -type f -name *.py -exec sed 's|^#!.*python$|#!/usr/bin/python2|' -i "{}" +
   sed 's|^#!.*python$|#!/usr/bin/python2|' -i tools/depends/native/rpl-native/rpl
-	sed 's/python/python2/' -i tools/Linux/kodi.sh.in
+  sed 's/python/python2/' -i tools/Linux/kodi.sh.in
   sed 's/shell python/shell python2/' -i tools/EventClients/Makefile.in
   # disable wiiremote due to incompatibility with bluez-5.29
   sed '/WiiRemote/d' -i tools/EventClients/Makefile.in
@@ -136,6 +138,9 @@ package_kodi-rbp-git() {
   install -Dm0644 $srcdir/kodi.service $pkgdir/usr/lib/systemd/system/kodi.service
   install -Dm0644 $srcdir/polkit.rules $pkgdir/usr/share/polkit-1/rules.d/10-kodi.rules
   chmod 0700 $pkgdir/usr/share/polkit-1/rules.d/
+
+  # fix permissions necessary for accelerated video playback
+  install -Dm0644 "$srcdir"/99-kodi.rules "$pkgdir"/etc/udev/rules.d/99-kodi.rules
 }
 
 package_kodi-rbp-git-eventclients() {


### PR DESCRIPTION
Addition of a set of udev rules allowing the video group access to the following required for accelerated video playback.  For rationale see: http://forum.kodi.tv/showthread.php?tid=295230
