### PR TITLE
alarm/kodi-rbp-git: Provide kodi-dev

### DIFF
--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -14,7 +14,7 @@ _suffix=rbp-git
 pkgname=("kodi-$_suffix" "kodi-eventclients-$_suffix" "kodi-tools-texturepacker-$_suffix" "kodi-dev-$_suffix")
 pkgver=17.1rc1.20170223
 _tag=17.1rc1-Krypton
-pkgrel=2
+pkgrel=3
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
 license=('GPL2')
@@ -172,6 +172,7 @@ package_kodi-tools-texturepacker-rbp-git() {
 package_kodi-dev-rbp-git() {
   pkgdesc="Kodi dev files (master branch)"
   depends=('kodi')
+  provides=('kodi-dev')
 
   _components=('kodi-addon-dev'
     'kodi-audio-dev'


### PR DESCRIPTION
This is a depency of various kodi-addon-* packages. The files that kodi-dev/x86 provides are already included in kodi-rbp-git.