### PR TITLE
linux-odroid-c2-headers - fix missing arch/arm/include headers, required by arch/arm64/include

### DIFF
--- a/core/linux-odroid-c2/PKGBUILD
+++ b/core/linux-odroid-c2/PKGBUILD
@@ -9,7 +9,7 @@ _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="ODROID-C2"
 pkgver=3.14.79
-pkgrel=24
+pkgrel=25
 arch=('aarch64')
 url="https://github.com/hardkernel/linux/tree/odroidc2-3.14.y"
 license=('GPL2')
@@ -132,7 +132,7 @@ _package() {
   install -D -m644 vmlinux "${pkgdir}/usr/lib/modules/${_kernver}/build/vmlinux"
 
   # install amlogic hdmi init script/service
-  install -Dm644 "${srcdir}/amlogic.service" "${pkgdir}/usr/lib/systemd/system/amlogic.service"  
+  install -Dm644 "${srcdir}/amlogic.service" "${pkgdir}/usr/lib/systemd/system/amlogic.service"
   install -Dm755 "${srcdir}/c2_bootini/c2_init.sh" "${pkgdir}/usr/bin/amlogic.sh"
 }
 
@@ -246,7 +246,7 @@ _package-headers() {
   done
 
   # remove unneeded architectures
-  rm -rf "${pkgdir}"/usr/lib/modules/${_kernver}/build/arch/{alpha,arc,arm,arm26,avr32,blackfin,c6x,cris,frv,h8300,hexagon,ia64,m32r,m68k,m68knommu,metag,mips,microblaze,mn10300,openrisc,parisc,powerpc,ppc,s390,score,sh,sh64,sparc,sparc64,tile,unicore32,um,v850,x86,xtensa}
+  rm -rf "${pkgdir}"/usr/lib/modules/${_kernver}/build/arch/{alpha,arc,arm26,avr32,blackfin,c6x,cris,frv,h8300,hexagon,ia64,m32r,m68k,m68knommu,metag,mips,microblaze,mn10300,openrisc,parisc,powerpc,ppc,s390,score,sh,sh64,sparc,sparc64,tile,unicore32,um,v850,x86,xtensa}
 }
 
 pkgname=("${pkgbase}" "${pkgbase}-headers")


### PR DESCRIPTION
All headers under arch/arm64/include/asm/xen there look like this:

    #include <../../arm/include/asm/xen/hypervisor.h>

But PKGBUILD removes all headers for "arm", so building dkms modules (newer rtl8812au in my case) that use these will fail.
This is not a quirk of hardkernel/linux, but is also how they are in upstream linux-3.14.

grep shows that stuff under arch/arm64/include/asm/xen are the only headers that do this kind of thing (include stuff from "arm"), so alternative fix might be applying a patch to copy these headers from "arm" to "arm64", saving ~1.3M of space (unpacked), but probably more error-prone, hence this patch.
