### PR TITLE
 alarm/kodi-rbp-git: update to 17.0.20170202-1

### DIFF
--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -12,8 +12,8 @@ _prefix=/usr
 pkgbase=kodi-rbp-git
 _suffix=rbp-git
 pkgname=("kodi-$_suffix" "kodi-eventclients-$_suffix" "kodi-tools-texturepacker-$_suffix" "kodi-dev-$_suffix")
-pkgver=17.0rc4.20170127
-_tag=17.0rc4-Krypton
+pkgver=17.0.20170202
+_tag=17.0-Krypton
 pkgrel=1
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
@@ -31,7 +31,7 @@ source=("xbmc-$_tag.tar.gz::https://github.com/xbmc/xbmc/archive/$_tag.tar.gz"
         'https://github.com/popcornmix/xbmc/commit/0c320b6cdd4fb409be45008e6b9042463d54b742.patch'
         'https://github.com/popcornmix/xbmc/commit/4d983105d7fd65b1d92f2ae2602e6e1cdcaddbe0.patch'
         'polkit.rules')
-sha256sums=('0fb082436da543777798f84162f2366654fbcd97388e008bb3359204fe7da797'
+sha256sums=('4bfffa2493973ae15ab1d922632c09a2583908d6140bc4f58ec8f9314e4f6545'
             '5235068d5800d69f0287087815990e7fe8d6572733d60c8800546d35f608e87f'
             'b31570f95654434b01fd8531612fbb6be77cbc1c519dd60f92feae26eb160f3d'
             '813f8c622c341eefb33774115199d2abe9c189cf2ce52e79719dbd42d48a1274'


### PR DESCRIPTION
This release is tagged as the final one.  Perhaps it's time to port the git package over to the stable one?