### PR TITLE
alarm/kodi-c2 to 17.1-1

### DIFF
--- a/alarm/kodi-c2/PKGBUILD
+++ b/alarm/kodi-c2/PKGBUILD
@@ -6,8 +6,8 @@ _prefix=/usr
 
 pkgbase=kodi-c2
 pkgname=('kodi-c2' 'kodi-c2-eventclients')
-_commit=a8a20945ee81446cc8453b09490cfb017027a711
-pkgver=17.0
+_commit=8cbff508cde50ae3e34d721da895d1a4655f131f
+pkgver=17.1
 pkgrel=1
 arch=('aarch64')
 url="http://kodi.tv"
@@ -23,12 +23,12 @@ makedepends=(
   'shairplay' 'smbclient' 'swig' 'taglib' 'tinyxml' 'unzip' 'upower' 'yajl' 'zip'
 )
 
-source=("https://github.com/phedoreanu/xbmc/archive/${_commit}.tar.gz"
+source=("https://github.com/Owersun/xbmc/archive/${_commit}.tar.gz"
         'kodi_permissions.conf'
         'kodi.service'
         'polkit.rules'
         '99-odroid.rules')
-sha256sums=('ae8a3f1d76f73a478cf1f29679e9006e0ae96f1259bdd61de57832a8c8438074'
+sha256sums=('31742e3e415826ea1c6fc9093eec010f529a0f70f2c86698d5ec5ac484d7b512'
             '8c606f29aa9ec90f4c93e1751cfd4000872937e604e6ad7538b96ba29612d2f6'
             '79aa17b475967d97b6c72c850b638705d6feb6d995844476b65d68d33d161114'
             'c68ed2bd377f80b606b8815d78239b9132b479eafc1d19797cee5824debe1800'


### PR DESCRIPTION
The git repository by @phedoreanu seems unmainted and has not been updated for months, so the upstream repo has been switched to the repo by @Owersun which also the current upstream repo for alarm/kodi-c1.

The referenced commit Owersun/xbmc@8cbff508cde50ae3e34d721da895d1a4655f131f works fine on my C2.