### PR TITLE
Add the install variable to kodi-c2 PKGBUILD

### DIFF
--- a/alarm/kodi-c2/PKGBUILD
+++ b/alarm/kodi-c2/PKGBUILD
@@ -24,7 +24,7 @@ pkgbase=kodi-c2
 pkgname=('kodi-c2' 'kodi-c2-eventclients' 'kodi-c2-tools-texturepacker' 'kodi-c2-dev')
 pkgver=17.4
 _commit=cf20c960135f7a9b702afbf7e252ab70cf22a1d9
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="http://kodi.tv"
 license=('GPL2')
@@ -108,6 +108,7 @@ package_kodi-c2() {
     'unzip: Archives support'
     'upower: Display battery level'
   )
+  install='kodi.install'
   provides=('kodi' 'xbmc')
   conflicts=('kodi' 'xbmc')
   replaces=('xbmc')


### PR DESCRIPTION
I think it was removed by mistake in 388d8bdadba05a9932c46ab924a84e3c87df4209.