### PR TITLE
Add package for FriendlyARM NanoPI Neo to uboot-sunxi. 

### DIFF
--- a/alarm/uboot-sunxi/PKGBUILD
+++ b/alarm/uboot-sunxi/PKGBUILD
@@ -16,9 +16,10 @@ pkgname=('uboot-a10-olinuxino-lime'
          'uboot-cubietruck'
          'uboot-pcduino'
          'uboot-pcduino3'
-         'uboot-pcduino3-nano')
-pkgver=2017.01
-pkgrel=2
+         'uboot-pcduino3-nano'
+         'uboot-nanopi-neo')
+pkgver=2017.03
+pkgrel=1
 arch=('armv7h')
 url="http://git.denx.de/u-boot.git/"
 license=('GPL')
@@ -27,7 +28,7 @@ backup=(boot/boot.txt boot/boot.scr)
 source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
         'boot.txt'
         'mkscr')
-md5sums=('ad2d82d5b4fa548b2b95bbc26c9bad79'
+md5sums=('52fed6ce16e0c4a50e2cd4defdf9097a'
          '95f60c0ae1315e986d8a2aee15d5f854'
          '021623a04afd29ac3f368977140cfbfd')
 
@@ -43,7 +44,8 @@ boards=('A10-OLinuXino-Lime'
         'Cubietruck'
         'Linksprite_pcDuino'
         'Linksprite_pcDuino3'
-        'Linksprite_pcDuino3_Nano')
+        'Linksprite_pcDuino3_Nano'
+        'nanopi_neo')
 
 prepare() {
   cd u-boot-${pkgver}
@@ -57,12 +59,13 @@ build() {
   unset CFLAGS CXXFLAGS LDFLAGS
 
   for i in ${boards[@]}; do
-    mkdir ../bin_${i}
+    mkdir -p ../bin_${i}
     make distclean
-    make ${i}_config
+    make ${i}_defconfig
     echo 'CONFIG_IDENT_STRING=" Arch Linux ARM"' >> .config
     make EXTRAVERSION=-${pkgrel}
     mv u-boot-sunxi-with-spl.bin ../bin_${i}
+    mv u-boot.dtb ../bin_${i}
   done
 
   tools/mkimage -A arm -O linux -T script -C none -n "U-Boot boot script" -d ../boot.txt ../boot.scr
@@ -245,6 +248,21 @@ package_uboot-pcduino3-nano() {
   install -d "${pkgdir}"/boot
   install -Dm644 bin_Linksprite_pcDuino3_Nano/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
 
+  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
+  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
+  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
+}
+
+package_uboot-nanopi-neo() {
+  pkgdesc="U-Boot for NanoPi Neo"
+  install=${pkgbase}.install
+  provides=('uboot-sunxi')
+  conflicts=('uboot-sunxi')
+
+  install -d "${pkgdir}"/boot
+  install -d "${pkgdir}"/boot/dtbs
+  install -Dm644 bin_nanopi_neo/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot/u-boot-sunxi-with-spl.bin
+  install -Dm644 bin_nanopi_neo/u-boot.dtb "${pkgdir}"/boot/dtbs/sun8i-h3-nanopi-neo.dtb
   install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
   install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
   install -Dm755 mkscr "${pkgdir}"/boot/mkscr


### PR DESCRIPTION
- Add package for FriendlyARM NanPI Neo to uboot-sunxi.
- Update to uboot-2017.03 in the process.
- The package will include the *.dtb build together with the *.bin, overwriting whatever is already put into /boot/dtbs/ by the image, because that actually *works*. Why are the *.dtb not shipped with the uboot packages?
- Tested on two different NanoPI Neo 512MB.