### PR TITLE
alarm/uboot-sunxi: Add BananaPi support

### DIFF
--- a/alarm/uboot-sunxi/PKGBUILD
+++ b/alarm/uboot-sunxi/PKGBUILD
@@ -11,6 +11,7 @@ pkgname=('uboot-a10-olinuxino-lime'
          'uboot-a20-olinuxino-lime'
          'uboot-a20-olinuxino-lime2'
          'uboot-a20-olinuxino-micro'
+         'uboot-bananapi'
          'uboot-cubieboard'
          'uboot-cubieboard2'
          'uboot-cubietruck'
@@ -38,6 +39,7 @@ boards=('A10-OLinuXino-Lime'
         'A20-OLinuXino-Lime'
         'A20-OLinuXino-Lime2'
         'A20-OLinuXino_MICRO'
+        'Bananapi'
         'Cubieboard'
         'Cubieboard2'
         'Cubietruck'
@@ -160,6 +162,20 @@ package_uboot-a20-olinuxino-micro() {
 
   install -d "${pkgdir}"/boot
   install -Dm644 bin_A20-OLinuXino_MICRO/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
+
+  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
+  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
+  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
+}
+
+package_uboot-bananapi() {
+  pkgdesc="U-Boot for BananaPi"
+  install=${pkgbase}.install
+  provides=('uboot-sunxi')
+  conflicts=('uboot-sunxi')
+
+  install -d "${pkgdir}"/boot
+  install -Dm644 bin_Bananapi/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot/u-boot-sunxi-with-spl.bin
 
   install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
   install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr


### PR DESCRIPTION
I tried to get this in here before with a pull request over 2 years ago (#892)
A lot has changed since then.

@kmihelich had a very strong opinion about these boards back then. And one of the key arguments to not implement my pull request was that there was no upstream uboot support available at that time.

I actually sold my Bananapi back then, because it was too much trouble to keep it running. A few weeks ago I bought another one which serves with Arch Linux ARM as my home router. There is absolutely no problem with this hardware. It works just as good as the Cubieboard 2 right next to me (except it has a gigabit ethernet controller)

Another rather subjective argument was that it is "chinese copycat garbage". It's a lot easier to buy a BananaPi in Germany than it is to buy a Cubieboard 2. And the European Union and Germany in particular have very strict laws to prevent "chinese copycat garbage". And still these boards are sold openly by all big electronic stores.

There seemed to be two other attempts by @synthead and one by @seidler2547, which were gunned down by @kmihelich.

In one of these pull requests another argument came up. Lemaker supposedly spams your site and social media. Well, I can't blame them. You refuse to add a hilariously simple patch to support their hardware.

And to close this up, here's another interesting fact. Allnet mentions Lemaker on their website. They don't just mention them. It's more like praising them for their good products.

I'd like to keep this request's discussion as rational as possible. So could we have a discussion here where everyone states arguments based on ones opinion and lets someone else counter these arguments.

Thanks in advance

Christopher