### PR TITLE
alarm/kodi-c2 to 17.4-1

### DIFF
--- a/alarm/kodi-c2/PKGBUILD
+++ b/alarm/kodi-c2/PKGBUILD
@@ -1,121 +1,140 @@
+# vim:set ts=2 sw=2 et:
+# $Id$
+# Maintainer: Sergej Pupykin <pupykin.s+arch@gmail.com>
+# Maintainer: BlackIkeEagle < ike DOT devolder AT gmail DOT com >
+# Contributor: graysky <graysky AT archlinux DOT us>
+# Contributor: DonVla <donvla@users.sourceforge.net>
+# Contributor: Ulf Winkelvos <ulf [at] winkelvos [dot] de>
+# Contributor: Ralf Barth <archlinux dot org at haggy dot org>
+# Contributor: B & monty - Thanks for your hints :)
+# Contributor: marzoul
+# Contributor: Sergej Pupykin <pupykin.s+arch@gmail.com>
+# Contributor: Brad Fanella <bradfanella@archlinux.us>
+# Contributor: [vEX] <niechift.dot.vex.at.gmail.dot.com>
+# Contributor: Zeqadious <zeqadious.at.gmail.dot.com>
+# Contributor: Bartłomiej Piotrowski <bpiotrowski@archlinux.org>
+# Contributor: Maxime Gauduin <alucryd@gmail.com>
+# Contributor: Jan Holthuis <holthuis dot jan at googlemail dot com>
+#
+# Original credits go to Edgar Hucek <gimli at dark-green dot com>
+# for his xbmc-vdpau-vdr PKGBUILD at https://archvdr.svn.sourceforge.net/svnroot/archvdr/trunk/archvdr/xbmc-vdpau-vdr/PKGBUILD
+
 buildarch=8
-
-_prefix=/usr
-
 pkgbase=kodi-c2
-pkgname=('kodi-c2' 'kodi-c2-eventclients')
-_commit=a69fc214a4bf72c811d84b28e05bcc419242e719
-pkgver=17.3
+pkgname=('kodi-c2' 'kodi-c2-eventclients' 'kodi-c2-tools-texturepacker' 'kodi-c2-dev')
+pkgver=17.4
+_commit=cf20c960135f7a9b702afbf7e252ab70cf22a1d9
 pkgrel=1
 arch=('aarch64')
 url="http://kodi.tv"
 license=('GPL2')
 makedepends=(
-  'afpfs-ng' 'bluez-libs' 'boost' 'cmake' 'curl' 'cwiid' 'doxygen' 'git' 'glew'
+  'afpfs-ng' 'bluez-libs' 'boost' 'cmake' 'curl' 'cwiid' 'doxygen' 'glew'
   'gperf' 'hicolor-icon-theme' 'jasper' 'java-runtime' 'libaacs' 'libass'
-  'libbluray' 'libcdio' 'odroid-c2-libgl-fb' 'odroid-c2-libgl-headers'
-  'libmariadbclient' 'libmicrohttpd' 'libmodplug' 'libmpeg2' 'libnfs'
-  'libplist' 'libpulse' 'libssh' 'libva' 'mesa' 'libcrossguid' 'libcec'
-  'libxslt' 'lzo' 'nasm' 'nss-mdns' 'python2-pillow' 'aml-libs-c2'
-  'python2-pybluez' 'python2-simplejson' 'rtmpdump' 'sdl2' 'sdl_image'
+  'libbluray' 'libcdio' 'libcec' 'libgl' 'libmariadbclient' 'libmicrohttpd'
+  'libmodplug' 'libmpeg2' 'libnfs' 'libplist' 'libpulse' 'libssh' 'libva'
+  'libvdpau' 'libxrandr' 'libxslt' 'lzo' 'nasm' 'nss-mdns' 'python2-pillow'
+  'python2-pybluez' 'python2-simplejson' 'rtmpdump'
   'shairplay' 'smbclient' 'swig' 'taglib' 'tinyxml' 'unzip' 'upower' 'yajl' 'zip'
+  'mesa' 'libcrossguid'
+   'odroid-c2-libgl-fb' 'odroid-c2-libgl-headers' 'aml-libs-c2'
 )
