### PR TITLE
community/python-kivy: search /usr/lib for libMali

### DIFF
--- a/community/python-kivy/PKGBUILD
+++ b/community/python-kivy/PKGBUILD
@@ -1,0 +1,74 @@
+# $Id: PKGBUILD 182562 2016-07-09 10:36:14Z felixonmars $
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+# Contributor: Lev Lybin <lev.lybin@gmail.com>
+# Contributor: lagrange <flkazemakase@gmail.com>
+# Contributor: mid-kid <esteve.varela@gmail.com>
+
+# ALARM: Joseph Kogut <joseph.kogut@gmail.com>
+# - patch to find libMali.so
+
+pkgbase=python-kivy
+pkgname=('python-kivy' 'python2-kivy')
+pkgver=1.9.1
+pkgrel=2
+pkgdesc="A software library for rapid development of hardware-accelerated multitouch applications."
+arch=('i686' 'x86_64')
+url="http://kivy.org/"
+license=('MIT')
+makedepends=('python-setuptools' 'python2-setuptools' 'cython' 'cython2' 'gstreamer' 'sdl2_ttf'
+             'sdl2_mixer' 'sdl2_image')
+checkdepends=('python-nose' 'python2-nose' 'python2-mock' 'python-coverage' 'python2-coverage'
+              'python-dbus' 'python2-dbus' 'python-gobject' 'python2-gobject' 'xorg-server-xvfb'
+              'git' 'mtdev' 'xclip' 'xsel' 'gst-plugins-base' 'gst-plugins-good')
+source=("https://pypi.python.org/packages/source/K/Kivy/kivy-$pkgver.tar.gz"
+	"autodetect-libmali.patch")
+
+sha256sums=('29bc45be34c26a8acb1dafdd329145f997a473be344cd052659f821f6478637e'
+            '8261f9a9208ea26082a9fad1f836e2b1effa4d79e16933b3fbd5444458ee3642')
+
+prepare() {
+  # For better metadata
+  export KIVY_USE_SETUPTOOLS=1
+
+  export LC_CTYPE=en_US.UTF-8
+
+  pushd "$srcdir"/kivy-$pkgver
+  patch -p1 -i ../autodetect-libmali.patch
+  popd
+
+  cp -r kivy-$pkgver{,-py2}
+}
+
+build() {
+  cd "$srcdir"/kivy-$pkgver
+  python setup.py build build_ext --inplace
+
+  cd "$srcdir"/kivy-$pkgver-py2
+  python2 setup.py build build_ext --inplace
+}
+
+check() {
+  cd "$srcdir"/kivy-$pkgver
+  PYTHONPATH="$PWD:$PYTHONPATH" xvfb-run -s "-screen 0 1280x720x24 -ac +extension GLX" make test
+
+  cd "$srcdir"/kivy-$pkgver-py2
+  PYTHONPATH="$PWD:$PYTHONPATH" xvfb-run -s "-screen 0 1280x720x24 -ac +extension GLX" make PYTHON=python2 test
+}
+
+package_python-kivy() {
+  depends=('python' 'gstreamer' 'sdl2_ttf' 'sdl2_mixer' 'sdl2_image')
+
+  cd kivy-$pkgver
+  python setup.py install --prefix=/usr --root="$pkgdir"
+  install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+}
+
+package_python2-kivy() {
+  depends=('python2' 'gstreamer' 'sdl2_ttf' 'sdl2_mixer' 'sdl2_image')
+
+  cd kivy-$pkgver-py2
+  python2 setup.py install --prefix=/usr --root="$pkgdir"
+  install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+
+  mv "$pkgdir"/usr/share/kivy{,2}-examples
+}

--- a/community/python-kivy/autodetect-libmali.patch
+++ b/community/python-kivy/autodetect-libmali.patch
@@ -1,0 +1,53 @@
+From 00247d477164793c8dff084751cf54734c209162 Mon Sep 17 00:00:00 2001
+From: Joseph Kogut <joseph.kogut@gmail.com>
+Date: Thu, 6 Oct 2016 16:34:03 +0000
+Subject: [PATCH] setup.py search /usr/lib recursively for libMali
+
+When detecting platform 'mali', the current setup code uses a
+predefined path to detect the presence of the userspace mali GLES
+library, which works on Debian based distros.
+
+Other distros may install the library in a different location. Arch,
+for instance, installs it to /usr/lib/mali-egl/libMali.so.
+
+This patch searches /usr/lib/ recursively for the library.
+---
+ setup.py | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 7ce58f8..4c12f8b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -86,6 +86,13 @@ def pkgconfig(*packages, **kw):
+     else:
+         osx_arch = 'i386'
+ 
++# search for libMali.so
++libmali_path = None
++for root, subFolders, files in walk('/usr/lib'):
++    for fn in files:
++        if fn == 'libMali.so':
++            libmali_path = os.path.join(root, fn)
++
+ # Detect Python for android project (http://github.com/kivy/python-for-android)
+ ndkplatform = environ.get('NDKPLATFORM')
+ if ndkplatform is not None and environ.get('LIBLINK'):
+@@ -95,7 +102,7 @@ def pkgconfig(*packages, **kw):
+     platform = 'ios'
+ if exists('/opt/vc/include/bcm_host.h'):
+     platform = 'rpi'
+-if exists('/usr/lib/arm-linux-gnueabihf/libMali.so'):
++if exists(libmali_path):
+     platform = 'mali'
+ 
+ # -----------------------------------------------------------------------------
+@@ -582,7 +589,7 @@ def determine_gl_flags():
+         flags['libraries'] = ['bcm_host', 'EGL', 'GLESv2']
+     elif platform == 'mali':
+         flags['include_dirs'] = ['/usr/include/']
+-        flags['library_dirs'] = ['/usr/lib/arm-linux-gnueabihf']
++        flags['library_dirs'] = [libmali_path]
+         flags['libraries'] = ['GLESv2']
+         c_options['use_x11'] = True
+         c_options['use_egl'] = True


### PR DESCRIPTION
When detecting platform 'mali', the current Kivy setup code uses a
predefined path to detect the presence of the userspace mali GLES
library, which works on Debian based distros.

Other distros may install the library in a different location. Arch,
for instance, installs it to /usr/lib/mali-egl/libMali.so.

This patch searches /usr/lib/ recursively for the library.