### PR TITLE
alarm/kodi-rbp-git: update to 17.1rc1.20170223-1

### DIFF
--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -12,13 +12,13 @@ _prefix=/usr
 pkgbase=kodi-rbp-git
 _suffix=rbp-git
 pkgname=("kodi-$_suffix" "kodi-eventclients-$_suffix" "kodi-tools-texturepacker-$_suffix" "kodi-dev-$_suffix")
-pkgver=17.0rc4.20170127
-_tag=17.0rc4-Krypton
+pkgver=17.1rc1.20170223
+_tag=17.1rc1-Krypton
 pkgrel=1
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
 license=('GPL2')
-makedepends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio'
+makedepends=('hicolor-icon-theme' 'fribidi' 'lzo' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio'
              'yajl' 'libmariadbclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd'
              'sdl_image' 'python2' 'python2-pillow' 'python2-pybluez' 'python2-simplejson' 'libass'
              'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray'
@@ -31,7 +31,7 @@ source=("xbmc-$_tag.tar.gz::https://github.com/xbmc/xbmc/archive/$_tag.tar.gz"
         'https://github.com/popcornmix/xbmc/commit/0c320b6cdd4fb409be45008e6b9042463d54b742.patch'
         'https://github.com/popcornmix/xbmc/commit/4d983105d7fd65b1d92f2ae2602e6e1cdcaddbe0.patch'
         'polkit.rules')
-sha256sums=('0fb082436da543777798f84162f2366654fbcd97388e008bb3359204fe7da797'
+sha256sums=('a614128c065d561fccd4167f25eddbad3875328f1e81f627ffe3d0b17958aa07'
             '5235068d5800d69f0287087815990e7fe8d6572733d60c8800546d35f608e87f'
             'b31570f95654434b01fd8531612fbb6be77cbc1c519dd60f92feae26eb160f3d'
             '813f8c622c341eefb33774115199d2abe9c189cf2ce52e79719dbd42d48a1274'
@@ -43,7 +43,7 @@ prepare() {
 
   # ffmpeg: Automatic switch to software decode for GMC with more than one warp point
   patch -Np1 -i "$srcdir/0c320b6cdd4fb409be45008e6b9042463d54b742.patch"
-  # hacky fix for files with GMC
+  # fix for files with GMC
   patch -Np1 -i "$srcdir/4d983105d7fd65b1d92f2ae2602e6e1cdcaddbe0.patch"
 
   [[ -d kodi-build ]] && rm -rf kodi-build
@@ -79,15 +79,16 @@ build() {
 
 package_kodi-rbp-git() {
   pkgdesc="A software media player and entertainment hub for digital media (Raspberry Pi)"
-  depends=('hicolor-icon-theme' 'fribidi' 'lzo2' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio'
+  depends=('hicolor-icon-theme' 'fribidi' 'lzo' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio'
            'yajl' 'libmariadbclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd'
-           'sdl_image' 'python2' 'python2-pillow' 'python2-pybluez' 'python2-simplejson' 'libass'
+           'sdl_image' 'python2' 'python2-pillow' 'python2-simplejson' 'libass'
            'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'xorg-xdpyinfo' 'libbluray'
            'avahi' 'bluez-libs' 'tinyxml' 'raspberrypi-firmware' 'libpulse'
            'libplist' 'swig' 'taglib' 'libxslt' 'libcrossguid-git')
 
   optdepends=(
     'afpfs-ng: Apple airplay and AFP share support'
+    'python2-pybluez: Bluetooth support'
     'libcec-rpi: Pulse-Eight USB-CEC adapter support'
     'libnfs: NFS shares support'
     'lirc: remote controller support'
@@ -102,11 +103,7 @@ package_kodi-rbp-git() {
   provides=('xbmc' 'kodi')
   conflicts=('xbmc' 'kodi' 'arm-mem-git' 'shairplay-git')
   replaces=('xbmc-rbp-git')
-
-  _components=(
-  'kodi'
-  'kodi-bin'
-  )
+  _components=('kodi' 'kodi-bin')
 
   cd kodi-build
   # install eventclients
@@ -137,17 +134,13 @@ package_kodi-rbp-git() {
 
 package_kodi-eventclients-rbp-git() {
   pkgdesc="Kodi Event Clients (master branch)"
+  provides=('kodi-eventclients')
   conflicts=('kodi-eventclients')
-
   depends=('cwiid')
-
-  # disable wiiremote due to incompatibility with bluez-5.29
-  _components=(
-    'kodi-eventclients-common'
+  _components=('kodi-eventclients-common'
     'kodi-eventclients-ps3'
-    #'kodi-eventclients-wiiremote'
-    'kodi-eventclients-xbmc-send'
-  )
+    'kodi-eventclients-wiiremote'
+    'kodi-eventclients-xbmc-send' )
 
   cd kodi-build
   # install eventclients
@@ -162,16 +155,10 @@ package_kodi-eventclients-rbp-git() {
   grep -lR '#!.*python' * | while read file; do sed -s 's/\(#!.*python\)/\12/g' -i "$file"; done
 }
 
-# kodi-tools-texturepacker
-# components: kodi-tools-texturepacker
-
 package_kodi-tools-texturepacker-rbp-git() {
   pkgdesc="Kodi Texturepacker tool (master branch)"
   depends=('libpng' 'giflib' 'libjpeg-turbo' 'lzo')
-
-  _components=(
-    'kodi-tools-texturepacker'
-  )
+  _components=('kodi-tools-texturepacker')
 
   cd kodi-build
   # install eventclients
@@ -186,8 +173,7 @@ package_kodi-dev-rbp-git() {
   pkgdesc="Kodi dev files (master branch)"
   depends=('kodi')
 
-  _components=(
-    'kodi-addon-dev'
+  _components=('kodi-addon-dev'
     'kodi-audio-dev'
     'kodi-eventclients-dev'
     'kodi-game-dev'
@@ -195,8 +181,7 @@ package_kodi-dev-rbp-git() {
     'kodi-peripheral-dev'
     'kodi-pvr-dev'
     'kodi-screensaver-dev'
-    'kodi-visualization-dev'
-  )
+    'kodi-visualization-dev')
 
   cd kodi-build
   # install eventclients


### PR DESCRIPTION
Updates to 17.1RC1 and fixes the lzo2 dependency hell. Builds and runs on RPi2.