-
-source=("https://github.com/Owersun/xbmc/archive/${_commit}.tar.gz"
-        'kodi_permissions.conf'
-        'kodi.service'
-        'polkit.rules'
-        '99-odroid.rules')
-sha256sums=('1193924fb14d0e88ab858560cb55037a18b8a6271984fbc6ce83a251091700c2'
-            '8c606f29aa9ec90f4c93e1751cfd4000872937e604e6ad7538b96ba29612d2f6'
-            '79aa17b475967d97b6c72c850b638705d6feb6d995844476b65d68d33d161114'
-            'c68ed2bd377f80b606b8815d78239b9132b479eafc1d19797cee5824debe1800'
-            '5ddf80329c9f5d054525b45f788b3405d199bfc6cf5b08c543ad29766ec27f6e')
+source=(
+  "https://github.com/Owersun/xbmc/archive/${_commit}.tar.gz"
+  'fix-python-lib-path.patch'
+  'kodi_permissions.conf'
+  'kodi.service'
+  'polkit.rules'
+  '99-odroid.rules'
+)
+sha512sums=('a18d4104b1a901939f6b4e2a2f303f814fcae8518abc030894d260c1fc9bfbb6b897c11c5041375d835f483ee95fc5d12374534a8093fca2e5137d5a5725a807'
+            '0f41604e38648969572a66d1124d6e090c3bfca4f9d8ccabcd1806254c38b178ee08df35e1bbbd1228f820729df52353321b3257122af601c3233dbc6405c6d2'
+            '890ed1fb944c337ed04397db7b2c8de5ef74f25eb49936e2fec418baf279cfa7d3ba292ccd6beccb60f83dc94b020d068162bc2c9a4ede8392d64ad7edcd5601'
+            '9953861cd17ec4c31094a2b1ef7161df13759b4b840cbc0231650ffc5349aa3ce98d8b860b1109eac22c6dcd153c43e165ed3451e5dbe2a3dbe130db53c28ad4'
+            '2e28e1366b89a94848822ccf8f6874fc69c1b2ffd27b129132e793bc41d27652f87d53deb48ff9a1dc01050f39a2bafa16b58e2a9c1c0f3cdc4155cd357c9b2a'
+            'dcb23c9074a6f646c419957169642bfd565e004f221bd972ae6034bcc4ef6aa6f4f2bbda011c759fef769b682f7a686cc041a02e5326530bd1ad2011366d1529')
 
 prepare() {
-  cd xbmc-${_commit}
+  [[ -d kodi-build ]] && rm -rf kodi-build
+  mkdir kodi-build
 
-  find -type f -name *.py -exec sed 's|^#!.*python$|#!/usr/bin/python2|' -i "{}" +
-  sed 's|^#!.*python$|#!/usr/bin/python2|' -i tools/depends/native/rpl-native/rpl
-  sed 's/python/python2/' -i tools/Linux/kodi.sh.in
+  cd "xbmc-$_commit"
+  patch -p1 -i "$srcdir/fix-python-lib-path.patch"
 }
 
 build() {
-  cd xbmc-${_commit}
-
-  # https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html
-  CFLAGS=`echo "$CFLAGS -I/usr/include/{ump,umplock} -mcpu=cortex-a53+crc -mtune=cortex-a53 -mabi=lp64"` && CXXFLAGS="$CFLAGS"
-  LDFLAGS+=" -L/usr/lib/mali-egl -L/usr/lib/aml_libs"
-
-  # Bootstrapping
-  MAKEFLAGS=-j`nproc` ./bootstrap
-
-  # Configuring XBMC
-  export PYTHON_VERSION=2  # external python v2
-  ./configure --prefix=$_prefix \
-    gl_cv_func_gettimeofday_clobber=no ac_cv_lib_bluetooth_hci_devid=no \
-    --disable-debug \
-    --enable-optimizations \
-    --enable-libbluray \
-    --disable-texturepacker \
-    --with-lirc-device=/run/lirc/lircd \
-    --disable-static --enable-shared \
-    --disable-vaapi \
-    --disable-vdpau \
-    --disable-openmax \
-    --disable-gl \
-    --disable-x11 \
-    --enable-gles \
-    --enable-codec=amcodec
-
-  # Now (finally) build
-  make -j`nproc`
+  cd kodi-build
+  cmake -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+    -DENABLE_EVENTCLIENTS=ON \
+    -DLIRC_DEVICE=/run/lirc/lircd \
+    -DENABLE_AML=ON                 \
+    -DENABLE_OPENGL=OFF             \
+    -DENABLE_OPENGLES=ON            \
+    -DENABLE_PULSEAUDIO=OFF         \
+    -DENABLE_VAAPI=OFF              \
+    -DENABLE_VDPAU=OFF              \
+    -DENABLE_X11=OFF                \
+    ../"xbmc-$_commit"/project/cmake
+  make
+  make preinstall
 }
