### PR TITLE
odroid-c2: added xf86-video-fbturbo-odroid-c2-git package

### DIFF
--- a/alarm/xf86-video-fbturbo-odroid-c2-git/PKGBUILD
+++ b/alarm/xf86-video-fbturbo-odroid-c2-git/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Kameron Larsen <kroylar@gmail.com>
+# Based on xf86-video-fbturbo-git
+
+buildarch=8
+
+pkgname=xf86-video-fbturbo-odroid-c2-git
+_gitname=xf86-video-fbturbo
+pkgver=199.f9a6ed7
+pkgrel=1
+pkgdesc="X.org fbturbo video driver for odroid-c2"
+arch=('aarch64')
+url="https://github.com/tnmeyer/xf86-video-fbturbo"
+license=('MIT')
+makedepends=('git' 'xorg-server-devel' 'X-ABI-VIDEODRV_VERSION=20')
+conflicts=('xf86-video-fbturbo' 'xorg-server<1.16' 'X-ABI-VIDEODRV_VERSION<20' 'X-ABI-VIDEODRV_VERSION>=21')
+options=('!libtool')
+provides=('xf86-video-fbturbo')
+source=('git+https://github.com/tnmeyer/xf86-video-fbturbo')
+md5sums=('SKIP')
+
+pkgver() {
+  cd "${SRCDEST}/${_gitname}"
+  echo $(git rev-list --count master).$(git rev-parse --short master)
+}
+
+build() {
+  cd "${srcdir}/${_gitname}"
+  ./autogen.sh
+  ./configure --prefix=/usr
+  make
+}
+
+package() {
+  cd "${srcdir}/${_gitname}"
+  mkdir -p "${pkgdir}/etc/X11/xorg.conf.d/"
+  cp "xorg.conf" "${pkgdir}/etc/X11/xorg.conf.d/99-fbturbo.conf"
+  make DESTDIR="${pkgdir}/" install
+  install -m755 -d "${pkgdir}/usr/share/licenses/${pkgname}"
+  install -m644 COPYING "${pkgdir}/usr/share/licenses/${pkgname}/"
+}


### PR DESCRIPTION
Currently, this fbturbo driver is faster than the mali driver on odroid-c2. I added a new package entirely based on the [current xf86-video-fbturbo-git PKGBUILD](https://github.com/archlinuxarm/PKGBUILDs/blob/master/alarm/xf86-video-fbturbo-git/PKGBUILD).