### PR TITLE
alarm/libcec-imx6: Variable name changed

### DIFF
--- a/alarm/libcec-imx6/PKGBUILD
+++ b/alarm/libcec-imx6/PKGBUILD
@@ -47,7 +47,7 @@ build() {
         -DCMAKE_INSTALL_LIBDIR=/usr/lib \
         -DCMAKE_INSTALL_LIBDIR_NOARCH=/usr/lib \
         -DHAVE_EXYNOS_API=0 \
-        -DHAVE_IMX6_API=1 \
+        -DHAVE_IMX_API=1 \
         -DRPI_INCLUDE_DIR=/opt/vc/include \
         -DRPI_LIB_DIR=/opt/vc/lib
     make


### PR DESCRIPTION
Variable name changed. See in `libcec-00-imx6-support.patch`