### PR TITLE
extra/pyqt5: Add back qt5-webengine makedepend

### DIFF
--- a/extra/pyqt5/PKGBUILD
+++ b/extra/pyqt5/PKGBUILD
@@ -5,8 +5,6 @@
 # Contributor: Douglas Soares de Andrade <douglas@archlinux.org>
 # Contributor: riai <riai@bigfoot.com> Ben <ben@benmazer.net>
 
-# ALARM: Kevin Mihelich <kevin@archlinuxarm.org>
-#  - remove qt5-webengine makedepend, not built for ARM
 
 pkgbase=pyqt5
 pkgname=('pyqt5-common' 'python-pyqt5' 'python2-pyqt5')
@@ -19,7 +17,7 @@ license=('GPL')
 makedepends=('python-sip' 'python2-sip' 'python-opengl' 'python2-opengl'
              'python2-dbus' 'python-dbus' 'qt5-connectivity'
              'qt5-multimedia' 'qt5-tools' 'qt5-serialport' 'qt5-svg'
-             'qt5-webkit' 'qt5-websockets' 'qt5-x11extras')
+             'qt5-webengine' 'qt5-webkit' 'qt5-websockets' 'qt5-x11extras')
 source=("http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-$pkgver/PyQt5_gpl-$pkgver.tar.gz" pyqt-qt5.7.1.patch)
 md5sums=('e3dc21f31fd714659f0688e1eb31bacf'
          '6f00ffd5def3ccb853c5e0d794f897b2')


### PR DESCRIPTION
With a6a83b917e609abaa29d6f46e4762792097141e7 QtWebEngine is now
functional.