### PR TITLE
core/linux-am33x: fix md5sum in PKGBUILD

### DIFF
--- a/core/linux-am33x/PKGBUILD
+++ b/core/linux-am33x/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-4.13
 _kernelname=${pkgbase#linux}
 _desc="TI AM335x Beaglebone (Black)"
 pkgver=4.13.1
-pkgrel=2
+pkgrel=3
 rcnrel=bone1
 arch=('armv7h')
 url="http://www.kernel.org/"
@@ -29,7 +29,7 @@ md5sums=('ab1a2abc6f37b752dd2595338bec4e78'
          'SKIP'
          'dc780fbf3d4d1175a94232d7ba1e3cb3'
          '9fca663632b353e196b4f090f22500ce'
-         'f575ed91dcd73677a820196fd1d1d986'
+         '78ccc998f27eec49a9d5490218b1b1ab'
          '79fa396e3f9a09a85156d6d7c2d34b58')
 
 prepare() {


### PR DESCRIPTION
It seems that linux.preset was added with a wrong md5sum in PKGBUILD (commit 346d93354105ac99ede5356015bc1db33aaae0c2).
This patch replaces the wrong md5sum (and increments pkgrel).