### PR TITLE
alarm/kodi-rpb-git: switch to software decode for GMC files

### DIFF
--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -12,7 +12,7 @@ pkgname=('kodi-rbp-git' 'kodi-rbp-git-eventclients')
 pkgver=17.0b5.20161029
 
 _tag=17.0b5-Krypton
-pkgrel=4
+pkgrel=5
 pkgdesc="A software media player and entertainment hub for digital media for the Raspberry Pi"
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
@@ -27,14 +27,23 @@ makedepends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libva'
 source=("xbmc-$_tag.tar.gz::https://github.com/xbmc/xbmc/archive/$_tag.tar.gz"
         'kodi.service'
         '99-kodi.rules'
+        'https://github.com/popcornmix/xbmc/commit/0c320b6cdd4fb409be45008e6b9042463d54b742.patch'
+        'https://github.com/popcornmix/xbmc/commit/4d983105d7fd65b1d92f2ae2602e6e1cdcaddbe0.patch'
         'polkit.rules')
 sha256sums=('e27d31c24de77f5f6b79f32d60c4e34787a2f98dcd7a15339ab6cf290f10a15d'
             '5235068d5800d69f0287087815990e7fe8d6572733d60c8800546d35f608e87f'
             'b31570f95654434b01fd8531612fbb6be77cbc1c519dd60f92feae26eb160f3d'
+            '813f8c622c341eefb33774115199d2abe9c189cf2ce52e79719dbd42d48a1274'
+            'd830c010ead152bc9a9ba6b812c985d6e649bda7480fec9b3c451f5ea03ba792'
             '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96')
 
 prepare() {
   cd "$srcdir/xbmc-$_tag"
+
+  # ffmpeg: Automatic switch to software decode for GMC with more than one warp point
+  patch -Np1 -i "$srcdir/0c320b6cdd4fb409be45008e6b9042463d54b742.patch"
+  # hacky fix for files with GMC
+  patch -Np1 -i "$srcdir/4d983105d7fd65b1d92f2ae2602e6e1cdcaddbe0.patch"
 
   find -type f -name *.py -exec sed 's|^#!.*python$|#!/usr/bin/python2|' -i "{}" +
   sed 's|^#!.*python$|#!/usr/bin/python2|' -i tools/depends/native/rpl-native/rpl


### PR DESCRIPTION
Changes introduced:

* Include patches from popcornmix's branch of kodi to solve issue of video tearing on playback of some video files.

Why needed:
* VIdeo files encoded with GMC (global motion compensation) cause the problem on RPi3.  The patches switch to software decoding mode when GMC is detected to avoid the tearing without user intervention and are including in LibreELEC and OSMC.

> Due to the extra decoding CPU cost of global motion compensation, most hardware players do not support global motion compensation.

Verified to solve the tearing issue on my box; non-GMC files seem to play just fine for the 5 that I tested.

[Link](http://forum.kodi.tv/showthread.php?tid=297524) to kodi forum thread for additional background info.