### PR TITLE
alarm/kodi-rbp-git: update to 17.0v6

### DIFF
--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -9,10 +9,10 @@ _prefix=/usr
 
 pkgbase=kodi-rbp-git
 pkgname=('kodi-rbp-git' 'kodi-rbp-git-eventclients')
-pkgver=17.0b5.20161029
+pkgver=17.0b6.20161201
 
-_tag=17.0b5-Krypton
-pkgrel=6
+_tag=17.0b6-Krypton
+pkgrel=1
 pkgdesc="A software media player and entertainment hub for digital media for the Raspberry Pi"
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
@@ -30,7 +30,7 @@ source=("xbmc-$_tag.tar.gz::https://github.com/xbmc/xbmc/archive/$_tag.tar.gz"
         'https://github.com/popcornmix/xbmc/commit/0c320b6cdd4fb409be45008e6b9042463d54b742.patch'
         'https://github.com/popcornmix/xbmc/commit/4d983105d7fd65b1d92f2ae2602e6e1cdcaddbe0.patch'
         'polkit.rules')
-sha256sums=('e27d31c24de77f5f6b79f32d60c4e34787a2f98dcd7a15339ab6cf290f10a15d'
+sha256sums=('961330e0b833793a6d58a00f29b58869dab643a24bf7622b790a43a2dde6fa4b'
             '5235068d5800d69f0287087815990e7fe8d6572733d60c8800546d35f608e87f'
             'b31570f95654434b01fd8531612fbb6be77cbc1c519dd60f92feae26eb160f3d'
             '813f8c622c341eefb33774115199d2abe9c189cf2ce52e79719dbd42d48a1274'


### PR DESCRIPTION
Beta 6 was released and this PR should bring out package up to this version.