### PR TITLE
[uboot-sunxi] simplify pkgbuild

### DIFF
--- a/alarm/uboot-sunxi/PKGBUILD
+++ b/alarm/uboot-sunxi/PKGBUILD
@@ -4,19 +4,7 @@
 buildarch=4
 
 pkgbase=uboot-sunxi
-pkgname=('uboot-a10-olinuxino-lime'
-         'uboot-a10s-olinuxino-micro'
-         'uboot-a13-olinuxino'
-         'uboot-a13-olinuxino-micro'
-         'uboot-a20-olinuxino-lime'
-         'uboot-a20-olinuxino-lime2'
-         'uboot-a20-olinuxino-micro'
-         'uboot-cubieboard'
-         'uboot-cubieboard2'
-         'uboot-cubietruck'
-         'uboot-pcduino'
-         'uboot-pcduino3'
-         'uboot-pcduino3-nano')
+pkgname=() # to be filled below
 pkgver=2017.01
 pkgrel=2
 arch=('armv7h')
@@ -31,19 +19,21 @@ md5sums=('ad2d82d5b4fa548b2b95bbc26c9bad79'
          '95f60c0ae1315e986d8a2aee15d5f854'
          '021623a04afd29ac3f368977140cfbfd')
 
-boards=('A10-OLinuXino-Lime'
-        'A10s-OLinuXino-M'
+_uboot_boards=(
+        'A10-OLinuXino-Lime'
+        'A10s-OLinuXino-M:a10s-olinuxino-micro'
         'A13-OLinuXino'
-        'A13-OLinuXinoM'
+        'A13-OLinuXinoM:a13-olinuxino-micro'
         'A20-OLinuXino-Lime'
         'A20-OLinuXino-Lime2'
         'A20-OLinuXino_MICRO'
         'Cubieboard'
         'Cubieboard2'
         'Cubietruck'
-        'Linksprite_pcDuino'
-        'Linksprite_pcDuino3'
-        'Linksprite_pcDuino3_Nano')
+        'Linksprite_pcDuino:pcduino'
+        'Linksprite_pcDuino3:pcduino3'
+        'Linksprite_pcDuino3_Nano:pcduino3-nano'
+)
 
 prepare() {
   cd u-boot-${pkgver}
@@ -56,196 +46,38 @@ build() {
 
   unset CFLAGS CXXFLAGS LDFLAGS
 
-  for i in ${boards[@]}; do
-    mkdir ../bin_${i}
+  for b in ${_uboot_boards[@]}; do
+    config=$(echo $b | cut -f1 -d':')
+    mkdir -p ../bin_${config}
     make distclean
-    make ${i}_config
+    make ${config}_config
     echo 'CONFIG_IDENT_STRING=" Arch Linux ARM"' >> .config
     make EXTRAVERSION=-${pkgrel}
-    mv u-boot-sunxi-with-spl.bin ../bin_${i}
+    mv u-boot-sunxi-with-spl.bin ../bin_${config}
   done
 
   tools/mkimage -A arm -O linux -T script -C none -n "U-Boot boot script" -d ../boot.txt ../boot.scr
 }
 
-package_uboot-a10-olinuxino-lime() {
-  pkgdesc="U-Boot for A10 OLinuXino Lime"
+for b in ${_uboot_boards[@]}; do
+    config=$(echo $b | cut -f1 -d':')
+    name=$(echo $config | tr '_-' '  ')
+    package=$(echo $b | cut -f2 -d':' | tr A-Z_ a-z-)
+    [ -z ${package} ] && package=$(echo $b | tr A-Z_ a-z-)
+    pkgname+=(uboot-${package})
+    eval "
+package_uboot-${package}() {
+  pkgdesc=\"U-Boot for ${name}\"
   install=${pkgbase}.install
   provides=('uboot-sunxi')
   conflicts=('uboot-sunxi')
 
-  install -d "${pkgdir}"/boot
-  install -Dm644 bin_A10-OLinuXino-Lime/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
+  install -d \"\${pkgdir}\"/boot
+  install -Dm644 bin_${config}/u-boot-sunxi-with-spl.bin \"\${pkgdir}\"/boot
 
-  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
-  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
-  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
+  install -Dm644 boot.txt \"\${pkgdir}\"/boot/boot.txt
+  install -Dm644 boot.scr \"\${pkgdir}\"/boot/boot.scr
+  install -Dm755 mkscr \"\${pkgdir}\"/boot/mkscr
 }
-
-package_uboot-a10s-olinuxino-micro() {
-  pkgdesc="U-Boot for A10s OLinuXino Micro"
-  install=${pkgbase}.install
-  provides=('uboot-sunxi')
-  conflicts=('uboot-sunxi')
-
-  install -d "${pkgdir}"/boot
-  install -Dm644 bin_A10s-OLinuXino-M/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
-
-  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
-  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
-  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
-}
-
-package_uboot-a13-olinuxino() {
-  pkgdesc="U-Boot for A13 OLinuXino"
-  install=${pkgbase}.install
-  provides=('uboot-sunxi')
-  conflicts=('uboot-sunxi')
-
-  install -d "${pkgdir}"/boot
-  install -Dm644 bin_A13-OLinuXino/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
-
-  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
-  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
-  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
-}
-
-package_uboot-a13-olinuxino-micro() {
-  pkgdesc="U-Boot for A13 OLinuXino Micro"
-  install=${pkgbase}.install
-  provides=('uboot-sunxi')
-  conflicts=('uboot-sunxi')
-
-  install -d "${pkgdir}"/boot
-  install -Dm644 bin_A13-OLinuXinoM/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
-
-  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
-  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
-  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
-}
-
-package_uboot-a20-olinuxino-lime() {
-  pkgdesc="U-Boot for A20 OLinuXino Lime"
-  install=${pkgbase}.install
-  provides=('uboot-sunxi')
-  conflicts=('uboot-sunxi')
-
-  install -d "${pkgdir}"/boot
-  install -Dm644 bin_A20-OLinuXino-Lime/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
-
-  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
-  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
-  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
-}
-
-package_uboot-a20-olinuxino-lime2() {
-  pkgdesc="U-Boot for A20 OLinuXino Lime2"
-  install=${pkgbase}.install
-  provides=('uboot-sunxi')
-  conflicts=('uboot-sunxi')
-
-  install -d "${pkgdir}"/boot
-  install -Dm644 bin_A20-OLinuXino-Lime2/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
-
-  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
-  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
-  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
-}
-
-package_uboot-a20-olinuxino-micro() {
-  pkgdesc="U-Boot for A20 OLinuXino Micro"
-  install=${pkgbase}.install
-  provides=('uboot-sunxi')
-  conflicts=('uboot-sunxi')
-
-  install -d "${pkgdir}"/boot
-  install -Dm644 bin_A20-OLinuXino_MICRO/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
-
-  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
-  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
-  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
-}
-
-package_uboot-cubieboard() {
-  pkgdesc="U-Boot for Cubieboard"
-  install=${pkgbase}.install
-  provides=('uboot-sunxi')
-  conflicts=('uboot-sunxi')
-
-  install -d "${pkgdir}"/boot
-  install -Dm644 bin_Cubieboard/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot/u-boot-sunxi-with-spl.bin
-
-  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
-  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
-  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
-}
-
-package_uboot-cubieboard2() {
-  pkgdesc="U-Boot for Cubieboard 2"
-  install=${pkgbase}.install
-  provides=('uboot-sunxi')
-  conflicts=('uboot-sunxi')
-
-  install -d "${pkgdir}"/boot
-  install -Dm644 bin_Cubieboard2/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot/u-boot-sunxi-with-spl.bin
-
-  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
-  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
-  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
-}
-
-package_uboot-cubietruck() {
-  pkgdesc="U-Boot for Cubietruck"
-  install=${pkgbase}.install
-  provides=('uboot-sunxi')
-  conflicts=('uboot-sunxi')
-
-  install -d "${pkgdir}"/boot
-  install -Dm644 bin_Cubietruck/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot/u-boot-sunxi-with-spl.bin
-
-  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
-  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
-  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
-}
-
-package_uboot-pcduino() {
-  pkgdesc="U-Boot for pcDuino"
-  install=${pkgbase}.install
-  provides=('uboot-sunxi')
-  conflicts=('uboot-sunxi')
-
-  install -d "${pkgdir}"/boot
-  install -Dm644 bin_Linksprite_pcDuino/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
-
-  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
-  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
-  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
-}
-
-package_uboot-pcduino3() {
-  pkgdesc="U-Boot for pcDuino3"
-  install=${pkgbase}.install
-  provides=('uboot-sunxi')
-  conflicts=('uboot-sunxi')
-
-  install -d "${pkgdir}"/boot
-  install -Dm644 bin_Linksprite_pcDuino3/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
-
-  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
-  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
-  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
-}
-
-package_uboot-pcduino3-nano() {
-  pkgdesc="U-Boot for pcDuino3 Nano"
-  install=${pkgbase}.install
-  provides=('uboot-sunxi')
-  conflicts=('uboot-sunxi')
-
-  install -d "${pkgdir}"/boot
-  install -Dm644 bin_Linksprite_pcDuino3_Nano/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
-
-  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
-  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
-  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
-}
+"
+done


### PR DESCRIPTION
I left package list unchanged, just replace many copies of package() function with loop.

It should be compatible with existing package names.