### PR TITLE
alarm/kodi-rbp to 17.4-2

### DIFF
--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -13,7 +13,7 @@ pkgbase=kodi-rbp
 pkgname=('kodi-rbp' 'kodi-rbp-eventclients' 'kodi-rbp-tools-texturepacker' 'kodi-rbp-dev')
 _codename=Krypton
 pkgver=17.4
-pkgrel=1
+pkgrel=2
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
 license=('GPL2')
@@ -23,7 +23,8 @@ makedepends=('hicolor-icon-theme' 'fribidi' 'lzo' 'smbclient' 'libtiff' 'libva' 
              'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray'
              'libnfs' 'afpfs-ng' 'avahi' 'bluez-libs' 'tinyxml' 'raspberrypi-firmware' 'libcec-rpi'
              'libplist' 'swig' 'taglib' 'libxslt' 'shairplay' 'boost' 'cmake' 'gperf' 'nasm' 'zip'
-             'upower' 'autoconf' 'java-environment' 'dcadec' 'libpulse' 'cwiid')
+             'upower' 'autoconf' 'java-environment' 'dcadec' 'libpulse' 'cwiid'
+             'doxygen' 'ffmpeg' 'glew' 'libaacs')
 source=("https://github.com/xbmc/xbmc/archive/$pkgver-$_codename.tar.gz"
         'kodi.service'
         '99-kodi.rules'
@@ -33,7 +34,7 @@ source=("https://github.com/xbmc/xbmc/archive/$pkgver-$_codename.tar.gz"
         'hifiberry_digi.patch'
         'fix-python-lib-path.patch')
 
-sha256sums=('b05e11b2d108222bfc3ff0c9a466d798c0feedf1228166239948e6ed37c3cb4f'
+sha256sums=('6b0886e7449fc201e0ec0584b37f9f654c429797a41e6d0b6a4b5a7fd5ec34dc'
             '5235068d5800d69f0287087815990e7fe8d6572733d60c8800546d35f608e87f'
             'b31570f95654434b01fd8531612fbb6be77cbc1c519dd60f92feae26eb160f3d'
             '6f23df9cf214502f0a446edf07b18ce1855e549cabb1cd94ac9180770ba48ee4'
@@ -82,6 +83,8 @@ build() {
     -DENABLE_VAAPI=OFF \
     -DENABLE_VDPAU=OFF \
     -DENABLE_INTERNAL_CROSSGUID=ON \
+    -DENABLE_INTERNAL_FFMPEG="no" \
+    -DWITH_FFMPEG="yes" \
     -DLIRC_DEVICE=/run/lirc/lircd \
     ../"xbmc-$pkgver-$_codename"/project/cmake
 
@@ -96,7 +99,7 @@ package_kodi-rbp() {
            'sdl_image' 'python2' 'python2-pillow' 'python2-pybluez' 'python2-simplejson' 'libass'
            'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'xorg-xdpyinfo' 'libbluray'
            'avahi' 'bluez-libs' 'tinyxml' 'raspberrypi-firmware' 'libpulse'
-           'libplist' 'swig' 'taglib' 'libxslt') 
+           'libplist' 'swig' 'taglib' 'libxslt' 'ffmpeg' 'glew')
   optdepends=(
     'afpfs-ng: Apple airplay and AFP share support'
     'libcec-rpi: Pulse-Eight USB-CEC adapter support'


### PR DESCRIPTION
Arch switched over to [external ffmpeg](https://git.archlinux.org/svntogit/community.git/commit/trunk?h=packages/kodi&id=8837248d5078a704b59e11f28c8debb23930b985); this PR mirrors that in our package.  [Here] (https://bugs.archlinux.org/task/55675)is the original FS.