### PR TITLE
Add retroarch-rbp

### DIFF
--- a/alarm/retroarch-rbp/PKGBUILD
+++ b/alarm/retroarch-rbp/PKGBUILD
@@ -1,0 +1,89 @@
+# $Id$
+# Maintainer: Maxime Gauduin <alucryd@archlinux.org>
+# Contributor: Themaister <maister@archlinux.us>
+# Contributor: lifning <definelightning@gmail.com>
+
+# ALARM: Kevin Mihelich <kevin@archlinuxarm.org>
+#  - enable GLES
+
+# ALARM: Sergey Slipchenko <faergeek@gmail.com>
+#  - add videocore paths to PKG_CONFIG_PATH
+#  - enable neon
+#  - enable floathard
+
+buildarch=4
+
+pkgname=retroarch-rbp
+pkgver=1.6.7
+pkgrel=1.1
+pkgdesc='Reference frontend for the libretro API (Raspberry Pi)'
+arch=('armv7h')
+url='http://www.libretro.com/'
+license=('GPL')
+groups=('libretro')
+provides=('retroarch')
+conflicts=('retroarch')
+depends=('alsa-lib' 'gcc-libs' 'glibc' 'libdrm' 'libgl' 'libpulse' 'libusb'
+         'libx11' 'libxcb' 'libxext' 'libxinerama' 'libxkbcommon' 'libxv'
+         'libxxf86vm' 'raspberrypi-firmware' 'openal' 'sdl2' 'wayland' 'zlib'
+         'libass.so' 'libavcodec.so' 'libavformat.so' 'libavutil.so'
+         'libfreetype.so' 'libswresample.so' 'libswscale.so' 'libudev.so')
+makedepends=('vulkan-icd-loader')
+optdepends=('libretro-desmume: Nintendo DS core'
+            'libretro-gambatte: Nintendo Game Boy/Game Boy Color core'
+            'libretro-genesis-plus: Sega Master System/Genesis/Game Gear/CD/32X core'
+            'libretro-mgba: Nintendo Game Boy Advance core'
+            'libretro-mupen64plus: Nintendo 64 core'
+            'libretro-nestopia: Nintendo Entertainment System core'
+            'libretro-pcsx-rearmed: Sony PlayStation core'
+            'libretro-reicast: Sega Dreamcast core'
+            'libretro-snes9x: Super Nintendo Entertainment System core'
+            'libretro-yabause: Sega Saturn core'
+            'libretro-overlays: Collection of overlays'
+            'libretro-shaders: Collection of shaders'
+            'python: retroarch-cg2glsl'
+            'retroarch-assets-xmb: XMB menu assets'
+            'retroarch-autoconfig-udev: udev joypad autoconfig')
+backup=('etc/retroarch.cfg')
+source=("retroarch-${pkgver}.tar.gz::https://github.com/libretro/RetroArch/archive/v${pkgver}.tar.gz"
+        'retroarch-config.patch')
+sha256sums=('212f281d3febde1df27d2edd5de3ced5be86c816b3f13614754495e4a62e778f'
+            'f37b12754256b0bcc2f9d738f9aa1c18557fffede670a328eb0eeb2f28a32bbd')
+
+prepare() {
+  cd RetroArch-${pkgver}
+
+  patch -Np1 -i ../retroarch-config.patch
+}
+
+build() {
+  cd RetroArch-${pkgver}
+
+  export PKG_CONFIG_PATH="/opt/vc/lib/pkgconfig:$PKG_CONFIG_PATH"
+
+  ./configure \
+    --prefix='/usr' \
+    --disable-cg \
+    --disable-jack \
+    --disable-oss \
+    --disable-sdl \
+    --enable-opengles \
+    --enable-neon \
+    --enable-floathard
+
+  make
+  make -C libretro-common/audio/dsp_filters
+  make -C gfx/video_filters
+}
+
+package() {
+  cd RetroArch-${pkgver}
+
+  make DESTDIR="${pkgdir}" install
+
+  install -dm 755 "${pkgdir}"/usr/lib/retroarch/filters/{audio,video}
+  install -m 644 libretro-common/audio/dsp_filters/*.so "${pkgdir}"/usr/lib/retroarch/filters/audio/
+  install -m 644 gfx/video_filters/*.{filt,so} "${pkgdir}"/usr/lib/retroarch/filters/video/
+}
+
+# vim: ts=2 sw=2 et:

--- a/alarm/retroarch-rbp/retroarch-config.patch
+++ b/alarm/retroarch-rbp/retroarch-config.patch
@@ -1,0 +1,52 @@
+diff -rupN RetroArch-1.6.6.orig/retroarch.cfg RetroArch-1.6.6/retroarch.cfg
+--- RetroArch-1.6.6.orig/retroarch.cfg	2017-08-24 15:30:11.730485158 +0200
++++ RetroArch-1.6.6/retroarch.cfg	2017-08-24 15:32:05.506771029 +0200
+@@ -41,10 +41,10 @@
+ # libretro_path = "/path/to/libretro.so"
+ 
+ # A directory for where to search for libretro core implementations.
+-# libretro_directory =
++libretro_directory = /usr/lib/libretro
+ 
+ # A directory for where to search for libretro core information.
+-# libretro_info_path =
++libretro_info_path = /usr/share/libretro/info
+ 
+ # Sets log level for libretro cores (GET_LOG_INTERFACE).
+ # If a log level issued by a libretro core is below libretro_log_level, it is ignored.
+@@ -104,7 +104,7 @@
+ 
+ # Assets directory. This location is queried by default when menu interfaces try to look for
+ # loadable assets, etc.
+-# assets_directory =
++assets_directory = /usr/share/retroarch/assets
+ 
+ # Dynamic wallpapers directory. The place to store the wallpapers dynamically
+ # loaded by the menu depending on context.
+@@ -235,7 +235,7 @@
+ # video_shader_enable = false
+ 
+ # Defines a directory where shaders (Cg, CGP, GLSL) are kept for easy access.
+-# video_shader_dir =
++video_shader_dir = /usr/share/libretro/shaders
+ 
+ # CPU-based video filter. Path to a dynamic library.
+ # video_filter =
+@@ -411,7 +411,7 @@
+ # Input binds which are made explicit (input_playerN_*_btn/axis) will take priority over autoconfigs.
+ # Autoconfigs can be created with retroarch-joyconfig, manually, or with a frontend.
+ # Requires input_autodetect_enable to be enabled.
+-# joypad_autoconfig_dir =
++joypad_autoconfig_dir = /usr/share/retroarch/autoconfig
+ 
+ # Sets which libretro device is used for a user.
+ # Devices are indentified with a number.
+@@ -655,7 +655,7 @@
+ # menu_show_online_updater = true
+ 
+ # If disabled, will hide the ability to update cores (and core info files) inside the menu.
+-# menu_show_core_updater = true
++menu_show_core_updater = false
+ 
+ # If disabled, the libretro core will keep running in the background when we
+ # are in the menu.


### PR DESCRIPTION
Sorry, not sure on which architectures it will actually work, I have only raspberry pi 2.

Differences from upstream (also listed in PKGBUILD itself):
1. Add paths to`/opt/vc` to use videocore gl libs instead of mesa. This should and seems to be more performant.
2. Enable `neon` and `floathard` flags. Also for performance.