### PR TITLE
Fix wrong _scrname of linux-aarch64's PKGBUILD

### DIFF
--- a/core/linux-aarch64/PKGBUILD
+++ b/core/linux-aarch64/PKGBUILD
@@ -4,7 +4,7 @@
 buildarch=8
 
 pkgbase=linux-aarch64
-_srcname=linux-4.14
+_srcname=linux-4.14.8
 _kernelname=${pkgbase#linux}
 _desc="AArch64 multi-platform"
 pkgver=4.14.8


### PR DESCRIPTION
Currently, the PKGBUILD file of linux-aarch64 claims to builder kernel 4.14.8 but actually kernel 4.14 is build by the PKGBUILD. I guess _scrname was not properly modified.