### PR TITLE
alarm/luajit-git to v2.1.0.beta2.r172.gd3e36e7

### DIFF
--- a/alarm/luajit-git/PKGBUILD
+++ b/alarm/luajit-git/PKGBUILD
@@ -10,7 +10,7 @@
 buildarch=8
 
 pkgname=luajit-git
-pkgver=v2.1.0.beta1.r47.g22e7b00
+pkgver=v2.1.0.beta2.r172.gd3e36e7
 pkgrel=1
 pkgdesc='Just-in-time compiler and drop-in replacement for Lua 5.1'
 arch=('i686' 'x86_64')


### PR DESCRIPTION
This enables JIT on AArch64