### PR TITLE
Updated Kodi IMX to version 17.4

### DIFF
--- a/alarm/kodi-imx/PKGBUILD
+++ b/alarm/kodi-imx/PKGBUILD
@@ -17,7 +17,7 @@ _prefix=/usr
 
 pkgbase=kodi
 pkgname=('kodi-imx' 'kodi-imx-eventclients' 'kodi-imx-tools-texturepacker' 'kodi-imx-dev')
-pkgver=17.3
+pkgver=17.4
 _codename=Krypton
 pkgrel=1
 arch=('armv7h')
@@ -44,7 +44,7 @@ source=("https://github.com/xbmc/xbmc/archive/$pkgver-$_codename.tar.gz"
         'https://raw.githubusercontent.com/OpenELEC/OpenELEC.tv/master/packages/mediacenter/kodi/patches/imx6/kodi-0044-IMXCODEC-Fix-hang-on-exit-and-invalid-file-descripto.patch'
         'https://raw.githubusercontent.com/OpenELEC/OpenELEC.tv/master/packages/mediacenter/kodi/patches/imx6/kodi-53-imx-fix-edid-readout.patch'
         'https://raw.githubusercontent.com/OpenELEC/OpenELEC.tv/master/packages/mediacenter/kodi/patches/imx6/kodi-58-imx-fractional-rates.patch')
-sha256sums=('1de8653a3729cefd1baaf09ecde5ace01a1e3a58fbf29d48c1363f2503d331a1'
+sha256sums=('6b0886e7449fc201e0ec0584b37f9f654c429797a41e6d0b6a4b5a7fd5ec34dc'
             '75eae110b6ca1c844505a231b453377afb092ef3969a31c8f4c72a3c3247381a'
             '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96'
             '6d9822d97b9e1268c04078f6c9b6316eb013f95f96f90034b51fa7473b9752ff'
@@ -72,9 +72,6 @@ prepare() {
   #
   patch -p1 -i "$srcdir/fix-python-lib-path.patch"
 
-  # Remove crossguid
-#  [[ -d tools/depends/target/crossguid ]] && rm -rf tools/depends/target/crossguid
-
   [[ -d kodi-build ]] && rm -rf kodi-build
   mkdir $srcdir/kodi-build
 }
@@ -94,7 +91,6 @@ build() {
     -DENABLE_IMX=ON \
     -DENABLE_VAAPI=OFF \
     -DENABLE_VDPAU=OFF \
-    -DENABLE_INTERNAL_CROSSGUID=OFF \
     -DENABLE_NONFREE=ON \
     -DENABLE_UPNP=ON \
     -DENABLE_CEC=ON \


### PR DESCRIPTION
I started having issues in 17.3 with movie playback a while back. I suspect the updated ffmpeg was to blame, but I'm not sure, didn't have time to investigate.

Kodi 17.4 compiles fine, works fine and I no longer have playback issues - everything seems to be back to normal.

I cleaned up a few lines in the PKGBUILD related to crossguid package that were either not necessary or caused problems during compilation.