### PR TITLE
alarm/kodi-rbp to 17.2-1

### DIFF
--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -12,8 +12,8 @@ _prefix=/usr
 pkgbase=kodi-rbp
 pkgname=('kodi-rbp' 'kodi-rbp-eventclients' 'kodi-rbp-tools-texturepacker' 'kodi-rbp-dev')
 _codename=Krypton
-pkgver=17.1
-pkgrel=4
+pkgver=17.2
+pkgrel=1
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
 license=('GPL2')
@@ -32,11 +32,11 @@ source=("https://github.com/xbmc/xbmc/archive/$pkgver-$_codename.tar.gz"
         'polkit.rules'
         'hifiberry_digi.patch')
 
-sha256sums=('303f3903cbb57ccc2961f09cf3746505542bcb129a464f0687d7ca8601cebbee'
+sha256sums=('aed9236c5a0074a4dfc775c111d362e4358daa0030d7e8ba38fbb6d58ae1affe'
             '5235068d5800d69f0287087815990e7fe8d6572733d60c8800546d35f608e87f'
             'b31570f95654434b01fd8531612fbb6be77cbc1c519dd60f92feae26eb160f3d'
-            '813f8c622c341eefb33774115199d2abe9c189cf2ce52e79719dbd42d48a1274'
-            'd830c010ead152bc9a9ba6b812c985d6e649bda7480fec9b3c451f5ea03ba792'
+            '6f23df9cf214502f0a446edf07b18ce1855e549cabb1cd94ac9180770ba48ee4'
+            '82057eccc4cadbd568dda76103dcc667754194e926ede78e43d70b3a17bbb5e5'
             '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96'
             '0b9d951911a8576c26dec8a31f394282677e48afff49b9579448121d27b8509e')
 prepare() {
@@ -126,7 +126,7 @@ package_kodi-rbp() {
 
   install -Dm0644 "$srcdir/kodi.service" "$pkgdir/usr/lib/systemd/system/kodi.service"
   install -Dm0644 "$srcdir/polkit.rules" "$pkgdir/usr/share/polkit-1/rules.d/10-kodi.rules"
-  chmod 0700 "$pkgdir/usr/share/polkit-1/rules.d/"
+  chmod 0750 "$pkgdir/usr/share/polkit-1/rules.d/"
 
   # fix permissions necessary for accelerated video playback
   install -Dm0644 "$srcdir/99-kodi.rules" "$pkgdir/etc/udev/rules.d/99-kodi.rules"


### PR DESCRIPTION
Bump to new upstream version and fix premissions on `/usr/share/polkit-1/rules.d/` which should be 0750 not 0700.