### PR TITLE
alarm/kodi-rbp-git: update to 17.0rc3.20170114-2

### DIFF
--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -14,7 +14,7 @@ _suffix=rbp-git
 pkgname=("kodi-$_suffix" "kodi-eventclients-$_suffix" "kodi-tools-texturepacker-$_suffix" "kodi-dev-$_suffix")
 pkgver=17.0rc3.20170114
 _tag=17.0rc3-Krypton
-pkgrel=1
+pkgrel=2
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
 license=('GPL2')
@@ -83,7 +83,7 @@ package_kodi-rbp-git() {
            'yajl' 'libmariadbclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd'
            'sdl_image' 'python2' 'python2-pillow' 'python2-pybluez' 'python2-simplejson' 'libass'
            'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray'
-           'avahi' 'bluez-libs' 'tinyxml' 'raspberrypi-firmware'
+           'avahi' 'bluez-libs' 'tinyxml' 'raspberrypi-firmware' 'libpulse'
            'libplist' 'swig' 'taglib' 'libxslt' 'shairplay' 'libcrossguid-git')
 
   optdepends=(


### PR DESCRIPTION
I neglected to add libpulse as a dep which will render systems unable to start `kodi.service` if not installed.