+
+# kodi
+# components: kodi, kodi-bin
 
 package_kodi-c2() {
   pkgdesc="A software media player and entertainment hub for digital media (ODROID-C2)"
-
-  # depends expected for kodi plugins:
-  # 'python2-pillow' 'python2-pybluez' 'python2-simplejson'
-  # depends expeced in FEH.py
-  # 'mesa-demos' 'xorg-xdpyinfo'
   depends=(
-    'python2-pillow' 'python2-pybluez' 'python2-simplejson'
-    'mesa-demos' 'xorg-xdpyinfo'
-    'bluez-libs' 'fribidi' 'glew' 'hicolor-icon-theme' 'libcdio'
-    'libjpeg-turbo' 'libmariadbclient' 'libmicrohttpd' 'libpulse' 'libssh'
-    'libva' 'libxrandr' 'libxslt' 'lzo' 'sdl2' 'smbclient' 'taglib' 'tinyxml'
-    'yajl' 'odroid-c2-libgl-fb' 'aml-libs-c2' 'mesa'
+    'python2-pillow' 'python2-simplejson' 'xorg-xdpyinfo' 'bluez-libs'
+    'fribidi' 'freetype2' 'glew' 'hicolor-icon-theme' 'libcdio' 'libjpeg-turbo'
+    'libmariadbclient' 'libmicrohttpd' 'libpulse' 'libssh' 'libva' 'libvdpau'
+    'libxrandr' 'libxslt' 'lzo' 'smbclient' 'taglib' 'tinyxml' 'yajl' 'mesa'
+    'desktop-file-utils'
+    'odroid-c2-libgl-fb' 'aml-libs-c2'
   )
   optdepends=(
     'afpfs-ng: Apple shares support'
     'bluez: Blutooth support'
+    'python2-pybluez: Bluetooth support'
     'libnfs: NFS shares support'
     'libplist: AirPlay support'
+    'libcec: Pulse-Eight USB-CEC adapter support'
     'lirc: Remote controller support'
+    'lsb-release: log distro information in crashlog'
     'pulseaudio: PulseAudio support'
     'shairplay: AirPlay support'
-    'udisks: Automount external drives'
     'unrar: Archives support'
     'unzip: Archives support'
     'upower: Display battery level'
-    'lsb-release: log distro information in crashlog'
   )
-  install="kodi.install"
-  provides=('xbmc' 'kodi')
-  conflicts=('xbmc' 'kodi' 'shairplay-git')
+  provides=('kodi' 'xbmc')
+  conflicts=('kodi' 'xbmc')
   replaces=('xbmc')
 
-  cd xbmc-${_commit}
-  # Running make install
-  make DESTDIR="$pkgdir" install
+  _components=(
+  'kodi'
+  'kodi-bin'
+  )
+
+  cd kodi-build
+  # install eventclients
+  for _cmp in ${_components[@]}; do
+  DESTDIR="$pkgdir" /usr/bin/cmake \
+    -DCMAKE_INSTALL_COMPONENT="$_cmp" \
+     -P cmake_install.cmake
+  done
 
   # Licenses
-  install -dm755 ${pkgdir}${_prefix}/share/licenses/${pkgname}
+  install -dm755 "$pkgdir/usr/share/licenses/$pkgname"
   for licensef in LICENSE.GPL copying.txt; do
-	mv ${pkgdir}${_prefix}/share/doc/kodi/${licensef} \
-		${pkgdir}${_prefix}/share/licenses/${pkgname}
+    mv "$pkgdir/usr/share/doc/kodi/$licensef" \
+      "$pkgdir/usr/share/licenses/$pkgname"
   done
+
+  # python2 is being used
+  cd "$pkgdir"
+  grep -lR '#!.*python' * | while read file; do sed -s 's/\(#!.*python\)/\12/g' -i "$file"; done
 
   install -Dm0644 $srcdir/kodi_permissions.conf $pkgdir/etc/tmpfiles.d/kodi_permissions.conf
   install -Dm0644 $srcdir/kodi.service $pkgdir/usr/lib/systemd/system/kodi.service
@@ -125,17 +144,88 @@ package_kodi-c2() {
   install -Dm0644 $srcdir/99-odroid.rules $pkgdir/etc/udev/rules.d/99-odroid.rules
 }
 
+# kodi-eventclients
+# components: kodi-eventclients-common kodi-eventclients-ps3 kodi-eventclients-wiiremote kodi-eventclients-xbmc-send
+
 package_kodi-c2-eventclients() {
   pkgdesc="Kodi Event Clients (ODROID-C2)"
   provides=('kodi-eventclients')
   conflicts=('kodi-eventclients')
+
   depends=('cwiid')
 
-  cd ${srcdir}/xbmc-${_commit}
+  _components=(
+    'kodi-eventclients-common'
+    'kodi-eventclients-ps3'
+    'kodi-eventclients-wiiremote'
+    'kodi-eventclients-xbmc-send'
+  )
 
-  make DESTDIR="$pkgdir" eventclients WII_EXTRA_OPTS=-DCWIID_OLD
+  cd kodi-build
+  # install eventclients
+  for _cmp in ${_components[@]}; do
+    DESTDIR="$pkgdir" /usr/bin/cmake \
+      -DCMAKE_INSTALL_COMPONENT="$_cmp" \
+      -P cmake_install.cmake
+  done
 
-  install -dm755 "$pkgdir/usr/lib/python2.7/$pkgbase"
-  mv "$pkgdir/kodi"/* "$pkgdir/usr/lib/python2.7/$pkgbase"
-  rmdir "$pkgdir/kodi"
+  # python2 is being used
+  cd "$pkgdir"
+  grep -lR '#!.*python' * | while read file; do sed -s 's/\(#!.*python\)/\12/g' -i "$file"; done
+}
+
+# kodi-tools-texturepacker
+# components: kodi-tools-texturepacker
+
+package_kodi-c2-tools-texturepacker() {
+  pkgdesc="Kodi Texturepacker tool (ODROID-C2)"
+  depends=('libpng' 'giflib' 'libjpeg-turbo' 'lzo')
+  provides=('kodi-tools-texturepacker')
+  conflicts=('kodi-tools-texturepacker')
+
+  _components=(
+    'kodi-tools-texturepacker'
+  )
+
+  cd kodi-build
+  # install eventclients
+  for _cmp in ${_components[@]}; do
+    DESTDIR="$pkgdir" /usr/bin/cmake \
+      -DCMAKE_INSTALL_COMPONENT="$_cmp" \
+      -P cmake_install.cmake
+  done
+}
+
+# kodi-dev
+# components: kodi-addon-dev kodi-audio-dev kodi-eventclients-dev kodi-game-dev kodi-inputstream-dev kodi-peripheral-dev kodi-pvr-dev kodi-screensaver-dev kodi-visualization-dev
+
+package_kodi-c2-dev() {
+  pkgdesc="Kodi dev files (ODROID-C2)"
+  depends=('kodi')
+  provides=('kodi-dev')
+  conflicts=('kodi-dev')
+
+  _components=(
+    'kodi-addon-dev'
+    'kodi-audio-dev'
+    'kodi-eventclients-dev'
+    'kodi-game-dev'
+    'kodi-inputstream-dev'
+    'kodi-peripheral-dev'
+    'kodi-pvr-dev'
+    'kodi-screensaver-dev'
+    'kodi-visualization-dev'
+  )
+
+  cd kodi-build
+  # install eventclients
+  for _cmp in ${_components[@]}; do
+    DESTDIR="$pkgdir" /usr/bin/cmake \
+      -DCMAKE_INSTALL_COMPONENT="$_cmp" \
+      -P cmake_install.cmake
+  done
+
+  # python2 is being used
+  cd "$pkgdir"
+  grep -lR '#!.*python' * | while read file; do sed -s 's/\(#!.*python\)/\12/g' -i "$file"; done
 }

--- a/alarm/kodi-c2/fix-python-lib-path.patch
+++ b/alarm/kodi-c2/fix-python-lib-path.patch
@@ -1,0 +1,29 @@
+--- a/project/cmake/scripts/linux/Install.cmake	2017-03-20 17:17:49.000000000 +0100
++++ b/project/cmake/scripts/linux/Install.cmake	2017-05-20 15:42:09.608550173 +0200
+@@ -199,7 +199,7 @@
+   install(PROGRAMS ${CORE_SOURCE_DIR}/tools/EventClients/lib/python/bt/__init__.py
+                    ${CORE_SOURCE_DIR}/tools/EventClients/lib/python/bt/bt.py
+                    ${CORE_SOURCE_DIR}/tools/EventClients/lib/python/bt/hid.py
+-          DESTINATION lib/python2.7/dist-packages/${APP_NAME_LC}/bt
++          DESTINATION lib/python2.7/site-packages/${APP_NAME_LC}/bt
+           COMPONENT kodi-eventclients-common)
+ 
+   # Install kodi-eventclients-common PS3 python files
+@@ -208,7 +208,7 @@
+                    ${CORE_SOURCE_DIR}/tools/EventClients/lib/python/ps3/sixaxis.py
+                    ${CORE_SOURCE_DIR}/tools/EventClients/lib/python/ps3/sixpair.py
+                    ${CORE_SOURCE_DIR}/tools/EventClients/lib/python/ps3/sixwatch.py
+-          DESTINATION lib/python2.7/dist-packages/${APP_NAME_LC}/ps3
++          DESTINATION lib/python2.7/site-packages/${APP_NAME_LC}/ps3
+           COMPONENT kodi-eventclients-common)
+ 
+   # Install kodi-eventclients-common python files
+@@ -218,7 +218,7 @@
+                    "${CORE_SOURCE_DIR}/tools/EventClients/Clients/PS3 BD Remote/ps3_remote.py"
+                    ${CORE_SOURCE_DIR}/tools/EventClients/lib/python/xbmcclient.py
+                    ${CORE_SOURCE_DIR}/tools/EventClients/lib/python/zeroconf.py
+-          DESTINATION lib/python2.7/dist-packages/${APP_NAME_LC}
++          DESTINATION lib/python2.7/site-packages/${APP_NAME_LC}
+           COMPONENT kodi-eventclients-common)
+ 
+   # Install kodi-eventclients-common icons


### PR DESCRIPTION
This updates `kodi-c2` to the latest commit (Owersun/xbmc@cf20c960135f7a9b702afbf7e252ab70cf22a1d9).

Mainline `kodi`'s PKGBUILD has been used as a base to make use of the new CMake build system. Modified for the ODROID-C2:
- Add necessary dependencies (odroid-c2-libgl-fb, odroid-c2-libgl-headers, aml-libs-c2)
- Add permissions file, polkit rules, udev rules and systemd unit
- Set CMake settings: enable AML, disable X11, etc.

Compiles and runs on my ODROID-C2.