### PR TITLE
extra/firefox: fix aarch64 build

### DIFF
--- a/extra/firefox/Build-Skia-NEON-code-on-arm64.patch
+++ b/extra/firefox/Build-Skia-NEON-code-on-arm64.patch
@@ -1,0 +1,38 @@
+From: Mike Hommey <mh@glandium.org>
+Date: Wed, 25 Jan 2017 15:31:46 +0900
+Subject: Build Skia NEON code on arm64
+
+---
+ gfx/skia/moz.build | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/gfx/skia/moz.build b/gfx/skia/moz.build
+index b33f1cdbee54..475075dbeebc 100644
+--- a/gfx/skia/moz.build
++++ b/gfx/skia/moz.build
+@@ -519,7 +519,7 @@ if CONFIG['INTEL_ARCHITECTURE']:
+         'skia/src/opts/SkOpts_sse41.cpp',
+         'skia/src/opts/SkOpts_ssse3.cpp',
+     ]
+-elif CONFIG['CPU_ARCH'] == 'arm' and CONFIG['GNU_CC']:
++elif CONFIG['CPU_ARCH'] in ('arm', 'aarch64') and CONFIG['GNU_CC']:
+     UNIFIED_SOURCES += [
+         'skia/src/core/SkUtilsArm.cpp',
+         'skia/src/opts/SkBitmapProcState_opts_arm.cpp',
+@@ -528,7 +528,7 @@ elif CONFIG['CPU_ARCH'] == 'arm' and CONFIG['GNU_CC']:
+     SOURCES += [
+         'skia/src/opts/SkBlitRow_opts_arm.cpp',
+     ]
+-    if CONFIG['BUILD_ARM_NEON']:
++    if CONFIG['CPU_ARCH'] == 'aarch64' or CONFIG['BUILD_ARM_NEON']:
+         SOURCES += [
+             'skia/src/opts/SkBitmapProcState_arm_neon.cpp',
+             'skia/src/opts/SkBitmapProcState_matrixProcs_neon.cpp',
+@@ -536,6 +536,7 @@ elif CONFIG['CPU_ARCH'] == 'arm' and CONFIG['GNU_CC']:
+             'skia/src/opts/SkBlitRow_opts_arm_neon.cpp',
+             'skia/src/opts/SkOpts_neon.cpp',
+         ]
++    if CONFIG['CPU_ARCH'] == 'arm' and CONFIG['BUILD_ARM_NEON']:
+         SOURCES['skia/src/opts/SkBitmapProcState_arm_neon.cpp'].flags += CONFIG['NEON_FLAGS']
+         SOURCES['skia/src/opts/SkBitmapProcState_matrixProcs_neon.cpp'].flags += CONFIG['NEON_FLAGS']
+         SOURCES['skia/src/opts/SkBlitMask_opts_arm_neon.cpp'].flags += CONFIG['NEON_FLAGS']

--- a/extra/firefox/PKGBUILD
+++ b/extra/firefox/PKGBUILD
@@ -11,7 +11,7 @@ highmem=1
 
 pkgname=firefox
 pkgver=51.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Standalone web browser from mozilla.org"
 arch=(i686 x86_64)
 license=(MPL GPL LGPL)
@@ -33,7 +33,8 @@ source=(https://ftp.mozilla.org/pub/mozilla.org/firefox/releases/$pkgver/source/
         firefox-symbolic.svg
         fix-wifi-scanner.diff
         mozilla-1253216.patch
-        mozilla-build-arm.patch)
+        mozilla-build-arm.patch
+        Build-Skia-NEON-code-on-arm64.patch)
 sha256sums=('30ba00ba716ea1eeda526e2ccc8642f8d18a836793fde50e87a4fcb9d9fccca9'
             '640e529734e4e021b99f2e28205d62b915b0884e487bca1b7d81a7d3164676ab'
             '75c526e9669b91b4fe5dcea650a1e8419220abb2e9564184f0d984c71eae82e8'
@@ -43,7 +44,8 @@ sha256sums=('30ba00ba716ea1eeda526e2ccc8642f8d18a836793fde50e87a4fcb9d9fccca9'
             'a2474b32b9b2d7e0fb53a4c89715507ad1c194bef77713d798fa39d507def9e9'
             '9765bca5d63fb5525bbd0520b7ab1d27cabaed697e2fc7791400abc3fa4f13b8'
             'fbb6011501a74a8ea6d01c041870fcefb7ef2859c134aedc676e5f6452833f65'
-            '56eecee8162c138c442773d66483886f1242c8dd2b16eed5711ae5e63d9b0e3a')
+            '56eecee8162c138c442773d66483886f1242c8dd2b16eed5711ae5e63d9b0e3a'
+            '0a786851c15fbef2afeedca56e13690145730d1d9cc2f010fc98e38348b069ed')
 validpgpkeys=('2B90598A745E992F315E22C58AB132963A06537A')
 
 # Google API keys (see http://www.chromium.org/developers/how-tos/api-keys)
@@ -86,6 +88,7 @@ prepare() {
   LDFLAGS+=" -Wl,--no-keep-memory -Wl,--reduce-memory-overheads"
   patch -p1 -i ../mozilla-1253216.patch
   patch -p1 -i ../mozilla-build-arm.patch
+  patch -p1 -i ../Build-Skia-NEON-code-on-arm64.patch
 }
 
 build() {


### PR DESCRIPTION
The Skia graphics library failed to build the
ClampX_ClampY_Procs_neon() function on aarch64, however it still
attempted to link against it, resulting in a linking error. The
patch is used by the Debian Sid Firefox package.