### PR TITLE
alarm/kodi-c2 to 17.4-3

### DIFF
--- a/alarm/kodi-c2/PKGBUILD
+++ b/alarm/kodi-c2/PKGBUILD
@@ -23,8 +23,8 @@ buildarch=8
 pkgbase=kodi-c2
 pkgname=('kodi-c2' 'kodi-c2-eventclients' 'kodi-c2-tools-texturepacker' 'kodi-c2-dev')
 pkgver=17.4
-_commit=cf20c960135f7a9b702afbf7e252ab70cf22a1d9
-pkgrel=2
+_commit=a3318ca2e106568ada0a9f959238b388a5757943
+pkgrel=3
 arch=('aarch64')
 url="http://kodi.tv"
 license=('GPL2')
@@ -47,7 +47,7 @@ source=(
   'polkit.rules'
   '99-odroid.rules'
 )
-sha512sums=('a18d4104b1a901939f6b4e2a2f303f814fcae8518abc030894d260c1fc9bfbb6b897c11c5041375d835f483ee95fc5d12374534a8093fca2e5137d5a5725a807'
+sha512sums=('66d54405f1630093274082162953c6eded8f81d725b931e7f908388504dfdbccf9d6d0d92500d361e672e5931a0531ed57c25eb296a4b0557c68fd97712910db'
             '0f41604e38648969572a66d1124d6e090c3bfca4f9d8ccabcd1806254c38b178ee08df35e1bbbd1228f820729df52353321b3257122af601c3233dbc6405c6d2'
             '890ed1fb944c337ed04397db7b2c8de5ef74f25eb49936e2fec418baf279cfa7d3ba292ccd6beccb60f83dc94b020d068162bc2c9a4ede8392d64ad7edcd5601'
             '9953861cd17ec4c31094a2b1ef7161df13759b4b840cbc0231650ffc5349aa3ce98d8b860b1109eac22c6dcd153c43e165ed3451e5dbe2a3dbe130db53c28ad4'


### PR DESCRIPTION
This updates the PKGBUILD to Owersun/xbmc@a3318ca2e106568ada0a9f959238b388a5757943.