### PR TITLE
alarm/kodi-rbp to 16.1-5

### DIFF
--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -12,7 +12,7 @@ pkgbase=kodi-rbp
 pkgname=('kodi-rbp' 'kodi-rbp-eventclients')
 pkgver=16.1
 _codename=Jarvis
-pkgrel=4
+pkgrel=5
 pkgdesc="A software media player and entertainment hub for digital media for the Raspberry Pi"
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
@@ -123,7 +123,8 @@ package_kodi-rbp() {
     'udisks: automount external drives'
     'upower: used to trigger power management functionality'
     'unrar: access compressed files without unpacking them'
-    'lsb-release: log distro information in crashlog')
+    'lsb-release: log distro information in crashlog'
+    'gdb: stack trace in crashlog')
 
   install="kodi.install"
   provides=('xbmc' 'kodi')
@@ -146,6 +147,7 @@ package_kodi-rbp() {
   done
 
   install -Dm0644 $srcdir/kodi.service $pkgdir/usr/lib/systemd/system/kodi.service
+  mkdir -m700 -p $pkgdir/usr/share/polkit-1/rules.d/
   install -Dm0644 $srcdir/polkit.rules $pkgdir/usr/share/polkit-1/rules.d/10-kodi.rules
   chmod 0750 $pkgdir/usr/share/polkit-1/rules.d/
 }

--- a/alarm/kodi-rbp/kodi.service
+++ b/alarm/kodi-rbp/kodi.service
@@ -1,6 +1,6 @@
 [Unit]
 Description = Starts an instance of Kodi
-After = remote-fs.target
+After = remote-fs.target lircd.service getty.target
 
 [Service]
 User = kodi


### PR DESCRIPTION
* Fixes transparent black boarders when used as systemd service
* Added gdb as optional dependency for stack traces
* Start kodi after lircd service to ensure lircd runs first
* Fixed a polkit permission warning when installing the package

-> Those changes should also be adopted to the -git package possibly.