### PR TITLE
alarm/kodi-odroid to 17.0.beta7

### DIFF
--- a/alarm/kodi-odroid/PKGBUILD
+++ b/alarm/kodi-odroid/PKGBUILD
@@ -16,8 +16,8 @@ _prefix=/usr
 
 pkgbase=kodi-odroid
 pkgname=('kodi-odroid' 'kodi-odroid-eventclients')
-_commit=897ed895615ce234f2baeb2fc586e392035b7b0f
-pkgver=17.0.beta4
+_commit=a04d7c60904e46eca888654b9f39b0162d657bdf
+pkgver=17.0.beta7
 pkgrel=1
 arch=('armv7h')
 url="http://kodi.tv"
@@ -30,17 +30,16 @@ makedepends=(
   'libxrandr' 'libxslt' 'lzo' 'nasm' 'nss-mdns' 'python2-pillow'
   'python2-pybluez' 'python2-simplejson' 'rtmpdump' 'sdl2' 'sdl_image'
   'shairplay' 'smbclient' 'swig' 'taglib' 'tinyxml' 'unzip' 'upower' 'yajl' 'zip'
-  'mesa' 'libdcadec.so' 'libcrossguid'
+  'mesa' 'libdcadec.so' 'libcrossguid' 'libcec'
 )
 
 source=("https://github.com/Owersun/xbmc/archive/${_commit}.tar.gz")
-sha256sums=('6e963cfde897fa4f957da517fa4e48e98b6f4d5cade60c67fc22af927213c027')
+sha256sums=('e8713be4b673b1bbcca0d4841a091b96717251708bd592c4a0a6b3e51aef3ab1')
 prepare() {
   cd xbmc-${_commit}
 
   find -type f -name *.py -exec sed 's|^#!.*python$|#!/usr/bin/python2|' -i "{}" +
   sed 's|^#!.*python$|#!/usr/bin/python2|' -i tools/depends/native/rpl-native/rpl
-  sed 's/python/python2/' -i tools/Linux/kodi.sh.in
 }
 
 build() {
@@ -95,6 +94,7 @@ package_kodi-odroid() {
     'libnfs: NFS shares support'
     'libplist: AirPlay support'
     'lirc: Remote controller support'
+    'libcec: CEC (Consumer Electronics Control) allows to control devices over HDMI port'
     'pulseaudio: PulseAudio support'
     'shairplay: AirPlay support'
     'udisks: Automount external drives'


### PR DESCRIPTION
I have been running this version with no glitches on my Odroid U3 for 3 days.

I have also enabled the missing in the previous version [CEC support](http://kodi.wiki/view/CEC#Settings_in_Kodi_for_CEC).