### PR TITLE
alarm/uboot-sunxi: added support for Cubieboard4 and changed source to 2016.11

### DIFF
--- a/alarm/uboot-sunxi/0001-arch-linux-arm-modifications.patch
+++ b/alarm/uboot-sunxi/0001-arch-linux-arm-modifications.patch
@@ -1,18 +1,31 @@
-From a4777cc3ee0d37d336e2769b00ca57ef67be78de Mon Sep 17 00:00:00 2001
-From: Kevin Mihelich <kevin@archlinuxarm.org>
-Date: Fri, 2 Jan 2015 20:16:57 -0700
-Subject: [PATCH] arch linux arm modifications
+From d23596b2d0b4f0a556ab4638b028fcf01f867dff Mon Sep 17 00:00:00 2001
+From: Michael Schmidt <michael.schmidt@sydney.edu.au>
+Date: Sat, 17 Dec 2016 14:07:57 +1100
+Subject: [PATCH] arch linux arm
 
 ---
+ board/sunxi/Kconfig              | 2 +-
  include/config_distro_defaults.h | 3 +++
- include/configs/sunxi-common.h   | 2 +-
  2 files changed, 4 insertions(+), 1 deletion(-)
 
+diff --git a/board/sunxi/Kconfig b/board/sunxi/Kconfig
+index e1d4ab148f..bb3d73e550 100644
+--- a/board/sunxi/Kconfig
++++ b/board/sunxi/Kconfig
+@@ -1,7 +1,7 @@
+ if ARCH_SUNXI
+ 
+ config IDENT_STRING
+-	default " Allwinner Technology"
++	default " Arch Linux ARM"
+ 
+ config PRE_CONSOLE_BUFFER
+ 	default y
 diff --git a/include/config_distro_defaults.h b/include/config_distro_defaults.h
-index 766a212..0df77cd 100644
+index f2e87ee2f3..ef60d0addc 100644
 --- a/include/config_distro_defaults.h
 +++ b/include/config_distro_defaults.h
-@@ -57,4 +57,7 @@
+@@ -29,4 +29,7 @@
  #define CONFIG_SUPPORT_RAW_INITRD
  #define CONFIG_ENV_VARS_UBOOT_CONFIG
  
@@ -20,19 +33,6 @@ index 766a212..0df77cd 100644
 +#define CONFIG_PARTITION_UUIDS
 +
  #endif	/* _CONFIG_CMD_DISTRO_DEFAULTS_H */
-diff --git a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
-index 2406115..8c64bbd 100644
---- a/include/configs/sunxi-common.h
-+++ b/include/configs/sunxi-common.h
-@@ -173,7 +173,7 @@
- #define CONFIG_SYS_NO_FLASH
- 
- #define CONFIG_SYS_MONITOR_LEN		(768 << 10)	/* 768 KiB */
--#define CONFIG_IDENT_STRING		" Allwinner Technology"
-+#define CONFIG_IDENT_STRING		" Arch Linux ARM"
- #define CONFIG_DISPLAY_BOARDINFO
- 
- #define CONFIG_ENV_OFFSET		(544 << 10) /* (8 + 24 + 512) KiB */
 -- 
-2.8.3
+2.11.0
 

--- a/alarm/uboot-sunxi/PKGBUILD
+++ b/alarm/uboot-sunxi/PKGBUILD
@@ -13,11 +13,12 @@ pkgname=('uboot-a10-olinuxino-lime'
          'uboot-a20-olinuxino-micro'
          'uboot-cubieboard'
          'uboot-cubieboard2'
+         'uboot-cubieboard4'
          'uboot-cubietruck'
          'uboot-pcduino'
          'uboot-pcduino3'
          'uboot-pcduino3-nano')
-pkgver=2016.07
+pkgver=2016.11
 pkgrel=1
 arch=('armv7h')
 url="http://git.denx.de/u-boot.git/"
@@ -28,8 +29,8 @@ source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
         '0001-arch-linux-arm-modifications.patch'
         'boot.txt'
         'mkscr')
-md5sums=('425a3fa610a7d972e5092a0e92276c70'
-         'a9303cc01e222117a870e1166266e02c'
+md5sums=('ca1f6e019d08aff8d0ca1beb2e66737d'
+         '72a6008f4d754606452e6b234a5c8a52'
          'b05eae006e4e35176ee3032eba1c4663'
          '021623a04afd29ac3f368977140cfbfd')
 
@@ -42,6 +43,7 @@ boards=('A10-OLinuXino-Lime'
         'A20-OLinuXino_MICRO'
         'Cubieboard'
         'Cubieboard2'
+        'Cubieboard4'
         'Cubietruck'
         'Linksprite_pcDuino'
         'Linksprite_pcDuino3'
@@ -191,6 +193,20 @@ package_uboot-cubieboard2() {
 
   install -d "${pkgdir}"/boot
   install -Dm644 bin_Cubieboard2/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot/u-boot-sunxi-with-spl.bin
+
+  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
+  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
+  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
+}
+
+package_uboot-cubieboard4() {
+  pkgdesc="U-Boot for Cubieboard 4"
+  install=${pkgbase}.install
+  provides=('uboot-sunxi')
+  conflicts=('uboot-sunxi')
+
+  install -d "${pkgdir}"/boot
+  install -Dm644 bin_Cubieboard4/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot/u-boot-sunxi-with-spl.bin
 
   install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
   install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr


### PR DESCRIPTION
I changed uboot version from 2016.07 to 2016.11 and added support for Cubieboard 4. 
CONFIG_IDENT_STRING has been moved from include/configs/sunxi-common.h to board/sunxi/Kconfig.

The updated uboot version allows to boot on Cubieboard4 from SD card. The standard armv7 kernel still fails to boot with the error message "Waiting for root device PARTUUID=". It is possible to boot a custom kernel from the sunxi-next kernel branch https://github.com/linux-sunxi/linux-sunxi/tree/sunxi-next using the default configuration 
make sunxi_defconfig
However I did not manage yet to get the network to work. I will look further into it and submit a pull request for a kernel as soon as I managed to create one, which supports basic functionality.