### PR TITLE
Update cryptodev-dkms to 1.8-6

### DIFF
--- a/alarm/cryptodev-dkms/PKGBUILD
+++ b/alarm/cryptodev-dkms/PKGBUILD
@@ -2,10 +2,10 @@
 
 pkgname=cryptodev-dkms
 _pkgname=${pkgname%-*}
-cryptodev_commit=2dbbb2313f7c1d9465f4867c7d02851730154db8
+cryptodev_commit=26e167f8527b386e6bcb5d69eb2e12e587376a28
 
 pkgver=1.8
-pkgrel=5
+pkgrel=6
 
 pkgdesc="Cryptodev module to take advantage of hardware crypto engines in userspace"
 arch=('arm' 'armv6h' 'armv7h' 'aarch64')
@@ -16,7 +16,7 @@ install=${pkgname}.install
 provides=('cryptodev_friendly')
 source=("cryptodev-${cryptodev_commit}.tar.gz::https://github.com/cryptodev-linux/cryptodev-linux/archive/${cryptodev_commit}.tar.gz"
         'dkms.conf')
-sha256sums=('76bedbef868d583ea2a8a513acbc3244947c329ba4934eab045db6acb51907c2'
+sha256sums=('f875cc1e0237380beca6a6d87a3fcdc94b5d0e23019ab20f91cb3532cbffe2dc'
             'c42865a4a800a4927619ac5ed742be59a6d960af8295727af909e9ea9587f3da')
 package() {
   cd "${srcdir}"


### PR DESCRIPTION
Upstream supports kernels >=4.10, but no new release now.
Current version fails to build, because of kernel api changes.