### PR TITLE
alarm: create xf86-video-armsoc-meson

### DIFF
--- a/alarm/xf86-video-armsoc-meson/99-mali-meson.conf
+++ b/alarm/xf86-video-armsoc-meson/99-mali-meson.conf
@@ -1,0 +1,7 @@
+Section "Device"
+	Identifier 	"Mali FBDEV"
+	Driver		"armsoc"
+	Option 		"DRI2"	"true"
+	Option		"DRI2_WAIT_VSYNC" "true"
+	Option		"DRI2_PAGE_FLIP" "true"
+EndSection

--- a/alarm/xf86-video-armsoc-meson/PKGBUILD
+++ b/alarm/xf86-video-armsoc-meson/PKGBUILD
@@ -1,0 +1,31 @@
+# Meson Mali Xorg Driver
+# Maintainer: Joseph Kogut <joseph.kogut@gmail.com>
+
+buildarch=8
+
+pkgname=xf86-video-armsoc-meson
+pkgver=0.5
+pkgrel=1
+pkgdesc="X.org Mali video driver for Meson platforms"
+arch=('aarch64')
+license=('MIT')
+url="https://github.com/jakogut/xf86-video-armsoc.git"
+depends=('mali-utgard-meson-libgl-x11')
+makedepends=('xorg-server-devel' 'X-ABI-VIDEODRV_VERSION=23' 'git')
+conflicts=('xorg-server<1.16' 'X-ABI-VIDEODRV_VERSION<23' 'X-ABI-VIDEODRV_VERSION>=24')
+source=($pkgname::"git+${url}"
+	99-mali-meson.conf)
+sha256sums=('SKIP'
+            'eca6ed5e20457d41a0fc9ac07034ee2682d5623cf6e566bf9df017d217540952')
+
+build() {
+  cd $pkgname
+  LDFLAGS+=" -L/usr/lib/mali-egl"
+  ./autogen.sh --prefix=/usr
+  make
+}
+
+package() {
+  install -Dm755 ${srcdir}/$pkgname/src/.libs/armsoc_drv.so "${pkgdir}/usr/lib/xorg/modules/drivers/armsoc_drv.so"
+  install -Dm644 ${srcdir}/99-mali-meson.conf "${pkgdir}/etc/X11/xorg.conf.d/99-mali-meson.conf"
+}


### PR DESCRIPTION
X.org Mali video driver for Meson platforms