### PR TITLE
alarm/kodi-rbp: Provide kodi-dev

### DIFF
--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -13,7 +13,7 @@ pkgbase=kodi-rbp
 pkgname=('kodi-rbp' 'kodi-rbp-eventclients' 'kodi-rbp-tools-texturepacker' 'kodi-rbp-dev')
 _codename=Krypton
 pkgver=17.1
-pkgrel=3
+pkgrel=4
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
 license=('GPL2')
@@ -173,6 +173,7 @@ package_kodi-rbp-tools-texturepacker() {
 package_kodi-rbp-dev() {
   pkgdesc="Kodi dev files (Raspberry Pi)"
   depends=('kodi')
+  provides=('kodi-dev')
 
   _components=('kodi-addon-dev'
     'kodi-audio-dev'


### PR DESCRIPTION
This is a depency of various kodi-addon-* packages. The files that kodi-dev/x86 provides are already included in kodi-rbp.