### PR TITLE
Include patch from upstream to fix font rendering on some ARM boards

### DIFF
--- a/extra/qt5-base/PKGBUILD
+++ b/extra/qt5-base/PKGBUILD
@@ -10,7 +10,7 @@
 pkgname=qt5-base
 _qtver=5.8.0
 pkgver=${_qtver/-/}
-pkgrel=7
+pkgrel=7.1
 arch=('i686' 'x86_64')
 url='http://qt-project.org/'
 license=('GPL3' 'LGPL3' 'FDL' 'custom')
@@ -34,12 +34,14 @@ source=("http://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submo
         qt5-base-journald.patch::"https://github.com/qt/qtbase/commit/0c8f3229.patch"
         plasma-crash-1.patch::https://github.com/qt/qtbase/commit/3bd0fd8f.patch
         plasma-crash-2.patch::https://github.com/qt/qtbase/commit/0874861b.patch
-        plasma-crash-3.patch::https://github.com/qt/qtbase/commit/baad82d2.patch)
+        plasma-crash-3.patch::https://github.com/qt/qtbase/commit/baad82d2.patch
+        android-driver-workaround.patch::https://github.com/qt/qtbase/commit/9ae028f5.patch)
 md5sums=('6e1f7f6fb6333eb66e563b175c4e87e9'
          '160fde81fe882c4241f04634f53691ad'
          '078d8a051c06abf28451fd2cdb7f19ce'
          '92daaa3ebd7cf10ee725b963e44c95a7'
-         '76ab122615f1ba2d68c83477f82e389e')
+         '76ab122615f1ba2d68c83477f82e389e'
+         '9ab1e7293a4959a30c7b6bf3dcd21a5d')
 
 prepare() {
   cd ${_pkgfqn}
@@ -62,6 +64,10 @@ prepare() {
   patch -p1 -i ../plasma-crash-1.patch
   patch -p1 -i ../plasma-crash-2.patch
   patch -p1 -i ../plasma-crash-3.patch
+
+  # Fix the glyph generation on some arm devices using android drivers
+  # see: https://codereview.qt-project.org/#/c/185259/
+  patch -p1 -i ../android-driver-workaround.patch
 }
 
 build() {


### PR DESCRIPTION
See: https://codereview.qt-project.org/#/c/185259/

This patch likely won't be included in the archlinux main repo currently
so submitting this here