### PR TITLE
Enable mmal support for motion package

### DIFF
--- a/community/motion/PKGBUILD
+++ b/community/motion/PKGBUILD
@@ -6,12 +6,12 @@
 
 pkgname=motion
 pkgver=4.0.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A software motion detector which grabs images from video4linux devices and/or from webcams"
 arch=('i686' 'x86_64')
 license=('GPL')
 url="http://www.lavrsen.dk/foswiki/bin/view/Motion/WebHome"
-depends=('libjpeg' 'v4l-utils' 'ffmpeg')
+depends=('libjpeg' 'v4l-utils' 'ffmpeg' 'raspberrypi-firmware-tools')
 backup=('etc/motion/motion.conf')
 options=('!makeflags')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/Motion-Project/motion/archive/release-$pkgver.tar.gz")


### PR DESCRIPTION
Add raspberrypi-firmware-tools as depends to enable mmal support.
configure detects this by checking for existence of path /opt/vc/include/interface/mmal.