### PR TITLE
alarm/kodi-rbp: update to 17.0-3

### DIFF
--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -13,11 +13,11 @@ pkgbase=kodi-rbp
 pkgname=('kodi-rbp' 'kodi-rbp-eventclients' 'kodi-rbp-tools-texturepacker' 'kodi-rbp-dev')
 _codename=Krypton
 pkgver=17.0
-pkgrel=2
+pkgrel=3
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
 license=('GPL2')
-makedepends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio'
+makedepends=('hicolor-icon-theme' 'fribidi' 'lzo' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio'
              'yajl' 'libmariadbclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd'
              'sdl_image' 'python2' 'python2-pillow' 'python2-pybluez' 'python2-simplejson' 'libass'
              'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray'
@@ -78,7 +78,7 @@ build() {
 
 package_kodi-rbp() {
   pkgdesc="A software media player and entertainment hub for digital media (Raspberry Pi)"
-  depends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio'
+  depends=('hicolor-icon-theme' 'fribidi' 'lzo' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio'
            'yajl' 'libmariadbclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd'
            'sdl_image' 'python2' 'python2-pillow' 'python2-pybluez' 'python2-simplejson' 'libass'
            'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'xorg-xdpyinfo' 'libbluray'


### PR DESCRIPTION
Fixes the lzo2 dependency hell.  Builds and runs on RPi2.