### PR TITLE
alarm/kodi-rbp to 17.3-2

### DIFF
--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -13,7 +13,7 @@ pkgbase=kodi-rbp
 pkgname=('kodi-rbp' 'kodi-rbp-eventclients' 'kodi-rbp-tools-texturepacker' 'kodi-rbp-dev')
 _codename=Krypton
 pkgver=17.3
-pkgrel=1
+pkgrel=2
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
 license=('GPL2')
@@ -30,7 +30,8 @@ source=("https://github.com/xbmc/xbmc/archive/$pkgver-$_codename.tar.gz"
         'https://github.com/popcornmix/xbmc/commit/0c320b6cdd4fb409be45008e6b9042463d54b742.patch'
         'https://github.com/popcornmix/xbmc/commit/4d983105d7fd65b1d92f2ae2602e6e1cdcaddbe0.patch'
         'polkit.rules'
-        'hifiberry_digi.patch')
+        'hifiberry_digi.patch'
+        'fix-python-lib-path.patch')
 
 sha256sums=('1de8653a3729cefd1baaf09ecde5ace01a1e3a58fbf29d48c1363f2503d331a1'
             '5235068d5800d69f0287087815990e7fe8d6572733d60c8800546d35f608e87f'
@@ -38,7 +39,8 @@ sha256sums=('1de8653a3729cefd1baaf09ecde5ace01a1e3a58fbf29d48c1363f2503d331a1'
             '6f23df9cf214502f0a446edf07b18ce1855e549cabb1cd94ac9180770ba48ee4'
             '82057eccc4cadbd568dda76103dcc667754194e926ede78e43d70b3a17bbb5e5'
             '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96'
-            '0b9d951911a8576c26dec8a31f394282677e48afff49b9579448121d27b8509e')
+            '0b9d951911a8576c26dec8a31f394282677e48afff49b9579448121d27b8509e'
+            '1c07c9fdd8e2958262cf917e4266c4933fcd06529c111e3cb0cbaaa05c934033')
 prepare() {
   cd "$srcdir/xbmc-$pkgver-$_codename"
 
@@ -48,13 +50,15 @@ prepare() {
   patch -Np1 -i "$srcdir/4d983105d7fd65b1d92f2ae2602e6e1cdcaddbe0.patch"
   # fix for lack of passthrough audio with hifiberry-digi+ card
   patch -Np1 -i "$srcdir/hifiberry_digi.patch"
+  #
+  patch -p1 -i "$srcdir/fix-python-lib-path.patch"
 
   [[ -d kodi-build ]] && rm -rf kodi-build
   mkdir $srcdir/kodi-build
 }
 
 build() {
-  cd "kodi-build"
+  cd kodi-build
 
   # -DCPU=arm1176jzf-s for rpi1
   # -DCPU=cortex-a7 for rpi2

--- a/alarm/kodi-rbp/fix-python-lib-path.patch
+++ b/alarm/kodi-rbp/fix-python-lib-path.patch
@@ -1,0 +1,29 @@
+--- a/project/cmake/scripts/linux/Install.cmake	2017-03-20 17:17:49.000000000 +0100
++++ b/project/cmake/scripts/linux/Install.cmake	2017-05-20 15:42:09.608550173 +0200
+@@ -199,7 +199,7 @@
+   install(PROGRAMS ${CORE_SOURCE_DIR}/tools/EventClients/lib/python/bt/__init__.py
+                    ${CORE_SOURCE_DIR}/tools/EventClients/lib/python/bt/bt.py
+                    ${CORE_SOURCE_DIR}/tools/EventClients/lib/python/bt/hid.py
+-          DESTINATION lib/python2.7/dist-packages/${APP_NAME_LC}/bt
++          DESTINATION lib/python2.7/site-packages/${APP_NAME_LC}/bt
+           COMPONENT kodi-eventclients-common)
+ 
+   # Install kodi-eventclients-common PS3 python files
+@@ -208,7 +208,7 @@
+                    ${CORE_SOURCE_DIR}/tools/EventClients/lib/python/ps3/sixaxis.py
+                    ${CORE_SOURCE_DIR}/tools/EventClients/lib/python/ps3/sixpair.py
+                    ${CORE_SOURCE_DIR}/tools/EventClients/lib/python/ps3/sixwatch.py
+-          DESTINATION lib/python2.7/dist-packages/${APP_NAME_LC}/ps3
++          DESTINATION lib/python2.7/site-packages/${APP_NAME_LC}/ps3
+           COMPONENT kodi-eventclients-common)
+ 
+   # Install kodi-eventclients-common python files
+@@ -218,7 +218,7 @@
+                    "${CORE_SOURCE_DIR}/tools/EventClients/Clients/PS3 BD Remote/ps3_remote.py"
+                    ${CORE_SOURCE_DIR}/tools/EventClients/lib/python/xbmcclient.py
+                    ${CORE_SOURCE_DIR}/tools/EventClients/lib/python/zeroconf.py
+-          DESTINATION lib/python2.7/dist-packages/${APP_NAME_LC}
++          DESTINATION lib/python2.7/site-packages/${APP_NAME_LC}
+           COMPONENT kodi-eventclients-common)
+ 
+   # Install kodi-eventclients-common icons


### PR DESCRIPTION
~~Note that this PR is dependent on https://github.com/archlinuxarm/PKGBUILDs/pull/1483~~

EDIT: It should be noted that the hardening-wrapper currently does not support distcc builds.  On my RPi3, it takes over 80 minutes to build this package without distcc compared to about 20 min with distcc.  If no distcc is a deal breaker, let me know and I will adjust the PR to not use the script.