### PR TITLE
aur/libcrossguid-git: needed for kodi rebuild

### DIFF
--- a/aur/libcrossguid-git/PKGBUILD
+++ b/aur/libcrossguid-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Cedric Girard <girard.cedric@gmail.com>
 
 pkgname=libcrossguid-git
-pkgver=r35.8f399e8
+pkgver=r37.fef89a4
 pkgrel=1
 pkgdesc="Lightweight cross platform C++ GUID/UUID library"
 arch=('i686' 'x86_64')
@@ -21,12 +21,12 @@ pkgver() {
 build() {
   cd "$srcdir"/libcrossguid
 
-  g++ -c guid.cpp -o guid.o $CXXFLAGS -std=c++11 -DGUID_LIBUUID
+  g++ -c guid.cpp -o guid.o $CXXFLAGS -fPIC -std=c++11 -DGUID_LIBUUID
   ar rvs libcrossguid.a guid.o
 
-  g++ -c test.cpp -o test.o $CXXFLAGS  -std=c++11
-  g++ -c testmain.cpp -o testmain.o $CXXFLAGS
-  g++ test.o guid.o testmain.o -o test $CXXFLAGS -luuid
+  g++ -c test.cpp -o test.o $CXXFLAGS -fPIC -std=c++11
+  g++ -c testmain.cpp -o testmain.o $CXXFLAGS -fPIC
+  g++ test.o guid.o testmain.o -o test $CXXFLAGS -fPIC -luuid
   chmod +x test
 
 }


### PR DESCRIPTION
Arch's kodi package is now using hardening-wrapper which requires the -fPIC flag in this package to build.  I will send a PR for kodi-rbp shortly, but for it to build, it will require this modification to aur/libcrossguid-git.

Reference to Arch kodi changes: https://git.archlinux.org/svntogit/community.git/commit/trunk?h=packages/kodi&id=fed4ef62666fa3f0f376ba575b64ef988deda8cd