### PR TITLE
Update cryptodev-dkms to 1.8-7

### DIFF
--- a/alarm/cryptodev-dkms/PKGBUILD
+++ b/alarm/cryptodev-dkms/PKGBUILD
@@ -2,10 +2,10 @@
 
 pkgname=cryptodev-dkms
 _pkgname=${pkgname%-*}
-cryptodev_commit=26e167f8527b386e6bcb5d69eb2e12e587376a28
+cryptodev_commit=6818263667ca488f9b1c86e36ea624c4ea1c309f
 
 pkgver=1.8
-pkgrel=6
+pkgrel=7
 
 pkgdesc="Cryptodev module to take advantage of hardware crypto engines in userspace"
 arch=('arm' 'armv6h' 'armv7h' 'aarch64')
@@ -16,7 +16,7 @@ install=${pkgname}.install
 provides=('cryptodev_friendly')
 source=("cryptodev-${cryptodev_commit}.tar.gz::https://github.com/cryptodev-linux/cryptodev-linux/archive/${cryptodev_commit}.tar.gz"
         'dkms.conf')
-sha256sums=('f875cc1e0237380beca6a6d87a3fcdc94b5d0e23019ab20f91cb3532cbffe2dc'
+sha256sums=('85f7545a3eba9749e253136cea47121e189974e98c8a4eddfbe076683bf354fb'
             'c42865a4a800a4927619ac5ed742be59a6d960af8295727af909e9ea9587f3da')
 package() {
   cd "${srcdir}"


### PR DESCRIPTION
Follow upstream changes: Fix ablkcipher algorithms usage in v4.8+ kernels.
It looks like cryptodev is working with new kernels again.
```
~$ fgrep crypto /proc/interrupts
 28:     520256  main-interrupt-ctrl  22 Edge      f1030000.crypto
~$ openssl speed -evp aes-128-cbc
Doing aes-128-cbc for 3s on 16 size blocks: 27480 aes-128-cbc's in 0.13s
Doing aes-128-cbc for 3s on 64 size blocks: 28800 aes-128-cbc's in 0.10s
[...]
~$ fgrep crypto /proc/interrupts
 28:     636846  main-interrupt-ctrl  22 Edge      f1030000.crypto
~$ uname -a
Linux redqueen 4.10.8-1-ARCH #1 PREEMPT Sun Apr 2 00:32:23 MDT 2017 armv5tel GNU/Linux
```
[Edit:]
BTW There is something funny with date on that commit: https://github.com/cryptodev-linux/cryptodev-linux/commit/6818263667ca488f9b1c86e36ea624c4ea1c309f, because it's parent was commited on Feb 9.