### PR TITLE
core/systemd: update to version 232

### DIFF
--- a/core/systemd/PKGBUILD
+++ b/core/systemd/PKGBUILD
@@ -7,8 +7,8 @@
 
 pkgbase=systemd
 pkgname=('systemd' 'libsystemd' 'systemd-sysvcompat')
-pkgver=231
-pkgrel=4
+pkgver=232
+pkgrel=1
 arch=('i686' 'x86_64')
 url="http://www.freedesktop.org/wiki/Software/systemd"
 makedepends=('acl' 'cryptsetup' 'docbook-xsl' 'gperf' 'lz4' 'xz' 'pam' 'libelf'
@@ -35,8 +35,6 @@ md5sums=('SKIP'
 
 _backports=(
   '531ac2b2349da02acc9c382849758e07eb92b020'  # If the notification message length is 0, ignore the message
-  '8523bf7dd514a3a2c6114b7b8fb8f308b4f09fc4'  # pid1: process zero-length notification messages again
-  '9987750e7a4c62e0eb8473603150596ba7c3a015'  # pid1: don't return any error in manager_dispatch_notify_fd()
   'bd64d82c1c0e3fe2a5f9b3dd9132d62834f50b2d'  # Revert "pid1: reconnect to the console before being re-executed"
   'bd5b9f0a12dd9c1947b11534e99c395ddf44caa9'  # systemctl: suppress errors with "show" for nonexistent units and properties
 )
@@ -167,8 +165,7 @@ package_libsystemd() {
   license=('GPL2')
   provides=('libsystemd.so' 'libudev.so')
 
-  # TODO(dreisner): for v232, this should be install-rootlibLTLIBRARIES.
-  make -C "$pkgbase" DESTDIR="$pkgdir" install-libLTLIBRARIES
+  make -C "$pkgbase" DESTDIR="$pkgdir" install-rootlibLTLIBRARIES
 }
 
 package_systemd-sysvcompat() {


### PR DESCRIPTION
Updating to the latest version of systemd fix the seccomp and seccomp-bpf
handling in case of kernel lacking the two related features.
Current systemd version shipped in ALARM images with kernels without
the features are barely ununsable: timeout at console login, timeout at
networking, etc.

Full changelog here : https://github.com/systemd/systemd/blob/master/NEWS

Also,
- drop uneeded backported patches that have been upstreamed;
- follow and remove a TODO for this version.

Signed-off-by: Jérôme Benoit <jerome.benoit@piment-noir.org>