### PR TITLE
core/linux-raspberrypi: Update Cypress (Broadcom) firmware

### DIFF
--- a/core/linux-raspberrypi/PKGBUILD
+++ b/core/linux-raspberrypi/PKGBUILD
@@ -10,22 +10,22 @@ _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="Raspberry Pi"
 pkgver=4.9.73
-pkgrel=1
+pkgrel=2
 arch=('armv6h' 'armv7h')
 url="http://www.kernel.org/"
 license=('GPL2')
 makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'git')
 options=('!strip')
 source=("https://github.com/raspberrypi/linux/archive/${_commit}.tar.gz"
-        'https://archlinuxarm.org/builder/src/brcmfmac43430-sdio.bin' 'https://archlinuxarm.org/builder/src/brcmfmac43430-sdio.txt'
+        "https://archlinuxarm.org/builder/src/bcm43430/7.45.41.46/brcmfmac43430-sdio."{bin,txt}
         'config.txt'
         'cmdline.txt'
         'config'
         'linux.preset'
         '99-linux.hook')
 md5sums=('c693d72483686089da4d011b4472892d'
-         '4a410ab9a1eefe82e158d36df02b3589'
-         '8c3cb6d8f0609b43f09d083b4006ec5a'
+         '5f520a38ab4e943bfa1ba102f80fb2a0'
+         '9a88b55134d9f8f3ad2331b93f4b7b79'
          '7c6b37a1353caccf6d3786bb4161c218'
          '60bc3624123c183305677097bcd56212'
          'b5c93babee899045446b81861422329c'


### PR DESCRIPTION
Replaces the current `7.45.41.23` with `7.45.41.46` which is the first version to fix the ["Broadpwn"](http://blog.exodusintel.com/2017/07/26/broadpwn/) vulnerability according to https://github.com/raspberrypi/linux/issues/1342#issuecomment-321221748.

The two files are the same as already used in `firmware-raspberrypi`.