### PR TITLE
alarm/kodi-rbp-git: update to 17.0rc2.20170101-2

### DIFF
--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -12,7 +12,7 @@ pkgname=('kodi-rbp-git' 'kodi-rbp-git-eventclients')
 pkgver=17.0rc2.20170101
 
 _tag=17.0rc2-Krypton
-pkgrel=1
+pkgrel=2
 pkgdesc="A software media player and entertainment hub for digital media for the Raspberry Pi"
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
@@ -101,11 +101,12 @@ package_kodi-rbp-git() {
            'yajl' 'libmariadbclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd'
            'sdl_image' 'python2' 'python2-pillow' 'python2-pybluez' 'python2-simplejson' 'libass'
            'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray'
-           'libnfs' 'avahi' 'bluez-libs' 'tinyxml' 'raspberrypi-firmware' 'libcec-rpi'
+           'libnfs' 'avahi' 'bluez-libs' 'tinyxml' 'raspberrypi-firmware'
            'libplist' 'swig' 'taglib' 'libxslt' 'shairplay' 'libcrossguid-git')
 
   optdepends=(
     'afpfs-ng: Apple shares support'
+    'libcec-rpi: Pulse-Eight USB-CEC adapter support'
     'lirc: remote controller support'
     'polkit: permissions for automounting external drives and power management functionality'
     'udisks: automount external drives'


### PR DESCRIPTION
The PR will allow libcec to be optional rather than required as it is with the official package.  On some systems, the kodi.log can be spammed with megabytes of errors if the using the 3.5mm jack for other autio output while the HDMI is connected to the TV.

I have been running this as-is without ill effect.