### PR TITLE
linux-odroid-c2: include arm arch headers

### DIFF
--- a/core/linux-odroid-c2/PKGBUILD
+++ b/core/linux-odroid-c2/PKGBUILD
@@ -9,7 +9,7 @@ _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="ODROID-C2"
 pkgver=3.14.79
-pkgrel=25
+pkgrel=26
 arch=('aarch64')
 url="https://github.com/hardkernel/linux/tree/odroidc2-3.14.y"
 license=('GPL2')
@@ -85,6 +85,7 @@ _package() {
   cd "${srcdir}/${_srcname}"
 
   KARCH=arm64
+  KSUBARCH=arm
 
   # get kernel version
   _kernver="$(make kernelrelease)"
@@ -161,6 +162,8 @@ _package-headers() {
   # copy arch includes for external modules
   mkdir -p ${pkgdir}/usr/lib/modules/${_kernver}/build/arch/$KARCH
   cp -a arch/$KARCH/include ${pkgdir}/usr/lib/modules/${_kernver}/build/arch/$KARCH/
+  mkdir -p ${pkgdir}/usr/lib/modules/${_kernver}/build/arch/$KSUBARCH
+  cp -a arch/$KSUBARCH/include ${pkgdir}/usr/lib/modules/${_kernver}/build/arch/$KSUBARCH/
 
   # copy files necessary for later builds, like nvidia and vmware
   cp Module.symvers "${pkgdir}/usr/lib/modules/${_kernver}/build"


### PR DESCRIPTION
Without this, it's not possible to build external modules, since there are lots of cross-arch (arm64->arm) includes.