### PR TITLE
alarm: create dkms-mali-utgard-meson

### DIFF
--- a/alarm/dkms-mali-utgard-meson/PKGBUILD
+++ b/alarm/dkms-mali-utgard-meson/PKGBUILD
@@ -1,0 +1,29 @@
+# Mali driver for mainline linux on Meson platforms
+# Maintainer: Joseph Kogut <joseph.kogut@gmail.com>
+
+buildarch=8
+
+_gitname="meson_gx_mali_450"
+pkgname=dkms-mali-utgard-meson
+pkgver=r6p1
+pkgrel=1
+pkgdesc="Mali Utgard Kernel Module for meson_drm"
+arch=('aarch64')
+url="https://github.com/jakogut/$_gitname"
+license=('MIT')
+install="$pkgname".install
+depends=('linux>=4.12' 'linux-headers>=4.12' 'dkms')
+makedepends=('git')
+provides=('dkms-mali')
+conflicts=('dkms-mali')
+options=(!strip)
+source=("git+${url}.git" "dkms.conf")
+md5sums=('SKIP'
+         '17a564c98a35df0577be76f3f5c8c758')
+
+package() {
+	cp dkms.conf "$srcdir/$_gitname/driver/src/devicedrv/mali"
+	cd "$srcdir/$_gitname/driver/src/devicedrv/mali"
+	mkdir -p "$pkgdir/usr/src/mali-utgard-meson-$pkgver"
+	cp -r . "$pkgdir/usr/src/mali-utgard-meson-$pkgver"
+}

--- a/alarm/dkms-mali-utgard-meson/dkms-mali-utgard-meson.install
+++ b/alarm/dkms-mali-utgard-meson/dkms-mali-utgard-meson.install
@@ -1,0 +1,13 @@
+pkgver="r6p1"
+
+post_install() {
+	dkms install "mali-utgard-meson/$pkgver"
+}
+
+post_upgrade() {
+	post_install
+}
+
+pre_remove() {
+	dkms remove "mali-utgard-meson/$pkgver" --all
+}

--- a/alarm/dkms-mali-utgard-meson/dkms.conf
+++ b/alarm/dkms-mali-utgard-meson/dkms.conf
@@ -1,0 +1,14 @@
+PACKAGE_NAME="mali-utgard-meson"
+PACKAGE_VERSION="r6p1"
+
+AUTOINSTALL="yes"
+
+CLEAN[0]="make clean"
+
+MAKE[0]="ARCH=arm64 KDIR=/lib/modules/${kernelver}/build USING_UMP=0 \
+	MALI_DMA_BUF_MAP_ON_ATTACH=1 USING_PROFILING=0 MALI_PLATFORM=meson make"
+
+BUILT_MODULE_NAME[0]="mali"
+BUILT_MODULE_LOCATION[0]="."
+DEST_MODULE_LOCATION[0]="/kernel/drivers/gpu/drm/"
+


### PR DESCRIPTION
DKMS package for Mali Utgard kernel driver on meson platform