### PR TITLE
alarm/kodi-rbp: spdif/toslink passthrough fix for hifiberry-digi+ card

### DIFF
--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -13,7 +13,7 @@ pkgbase=kodi-rbp
 pkgname=('kodi-rbp' 'kodi-rbp-eventclients' 'kodi-rbp-tools-texturepacker' 'kodi-rbp-dev')
 _codename=Krypton
 pkgver=17.1
-pkgrel=1
+pkgrel=2
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
 license=('GPL2')
@@ -29,14 +29,16 @@ source=("https://github.com/xbmc/xbmc/archive/$pkgver-$_codename.tar.gz"
         '99-kodi.rules'
         'https://github.com/popcornmix/xbmc/commit/0c320b6cdd4fb409be45008e6b9042463d54b742.patch'
         'https://github.com/popcornmix/xbmc/commit/4d983105d7fd65b1d92f2ae2602e6e1cdcaddbe0.patch'
-        'polkit.rules')
+        'polkit.rules'
+        'hifiberry_digi.patch')
 
 sha256sums=('303f3903cbb57ccc2961f09cf3746505542bcb129a464f0687d7ca8601cebbee'
             '5235068d5800d69f0287087815990e7fe8d6572733d60c8800546d35f608e87f'
             'b31570f95654434b01fd8531612fbb6be77cbc1c519dd60f92feae26eb160f3d'
             '813f8c622c341eefb33774115199d2abe9c189cf2ce52e79719dbd42d48a1274'
             'd830c010ead152bc9a9ba6b812c985d6e649bda7480fec9b3c451f5ea03ba792'
-            '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96')
+            '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96'
+            '0b9d951911a8576c26dec8a31f394282677e48afff49b9579448121d27b8509e')
 prepare() {
   cd "$srcdir/xbmc-$pkgver-$_codename"
 
@@ -44,6 +46,8 @@ prepare() {
   patch -Np1 -i "$srcdir/0c320b6cdd4fb409be45008e6b9042463d54b742.patch"
   # fix for files with GMC
   patch -Np1 -i "$srcdir/4d983105d7fd65b1d92f2ae2602e6e1cdcaddbe0.patch"
+  # fix for lack of passthrough audio with hifiberry-digi+ card
+  patch -Np1 -i "$srcdir/hifiberry_digi.patch"
 
   [[ -d kodi-build ]] && rm -rf kodi-build
   mkdir $srcdir/kodi-build

--- a/alarm/kodi-rbp/hifiberry_digi.patch
+++ b/alarm/kodi-rbp/hifiberry_digi.patch
@@ -1,0 +1,14 @@
+diff -rupN a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp	2016-04-24 07:48:30.000000000 +0100
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp	2016-07-06 23:15:14.851453568 +0100
+@@ -1342,6 +1342,10 @@ void CAESinkALSA::EnumerateDevice(AEDevi
+     if (snd_card_get_name(cardNr, &cardName) == 0)
+       info.m_displayName = cardName;
+ 
++    /* hifiberry digi doesn't correctly report as iec958 device. Needs fixing in kernel driver */
++    if (info.m_displayName == "snd_rpi_hifiberry_digi")
++        info.m_deviceType = AE_DEVTYPE_IEC958;
++
+     if (info.m_deviceType == AE_DEVTYPE_HDMI && info.m_displayName.size() > 5 &&
+         info.m_displayName.substr(info.m_displayName.size()-5) == " HDMI")
+     {


### PR DESCRIPTION
alarm/kodi-rbp 

This is basically copy of a pull request #1376.
As a reminder:

> The HiFiBerry Digi+ is a S/PDIF/Toslink output board for the Raspberry Pi (rPi2 and rPi3).
> 
> For years (I found forum topics going back to 2014) kodi is not able to use it as pass-through device for audio output. What that means is, you are not able to get DTS or DolbyD signal in your amp.
> 
> It looks OpenELEC and Osmc already applied the patch, or rather workaround for that issue.
> More info here:
> https://support.hifiberry.com/hc/en-us/community/posts/201845791-Kodi-no-passthrough
> and here
> http://forum.kodi.tv/showthread.php?tid=261778
> 
> Kodi won't apply the patch as in their eyes the problem should be fixed in kernel or by Hifiberry. 
> I really doubt it will be fixed upstream in the near future (judging on the sheer amount of topics/issues which are open all over the web).
> 
> It's worth applying that patch to save time and headache to arm arch users.

It looks like patch was removed when kodi package was upgraded to Krypton (v17) release.

Could it be merged again, please?