### PR TITLE
core/linux-aarch64-rc: include clocksource in linux-headers

### DIFF
--- a/core/linux-aarch64-rc/PKGBUILD
+++ b/core/linux-aarch64-rc/PKGBUILD
@@ -11,7 +11,7 @@ _srcname=linux-${_rcver}-rc${_rcrel}
 _kernelname=${pkgbase#linux}
 _desc="AArch64 multi-platform (release candidate)"
 pkgver=${_rcver}.rc${_rcrel}
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -148,8 +148,8 @@ _package-headers() {
 
   mkdir -p "${pkgdir}/usr/lib/modules/${_kernver}/build/include"
 
-  for i in acpi asm-generic config crypto drm generated keys linux math-emu \
-    media net pcmcia scsi soc sound trace uapi video xen; do
+  for i in acpi asm-generic clocksource config crypto drm generated keys linux \
+    math-emu media net pcmcia scsi soc sound trace uapi video xen; do
     cp -a include/${i} "${pkgdir}/usr/lib/modules/${_kernver}/build/include/"
   done
 


### PR DESCRIPTION
Required to build Mali Utgard kernel driver for meson_drm