### PR TITLE
alarm/kodi-rbp-git: fixup PKGBUILD

### DIFF
--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -12,7 +12,7 @@ pkgname=('kodi-rbp-git' 'kodi-rbp-git-eventclients')
 pkgver=17.0b5.20161029
 
 _tag=17.0b5-Krypton
-pkgrel=2
+pkgrel=3
 pkgdesc="A software media player and entertainment hub for digital media for the Raspberry Pi"
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
@@ -24,7 +24,7 @@ makedepends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libva'
              'libnfs' 'afpfs-ng' 'avahi' 'bluez-libs' 'tinyxml' 'raspberrypi-firmware' 'libcec-rpi'
              'libplist' 'swig' 'taglib' 'libxslt' 'shairplay' 'boost' 'cmake' 'gperf' 'nasm' 'zip'
              'udisks' 'upower' 'git' 'autoconf' 'java-environment' 'libcrossguid-git' 'dcadec' 'libpulse')
-source=("xbmc-${_tag}.tar.gz::https://github.com/xbmc/xbmc/archive/${_tag}.tar.gz"
+source=("xbmc-$_tag.tar.gz::https://github.com/xbmc/xbmc/archive/$_tag.tar.gz"
         'kodi.service'
         '99-kodi.rules'
         'polkit.rules')
@@ -34,7 +34,7 @@ sha256sums=('e27d31c24de77f5f6b79f32d60c4e34787a2f98dcd7a15339ab6cf290f10a15d'
             '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96')
 
 prepare() {
-  cd "$srcdir/xbmc-${_tag}"
+  cd "$srcdir/xbmc-$_tag"
 
   find -type f -name *.py -exec sed 's|^#!.*python$|#!/usr/bin/python2|' -i "{}" +
   sed 's|^#!.*python$|#!/usr/bin/python2|' -i tools/depends/native/rpl-native/rpl
@@ -48,7 +48,7 @@ install:' -i tools/EventClients/Makefile.in
 }
 
 build() {
-  cd "${srcdir}/xbmc-${_tag}"
+  cd "$srcdir/xbmc-$_tag"
 
   # Bootstrapping
   MAKEFLAGS=-j1 ./bootstrap
@@ -71,21 +71,10 @@ build() {
   --disable-gl \
   --enable-gles \
   --disable-x11 \
-  --enable-optimizations \
-  --disable-pulse \
   --disable-vaapi \
   --disable-vdpau \
-  --enable-airplay \
-  --enable-airtunes \
-  --enable-avahi \
-  --enable-libbluray \
   --disable-debug \
   --disable-mid \
-  --enable-nfs \
-  --disable-profiling \
-  --enable-alsa \
-  --enable-pulse \
-  --enable-optical-drive \
   --enable-player=omxplayer \
   --with-lirc-device=/run/lirc/lircd \
   ac_cv_lib_bluetooth_hci_devid=no
@@ -115,14 +104,14 @@ package_kodi-rbp-git() {
     'unrar: access compressed files without unpacking them'
     'lsb-release: log distro information in crashlog')
 
-  install="kodi.install"
+  install='kodi.install'
   provides=('xbmc' 'kodi')
   conflicts=('xbmc' 'kodi' 'arm-mem-git' 'shairplay-git')
   replaces=('xbmc-rbp-git')
 
-  cd "$srcdir/xbmc-${_tag}"
+  cd "$srcdir/xbmc-$_tag"
   # Running make install
-  make DESTDIR="${pkgdir}" install
+  make DESTDIR="$pkgdir" install
 
   # We will no longer support the xbmc name
   rm "$pkgdir/usr/share/xsessions/xbmc.desktop"
@@ -130,17 +119,17 @@ package_kodi-rbp-git() {
   # we will leave /usr/{include,lib,share}/xbmc for now
 
   # Licenses
-  install -d -m 0755 "${pkgdir}${_prefix}/share/licenses/${pkgname}"
+  install -dm0755 "$pkgdir$_prefix/share/licenses/$pkgname"
   for licensef in LICENSE.GPL copying.txt; do
-    mv "${pkgdir}${_prefix}/share/doc/kodi/${licensef}" "${pkgdir}${_prefix}/share/licenses/${pkgname}"
+    mv "$pkgdir$_prefix/share/doc/kodi/$licensef" "$pkgdir$_prefix/share/licenses/$pkgname"
   done
 
-  install -Dm0644 $srcdir/kodi.service $pkgdir/usr/lib/systemd/system/kodi.service
-  install -Dm0644 $srcdir/polkit.rules $pkgdir/usr/share/polkit-1/rules.d/10-kodi.rules
-  chmod 0700 $pkgdir/usr/share/polkit-1/rules.d/
+  install -Dm0644 "$srcdir/kodi.service" "$pkgdir/usr/lib/systemd/system/kodi.service"
+  install -Dm0644 "$srcdir/polkit.rules" "$pkgdir/usr/share/polkit-1/rules.d/10-kodi.rules"
+  chmod 0700 "$pkgdir/usr/share/polkit-1/rules.d/"
 
   # fix permissions necessary for accelerated video playback
-  install -Dm0644 "$srcdir"/99-kodi.rules "$pkgdir"/etc/udev/rules.d/99-kodi.rules
+  install -Dm0644 "$srcdir/99-kodi.rules" "$pkgdir/etc/udev/rules.d/99-kodi.rules"
 }
 
 package_kodi-rbp-git-eventclients() {
@@ -149,7 +138,7 @@ package_kodi-rbp-git-eventclients() {
   conflicts=('kodi-eventclients')
   depends=('cwiid')
 
-  cd "$srcdir/xbmc-${_tag}"
+  cd "$srcdir/xbmc-$_tag"
 
   make DESTDIR="$pkgdir" eventclients WII_EXTRA_OPTS=-DCWIID_OLD
 }


### PR DESCRIPTION
Standardized the use of quotes and variables through out the PKGBUILD.  The configure step contained options that are defaulted either by an auto settings that will pick them up based on the dependencies or that are hard coded into configure so remove them.  In one case, an option as defined twice (pulse).  Changes build fine and lead to a functional package on RPi3.