### PR TITLE
Updated U-Boot Cubox-I to version 2017.09

### DIFF
--- a/alarm/uboot-cubox-i/PKGBUILD
+++ b/alarm/uboot-cubox-i/PKGBUILD
@@ -5,7 +5,7 @@
 buildarch=4
 
 pkgname=uboot-cubox-i
-pkgver=2017.01
+pkgver=2017.09
 pkgrel=1
 pkgdesc="U-Boot for Cubox-i"
 arch=('armv7h')


### PR DESCRIPTION
Update to 2017.09. Tested on CuBox-i2eX with 1GB RAM.