### PR TITLE
Added HP T5335z support

### DIFF
--- a/core/linux-armv7/0010-ARM-dove-add-hp-t5335z-device-tree.patch
+++ b/core/linux-armv7/0010-ARM-dove-add-hp-t5335z-device-tree.patch
@@ -1,0 +1,105 @@
+--- a/arch/arm/boot/dts/Makefile	2017-11-23 23:04:48.053643768 -0300
++++ b/arch/arm/boot/dts/Makefile	2017-11-23 23:04:35.116977485 -0300
+@@ -1055,6 +1055,7 @@
+ 	dove-d2plug.dtb \
+ 	dove-d3plug.dtb \
+ 	dove-dove-db.dtb \
++	dove-hp-t5335z.dtb \
+ 	dove-sbc-a510.dtb
+ dtb-$(CONFIG_ARCH_MEDIATEK) += \
+ 	mt2701-evb.dtb \
+
+--- /dev/null	2017-11-23 22:24:43.246656785 -0300
++++ arch/arm/boot/dts/dove-hp-t5335z.dts	2017-11-23 01:08:32.628772542 -0300
+@@ -0,0 +1,201 @@
++// SPDX-License-Identifier: GPL-2.0
++
++/dts-v1/;
++
++#include "dove.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++
++/ {
++	model = "HP T5335z";
++	compatible = "hp,t5335z", "marvell,dove";
++
++	memory {
++		device_type = "memory";
++		reg = <0x00000000 0x40000000>;
++	};
++
++	chosen {
++		bootargs = "console=ttyS0,115200n8 earlyprintk";
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++		power-button {
++			label = "Power Button";
++			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_POWER>;
++			wakeup-source;
++		};
++	};
++
++	sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,name = "OnboardALC5621";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,widgets =
++			"Headphone", "Headphone Jack",
++			"Speaker", "Speaker",
++			"Microphone", "Mic Jack";
++		simple-audio-card,routing =
++			"Headphone Jack", "HPL",
++			"Headphone Jack", "HPR",
++			"Speaker", "SPKOUT",
++			"Speaker", "SPKOUTN",
++			"MIC1", "Mic Jack",
++			"MIC2", "Mic Jack";
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,cpu {
++			sound-dai = <&audio1 0>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&audiocodec>;
++		};
++	};
++};
++
++&audio1 {
++	#sound-dai-cells = <1>;
++	status = "okay";
++};
++&uart0 { status = "okay"; };
++&sata0 { status = "okay"; };
++&mdio { status = "okay"; };
++&eth { status = "okay"; };
++
++&ethphy {
++	compatible = "marvell,88e1310";
++	reg = <1>;
++};
++
++&spi0 {
++	status = "okay";
++	/* 1M Flash Microchip SST25VF080B */
++	spi-flash@0 {
++		compatible = "microchip,m25p80", "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <40000000>;
++		m25p,fast-read;
++	};
++};
++
++&i2c0 {
++	status = "okay";
++	audiocodec: alc5621@1a {
++		#sound-dai-cells = <0>;
++		compatible = "realtek,alc5621";
++		reg = <0x1a>;
++		add-ctrl = <0x3700>;
++		jack-det-ctrl = <0x4810>;
++	};
++};

--- a/core/linux-armv7/0010-ARM-dove-add-hp-t5335z-device-tree.patch
+++ b/core/linux-armv7/0010-ARM-dove-add-hp-t5335z-device-tree.patch
@@ -1,3 +1,15 @@
+--- a/config	2017-11-23 23:18:15.336953126 -0300
++++ b/config	2017-11-23 23:18:52.036952036 -0300
+@@ -5854,7 +5854,7 @@
+ # CONFIG_SND_SOC_AK4613 is not set
+ # CONFIG_SND_SOC_AK4642 is not set
+ # CONFIG_SND_SOC_AK5386 is not set
+-# CONFIG_SND_SOC_ALC5623 is not set
++CONFIG_SND_SOC_ALC5623=m
+ CONFIG_SND_SOC_ALC5632=m
+ # CONFIG_SND_SOC_BT_SCO is not set
+ # CONFIG_SND_SOC_CS35L32 is not set
+
 --- a/arch/arm/boot/dts/Makefile	2017-11-23 23:04:48.053643768 -0300
 +++ b/arch/arm/boot/dts/Makefile	2017-11-23 23:04:35.116977485 -0300
 @@ -1055,6 +1055,7 @@

--- a/core/linux-armv7/PKGBUILD
+++ b/core/linux-armv7/PKGBUILD
@@ -27,6 +27,7 @@ source=("http://www.kernel.org/pub/linux/kernel/v4.x/${_srcname}.tar.xz"
         '0007-exynos4412-odroid-set-higher-minimum-buck2-regulator.patch'
         '0008-disable-USB3-port-on-ODROID-XU.patch'
         '0009-ARM-dove-enable-ethernet-on-D3Plug.patch'
+        '0010-ARM-dove-add-hp-t5335z-device-tree.patch'
         'config'
         'kernel.its'
         'kernel.keyblock'
@@ -70,6 +71,7 @@ prepare() {
   git apply ../0007-exynos4412-odroid-set-higher-minimum-buck2-regulator.patch
   git apply ../0008-disable-USB3-port-on-ODROID-XU.patch
   git apply ../0009-ARM-dove-enable-ethernet-on-D3Plug.patch
+  git apply ../0010-ARM-dove-add-hp-t5335z-device-tree.patch
 
   cat "${srcdir}/config" > ./.config
 
@@ -380,6 +382,20 @@ _package-chromebook() {
 
   mkdir -p "${pkgdir}/boot"
   cp vmlinux.kpart "${pkgdir}/boot"
+}
+
+_package-hpt5335z() {
+  pkgdesc="The Linux Kernel - ${_desc} - HP T5335z"
+  depends=('linux-armv7')
+  provides=('linux-armv7-uimage')
+  conflicts=('linux-armv7-uimage')
+  replaces=('linux-hpt5335z')
+
+  cd "${srcdir}/${_srcname}"
+
+  mkdir -p "${pkgdir}/boot"
+  cat arch/$KARCH/boot/zImage arch/$KARCH/boot/dts/dove-hp-t5335z.dtb > myimage
+  mkimage -A arm -O linux -T kernel -C none -a 0x00008000 -e 0x00008000 -n "${pkgname}" -d myimage "${pkgdir}/boot/uImage"
 }
 
 pkgname=("${pkgbase}" "${pkgbase}-headers" "${pkgbase}-smileplug" "${pkgbase}-mirabox" "${pkgbase}-ax3" "${pkgbase}-d3plug" "${pkgbase}-cubox" "${pkgbase}-chromebook")


### PR DESCRIPTION
Hello,

I added HP T5335z thin client device tree, with audio chipset (ALC5621) working but DVI not working.
