### PR TITLE
PKGBUILD for kodi-addon-pvr-iptvsimple. compatible with kodi-rbp

### DIFF
--- a/alarm/kodi-rbp-addon-pvr-iptvsimple/PKGBUILD
+++ b/alarm/kodi-rbp-addon-pvr-iptvsimple/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Nicolás Demarchi <mail@gilgamezh.me> 
+
+buildarch=20
+
+pkgname=kodi-rbp-addon-pvr-iptvsimple
+pkgrel=1
+pkgver=2.4.8
+_codename=Krypton
+pkgdesc='IPTV Simple PVR client addon for Kodi-rbp'
+arch=('armv6h' 'armv7h')
+url="https://github.com/kodi-pvr/pvr.iptvsimple/"
+license=('GPL')
+groups=('kodi')
+makedepends=('cmake' 'git')
+provides=('kodi-rbp-addon-pvr-iptvsimple');
+conflicts=('kodi-rbp-addon-pvr-iptvsimple');
+depends=('kodi-rbp' 'kodi-platform' 'kodi-rbp-dev')
+source=("https://github.com/kodi-pvr/pvr.iptvsimple/archive/${pkgver}-${_codename}.tar.gz")
+md5sums=('9904b822be1f8aae3e420ee967479b95')
+
+build() {
+    cd "${srcdir}/pvr.iptvsimple-${pkgver}-${_codename}"
+
+    rm -rf build
+    mkdir build
+    cd build
+
+    cmake ../ -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib/kodi -DCMAKE_BUILD_TYPE=Release  || return 1
+    make || return 1
+}
+
+package() {
+    cd "${srcdir}/pvr.iptvsimple-${pkgver}-${_codename}/build"
+
+    make DESTDIR="$pkgdir" install
+}


### PR DESCRIPTION
PKGBUILD to use https://github.com/kodi-pvr/pvr.iptvsimple with kodi-rbp.