### PR TITLE
alarm/kodi-rbp to 17.4-3

### DIFF
--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -13,27 +13,26 @@ pkgbase=kodi-rbp
 pkgname=('kodi-rbp' 'kodi-rbp-eventclients' 'kodi-rbp-tools-texturepacker' 'kodi-rbp-dev')
 _codename=Krypton
 pkgver=17.4
-pkgrel=2
+pkgrel=3
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
 license=('GPL2')
-makedepends=('hicolor-icon-theme' 'fribidi' 'lzo' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio'
-             'yajl' 'libmariadbclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd'
-             'sdl_image' 'python2' 'python2-pillow' 'python2-pybluez' 'python2-simplejson' 'libass'
-             'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray'
-             'libnfs' 'afpfs-ng' 'avahi' 'bluez-libs' 'tinyxml' 'raspberrypi-firmware' 'libcec-rpi'
-             'libplist' 'swig' 'taglib' 'libxslt' 'shairplay' 'boost' 'cmake' 'gperf' 'nasm' 'zip'
-             'upower' 'autoconf' 'java-environment' 'dcadec' 'libpulse' 'cwiid'
-             'doxygen' 'ffmpeg' 'glew' 'libaacs')
+makedepends=('afpfs-ng' 'autoconf' 'avahi' 'bluez-libs' 'boost' 'cmake' 'cwiid' 'dcadec'
+    'doxygen' 'ffmpeg' 'fribidi' 'glew' 'gperf' 'hicolor-icon-theme' 'jasper' 'java-environment'
+    'libaacs' 'libass' 'libbluray' 'libcdio' 'libcec-rpi' 'libjpeg-turbo' 'libmad'
+    'libmariadbclient' 'libmicrohttpd' 'libmodplug' 'libmpeg2' 'libnfs' 'libplist' 'libpng'
+    'libpulse' 'libsamplerate' 'libssh' 'libtiff' 'libva' 'libxslt' 'lzo' 'nasm' 'python2'
+    'python2-pillow' 'python2-pybluez' 'python2-simplejson' 'raspberrypi-firmware' 'rtmpdump'
+    'sdl_image' 'shairplay' 'smbclient' 'swig' 'taglib' 'tinyxml' 'unzip' 'upower' 'xorg-xdpyinfo'
+    'yajl' 'zip')
 source=("https://github.com/xbmc/xbmc/archive/$pkgver-$_codename.tar.gz"
-        'kodi.service'
-        '99-kodi.rules'
-        'https://github.com/popcornmix/xbmc/commit/0c320b6cdd4fb409be45008e6b9042463d54b742.patch'
-        'https://github.com/popcornmix/xbmc/commit/4d983105d7fd65b1d92f2ae2602e6e1cdcaddbe0.patch'
-        'polkit.rules'
-        'hifiberry_digi.patch'
-        'fix-python-lib-path.patch')
-
+    'kodi.service'
+    '99-kodi.rules'
+    'https://github.com/popcornmix/xbmc/commit/0c320b6cdd4fb409be45008e6b9042463d54b742.patch'
+    'https://github.com/popcornmix/xbmc/commit/4d983105d7fd65b1d92f2ae2602e6e1cdcaddbe0.patch'
+    'polkit.rules'
+    'hifiberry_digi.patch'
+    'fix-python-lib-path.patch')
 sha256sums=('6b0886e7449fc201e0ec0584b37f9f654c429797a41e6d0b6a4b5a7fd5ec34dc'
             '5235068d5800d69f0287087815990e7fe8d6572733d60c8800546d35f608e87f'
             'b31570f95654434b01fd8531612fbb6be77cbc1c519dd60f92feae26eb160f3d'
@@ -42,6 +41,7 @@ sha256sums=('6b0886e7449fc201e0ec0584b37f9f654c429797a41e6d0b6a4b5a7fd5ec34dc'
             '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96'
             '0b9d951911a8576c26dec8a31f394282677e48afff49b9579448121d27b8509e'
             '1c07c9fdd8e2958262cf917e4266c4933fcd06529c111e3cb0cbaaa05c934033')
+
 prepare() {
   cd "$srcdir/xbmc-$pkgver-$_codename"
   # python2 path fix
@@ -68,10 +68,6 @@ build() {
   [[ $CARCH == "armv6h" ]] && _CPU=arm1176jzf-s && LDFLAGS+=" -latomic"
   [[ $CARCH == "armv7h" ]] && _CPU=cortex-a7
 
-  # needed to avoid bad value on build/lib/libcrossguid.a
-  CFLAGS+=" -fPIC"
-  CXXFLAGS+=" -fPIC"
-
   cmake -DCMAKE_INSTALL_PREFIX=/usr \
     -DCMAKE_INSTALL_LIBDIR=/usr/lib \
     -DCMAKE_PREFIX_PATH=/opt/vc \
@@ -94,12 +90,9 @@ build() {
 
 package_kodi-rbp() {
   pkgdesc="A software media player and entertainment hub for digital media (Raspberry Pi)"
-  depends=('hicolor-icon-theme' 'fribidi' 'lzo' 'smbclient' 'libtiff' 'libva' 'libpng' 'libcdio'
-           'yajl' 'libmariadbclient' 'libjpeg-turbo' 'libsamplerate' 'libssh' 'libmicrohttpd'
-           'sdl_image' 'python2' 'python2-pillow' 'python2-pybluez' 'python2-simplejson' 'libass'
-           'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'xorg-xdpyinfo' 'libbluray'
-           'avahi' 'bluez-libs' 'tinyxml' 'raspberrypi-firmware' 'libpulse'
-           'libplist' 'swig' 'taglib' 'libxslt' 'ffmpeg' 'glew')
+  depends=('ffmpeg' 'glew' 'jasper' 'libbluray' 'libcdio' 'libmad' 'libmariadbclient' 'libmicrohttpd'
+    'libmpeg2' 'libplist' 'libxslt' 'python2-pillow' 'python2-pybluez' 'python2-simplejson'
+    'raspberrypi-firmware' 'rtmpdump' 'sdl_image' 'smbclient' 'swig' 'taglib' 'tinyxml' 'xorg-xdpyinfo' 'yajl')
   optdepends=(
     'afpfs-ng: Apple airplay and AFP share support'
     'libcec-rpi: Pulse-Eight USB-CEC adapter support'

--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -13,7 +13,7 @@ pkgbase=kodi-rbp
 pkgname=('kodi-rbp' 'kodi-rbp-eventclients' 'kodi-rbp-tools-texturepacker' 'kodi-rbp-dev')
 _codename=Krypton
 pkgver=17.4
-pkgrel=1
+pkgrel=2
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
 license=('GPL2')
@@ -23,7 +23,8 @@ makedepends=('hicolor-icon-theme' 'fribidi' 'lzo' 'smbclient' 'libtiff' 'libva' 
              'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'unzip' 'xorg-xdpyinfo' 'libbluray'
              'libnfs' 'afpfs-ng' 'avahi' 'bluez-libs' 'tinyxml' 'raspberrypi-firmware' 'libcec-rpi'
              'libplist' 'swig' 'taglib' 'libxslt' 'shairplay' 'boost' 'cmake' 'gperf' 'nasm' 'zip'
-             'upower' 'autoconf' 'java-environment' 'dcadec' 'libpulse' 'cwiid')
+             'upower' 'autoconf' 'java-environment' 'dcadec' 'libpulse' 'cwiid'
+             'doxygen' 'ffmpeg' 'glew' 'libaacs')
 source=("https://github.com/xbmc/xbmc/archive/$pkgver-$_codename.tar.gz"
         'kodi.service'
         '99-kodi.rules'
@@ -33,7 +34,7 @@ source=("https://github.com/xbmc/xbmc/archive/$pkgver-$_codename.tar.gz"
         'hifiberry_digi.patch'
         'fix-python-lib-path.patch')
 
-sha256sums=('b05e11b2d108222bfc3ff0c9a466d798c0feedf1228166239948e6ed37c3cb4f'
+sha256sums=('6b0886e7449fc201e0ec0584b37f9f654c429797a41e6d0b6a4b5a7fd5ec34dc'
             '5235068d5800d69f0287087815990e7fe8d6572733d60c8800546d35f608e87f'
             'b31570f95654434b01fd8531612fbb6be77cbc1c519dd60f92feae26eb160f3d'
             '6f23df9cf214502f0a446edf07b18ce1855e549cabb1cd94ac9180770ba48ee4'
@@ -82,6 +83,8 @@ build() {
     -DENABLE_VAAPI=OFF \
     -DENABLE_VDPAU=OFF \
     -DENABLE_INTERNAL_CROSSGUID=ON \
+    -DENABLE_INTERNAL_FFMPEG="no" \
+    -DWITH_FFMPEG="yes" \
     -DLIRC_DEVICE=/run/lirc/lircd \
     ../"xbmc-$pkgver-$_codename"/project/cmake
 
@@ -96,7 +99,7 @@ package_kodi-rbp() {
            'sdl_image' 'python2' 'python2-pillow' 'python2-pybluez' 'python2-simplejson' 'libass'
            'libmpeg2' 'libmad' 'libmodplug' 'jasper' 'rtmpdump' 'xorg-xdpyinfo' 'libbluray'
            'avahi' 'bluez-libs' 'tinyxml' 'raspberrypi-firmware' 'libpulse'
-           'libplist' 'swig' 'taglib' 'libxslt') 
+           'libplist' 'swig' 'taglib' 'libxslt' 'ffmpeg' 'glew')
   optdepends=(
     'afpfs-ng: Apple airplay and AFP share support'
     'libcec-rpi: Pulse-Eight USB-CEC adapter support'

--- a/alarm/kodi-rbp/kodi.install
+++ b/alarm/kodi-rbp/kodi.install
@@ -1,6 +1,4 @@
 post_install() {
-  [[ $(type -p gtk-update-icon-cache) ]] && usr/bin/gtk-update-icon-cache -qtf usr/share/icons/hicolor
-  [[ $(type -p update-desktop-database) ]] && usr/bin/update-desktop-database -q usr/share/applications
   getent group kodi > /dev/null || groupadd -r kodi
   getent passwd kodi > /dev/null || useradd -r -m -d /var/lib/kodi -g kodi -s /usr/bin/nologin kodi
   usermod -a -G kodi,audio,video,power,network,optical,storage,disk,tty,input kodi
@@ -13,7 +11,5 @@ post_upgrade() {
 }
 
 post_remove() {
-  [[ $(type -p gtk-update-icon-cache) ]] && usr/bin/gtk-update-icon-cache -qtf usr/share/icons/hicolor
-  [[ $(type -p update-desktop-database) ]] && usr/bin/update-desktop-database -q usr/share/applications
   getent passwd kodi > /dev/null && userdel kodi
 }


### PR DESCRIPTION
This PR cleans up unnecessary dependencies the ffmpeg addition now provides and also removes unneeded post-processing in .INSTALL which pacman hooks cover.