### PR TITLE
alarm/kodi-c2 to 17.3-1

### DIFF
--- a/alarm/kodi-c2/PKGBUILD
+++ b/alarm/kodi-c2/PKGBUILD
@@ -1,13 +1,11 @@
-# Maintainer: Adrian Fedoreanu <adrian.fedoreanu@gmail.com>
-
 buildarch=8
 
 _prefix=/usr
 
 pkgbase=kodi-c2
 pkgname=('kodi-c2' 'kodi-c2-eventclients')
-_commit=8cbff508cde50ae3e34d721da895d1a4655f131f
-pkgver=17.1
+_commit=a69fc214a4bf72c811d84b28e05bcc419242e719
+pkgver=17.3
 pkgrel=1
 arch=('aarch64')
 url="http://kodi.tv"
@@ -28,7 +26,7 @@ source=("https://github.com/Owersun/xbmc/archive/${_commit}.tar.gz"
         'kodi.service'
         'polkit.rules'
         '99-odroid.rules')
-sha256sums=('31742e3e415826ea1c6fc9093eec010f529a0f70f2c86698d5ec5ac484d7b512'
+sha256sums=('1193924fb14d0e88ab858560cb55037a18b8a6271984fbc6ce83a251091700c2'
             '8c606f29aa9ec90f4c93e1751cfd4000872937e604e6ad7538b96ba29612d2f6'
             '79aa17b475967d97b6c72c850b638705d6feb6d995844476b65d68d33d161114'
             'c68ed2bd377f80b606b8815d78239b9132b479eafc1d19797cee5824debe1800'


### PR DESCRIPTION
Upgrade kodi-c2 to 17.3-1.

Please note that Kodi team may drop autoconf in favor of cmake in the nearest future.