### PR TITLE
Fix install directory of java9-openjdk

### DIFF
--- a/extra/java9-openjdk/PKGBUILD
+++ b/extra/java9-openjdk/PKGBUILD
@@ -76,6 +76,7 @@ case "$CARCH" in
   aarch64) _JARCH='aarch64';;
 esac
 
+_jvmdir=/usr/lib/jvm/java-$_majorver-openjdk
 _jdkdir=jdk${_majorver}u-$_hg_tag
 if [[ $CARCH == "arm" ]]; then
   _imgdir=$_jdkdir/build/linux-$_JARCH-normal-zero-release/images


### PR DESCRIPTION
I suppose that `_jvmdir` in `PKGBUILD` was accidentally removed. The files that should be placed under `/usr/lib/jvm/java-9-openjdk` were incorrectly placed in `/`.