### PR TITLE
alarm/kodi-c2 to 17.0-1

### DIFF
--- a/alarm/kodi-c2/PKGBUILD
+++ b/alarm/kodi-c2/PKGBUILD
@@ -6,8 +6,8 @@ _prefix=/usr
 
 pkgbase=kodi-c2
 pkgname=('kodi-c2' 'kodi-c2-eventclients')
-_commit=c695b8ab9ab93120ac3f5ab952bcbf28cbcce959
-pkgver=17.0rc2
+_commit=a8a20945ee81446cc8453b09490cfb017027a711
+pkgver=17.0
 pkgrel=1
 arch=('aarch64')
 url="http://kodi.tv"
@@ -28,7 +28,7 @@ source=("https://github.com/phedoreanu/xbmc/archive/${_commit}.tar.gz"
         'kodi.service'
         'polkit.rules'
         '99-odroid.rules')
-sha256sums=('2f26c0a4de2abcc5171a6a75219fd0333d85498a0fa1df9d164b0b8b63e8fbc6'
+sha256sums=('ae8a3f1d76f73a478cf1f29679e9006e0ae96f1259bdd61de57832a8c8438074'
             '8c606f29aa9ec90f4c93e1751cfd4000872937e604e6ad7538b96ba29612d2f6'
             '79aa17b475967d97b6c72c850b638705d6feb6d995844476b65d68d33d161114'
             'c68ed2bd377f80b606b8815d78239b9132b479eafc1d19797cee5824debe1800'


### PR DESCRIPTION
```sh
------------------------
  Kodi Configuration:
------------------------
  Kodi Version:	17.0
  git Rev.:	Unknown
  Debugging:	No
  Profiling:	No
  Optimization:	Yes
  SWIG Available:	Yes
  JRE Available:	Yes
  Doxygen Available:	Yes
  Crosscomp.:	No
  target ARCH:	aarch64
  target CPU:	
  OpenGLES:	Yes
  ALSA:		Yes
  DBUS:		Yes
  VDPAU:	No
  VAAPI:	No
  OpenMax:	No
  X11:		No
  Bluray:	Yes
  XSLT scrapers:	Yes
  TexturePacker:No
  MID Support:	No
  ccache:	Yes
  ALSA Support:	Yes
  PulseAudio:	Yes
  Google Test Framework Configured:	Yes
  Avahi:	Yes
  mDNSEmbedded:	No
  Non-free:	Yes
  MySQL:	Yes
  Webserver:	Yes
  libssh support:	Yes
  libsmbclient support:	Yes
  libnfs client support:Yes
  AirPlay support:	Yes
  AirTunes support (libshairplay):	Yes
  UPnP support:		Yes
  Optical drive:	Yes
  libudev support:	Yes
  libusb support:	No
  libcec support:	Yes
  lcms2 support:	Yes
  libbluetooth support:	Yes
  libcap support:	Yes
  additional players:	No
  additional codecs:	Yes, amcodec
  Odroid Hybris support:	No
  prefix:	/usr
------------------------
```