### PR TITLE
Update extra/webkitgtk to 2.4.11-11

### DIFF
--- a/extra/webkitgtk/PKGBUILD
+++ b/extra/webkitgtk/PKGBUILD
@@ -12,7 +12,7 @@ highmem=1
 pkgbase=webkitgtk
 pkgname=(webkitgtk webkitgtk2)
 pkgver=2.4.11
-pkgrel=6
+pkgrel=11
 pkgdesc="Legacy Web content engine"
 arch=(i686 x86_64)
 url="https://webkitgtk.org/"
@@ -27,10 +27,14 @@ options=(!emptydirs)
 install=webkitgtk.install
 source=(https://webkitgtk.org/releases/$pkgbase-${pkgver}.tar.xz
         webkitgtk-2.4.9-abs.patch
-        icu59.patch)
+        icu59.patch
+        enchant-2.x.patch
+        pkgconfig-enchant-2.patch)
 sha256sums=('588aea051bfbacced27fdfe0335a957dca839ebe36aa548df39c7bbafdb65bf7'
             'ec294bbb5588a1802a68e3615c6718486b22f922645c5fef686d3d103014bf70'
-            'eb791b9c8dcb84996904846dedf8c3ddf1a5fde32330177f3f0071510bd8ca6d')
+            'eb791b9c8dcb84996904846dedf8c3ddf1a5fde32330177f3f0071510bd8ca6d'
+            '81a4ad1c921bece16edb9a3cb187096fd8f336db8b89114356119a86f26e3d6d'
+            'df8284004f25d189184aab1009df696c915212e0e439a555dbd0dbec06111e2e')
 
 prepare() {
   mkdir build-gtk{,2} path
@@ -43,7 +47,11 @@ prepare() {
     CFLAGS+=" -DENABLE_YARR_JIT=0"
     CXXFLAGS+=" -DENABLE_YARR_JIT=0"
   fi
-  patch -p1 -i ../webkitgtk-2.4.9-abs.patch
+  patch -Np1 -i ../webkitgtk-2.4.9-abs.patch
+  patch -Np1 -i ../icu59.patch
+  patch -Np1 -i ../enchant-2.x.patch
+  # https://www.archlinux.org/todo/enchant-221-rebuild/
+  patch -Np1 -i ../pkgconfig-enchant-2.patch
 }
 
 _build() (
@@ -54,6 +62,9 @@ _build() (
 
   CXXFLAGS+=" -fno-delete-null-pointer-checks"
   CFLAGS+=" -fno-delete-null-pointer-checks"
+
+  CFLAGS+=" -Wno-expansion-to-defined"
+  CXXFLAGS+=" -Wno-expansion-to-defined"
 
   ../$pkgbase-$pkgver/configure --prefix=/usr \
     --libexecdir=/usr/lib/webkit${_ver} \

--- a/extra/webkitgtk/enchant-2.x.patch
+++ b/extra/webkitgtk/enchant-2.x.patch
@@ -1,0 +1,11 @@
+--- webkitgtk-2.4.9/Source/WebCore/platform/text/enchant/TextCheckerEnchant.cpp.orig	2017-12-06 14:59:40.768262788 -0500
++++ webkitgtk-2.4.9/Source/WebCore/platform/text/enchant/TextCheckerEnchant.cpp	2017-12-06 15:03:10.000000000 -0500
+@@ -128,7 +128,7 @@
+         for (i = 0; i < numberOfSuggestions; i++)
+             guesses.append(String::fromUTF8(suggestions[i]));
+ 
+-        enchant_dict_free_suggestions(*iter, suggestions);
++        enchant_dict_free_string_list(*iter, suggestions);
+     }
+ 
+     return guesses;

--- a/extra/webkitgtk/pkgconfig-enchant-2.patch
+++ b/extra/webkitgtk/pkgconfig-enchant-2.patch
@@ -1,0 +1,11 @@
+--- webkitgtk-2.4.11/Source/autotools/FindDependencies.m4.orig	2018-01-19 23:47:23.866875328 +0800
++++ webkitgtk-2.4.11/Source/autotools/FindDependencies.m4	2018-01-19 23:47:34.543576202 +0800
+@@ -154,7 +154,7 @@
+ AC_SUBST(PANGO_LIBS)
+ 
+ if test "$enable_spellcheck" = "yes"; then
+-    PKG_CHECK_MODULES(ENCHANT, enchant >= enchant_required_version, [], [enable_spellcheck="no"])
++    PKG_CHECK_MODULES(ENCHANT, enchant-2 >= enchant_required_version, [], [enable_spellcheck="no"])
+     AC_SUBST(ENCHANT_CFLAGS)
+     AC_SUBST(ENCHANT_LIBS)
+ fi


### PR DESCRIPTION
The current webkitgtk/2 packages found on the extra repository aren't properly linked to enchant and icu do to updates on the mentioned packages. So this commit merges changes found on the latest webkitgtk package build on the aur repository.