### PR TITLE
alarm/kodi-rbp-git: update to 17.0rc3.20170114-4

### DIFF
--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -14,7 +14,7 @@ _suffix=rbp-git
 pkgname=("kodi-$_suffix" "kodi-eventclients-$_suffix" "kodi-tools-texturepacker-$_suffix" "kodi-dev-$_suffix")
 pkgver=17.0rc3.20170114
 _tag=17.0rc3-Krypton
-pkgrel=3
+pkgrel=4
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
 license=('GPL2')
@@ -24,7 +24,7 @@ makedepends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libva'
              'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray'
              'libnfs' 'afpfs-ng' 'avahi' 'bluez-libs' 'tinyxml' 'raspberrypi-firmware' 'libcec-rpi'
              'libplist' 'swig' 'taglib' 'libxslt' 'shairplay' 'boost' 'cmake' 'gperf' 'nasm' 'zip'
-             'udisks' 'upower' 'git' 'autoconf' 'java-environment' 'libcrossguid-git' 'dcadec' 'libpulse')
+             'upower' 'git' 'autoconf' 'java-environment' 'libcrossguid-git' 'dcadec' 'libpulse')
 source=("xbmc-$_tag.tar.gz::https://github.com/xbmc/xbmc/archive/$_tag.tar.gz"
         'kodi.service'
         '99-kodi.rules'
@@ -94,7 +94,6 @@ package_kodi-rbp-git() {
     'lsb-release: log distro information in crashlog'
     'polkit: permissions for automounting external drives and power management functionality'
     'shairplay: limited Apple airplay support'
-    'udisks: automount external drives'
     'unrar: access compressed files without unpacking them'
     'unzip: access compressed files without unpacking them'
     'upower: used to trigger power management functionality')


### PR DESCRIPTION
udisks has been officially dropped