### PR TITLE
[kodi-rpb-git] - allow USB keyboard to work out-of-the-box

### DIFF
--- a/alarm/kodi-rbp-git/99-kodi.rules
+++ b/alarm/kodi-rbp-git/99-kodi.rules
@@ -1,3 +1,4 @@
 SUBSYSTEM=="bcm2708_vcio",GROUP="video",MODE="0660"
 SUBSYSTEM=="vc-sm",GROUP="video",MODE="0660"
 SUBSYSTEM=="vchiq",GROUP="video",MODE="0660"
+SUBSYSTEM=="tty", KERNEL=="tty[0-9]*", GROUP="tty", MODE="0660"

--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -12,7 +12,7 @@ pkgname=('kodi-rbp-git' 'kodi-rbp-git-eventclients')
 pkgver=17.0b5.20161029
 
 _tag=17.0b5-Krypton
-pkgrel=3
+pkgrel=4
 pkgdesc="A software media player and entertainment hub for digital media for the Raspberry Pi"
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
@@ -30,7 +30,7 @@ source=("xbmc-$_tag.tar.gz::https://github.com/xbmc/xbmc/archive/$_tag.tar.gz"
         'polkit.rules')
 sha256sums=('e27d31c24de77f5f6b79f32d60c4e34787a2f98dcd7a15339ab6cf290f10a15d'
             '5235068d5800d69f0287087815990e7fe8d6572733d60c8800546d35f608e87f'
-            'ca60da5051475e0807d3f45ed638c15de5c04008f4c6776bb8ae4f2325d8ad23'
+            'b31570f95654434b01fd8531612fbb6be77cbc1c519dd60f92feae26eb160f3d'
             '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96')
 
 prepare() {

--- a/alarm/kodi-rbp-git/kodi.install
+++ b/alarm/kodi-rbp-git/kodi.install
@@ -3,7 +3,7 @@ post_install() {
   [[ $(type -p update-desktop-database) ]] && usr/bin/update-desktop-database -q usr/share/applications
   getent group kodi > /dev/null || groupadd -r kodi
   getent passwd kodi > /dev/null || useradd -r -m -d /var/lib/kodi -g kodi -s /usr/bin/nologin kodi
-  usermod -a -G kodi,audio,video,power,network,optical,storage,disk kodi
+  usermod -a -G kodi,audio,video,power,network,optical,storage,disk,tty,input kodi
   mkdir -p var/lib/kodi
   chown -R kodi:kodi var/lib/kodi
 


### PR DESCRIPTION
Changes introduced:
* udev rule to enable keyboard to work
* modification of kodi user on install to be in tty and input groups

Why needed:
* USB keyboards do not work out-of-the-box without this modification

Note:
* If approved, this should be backported to [alarm]/kodi-rbp as well.