### PR TITLE
linux-aarch64: sunxi - enable USB gadget support

### DIFF
--- a/core/linux-aarch64/PKGBUILD
+++ b/core/linux-aarch64/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-4.15
 _kernelname=${pkgbase#linux}
 _desc="AArch64 multi-platform"
 pkgver=4.15.2
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -25,7 +25,7 @@ md5sums=('0d701ac1e2a67d47ce7127432df2c32b'
          '2ab9af1ef74132932b760e677e338983'
          'c656b4169dd6c87f93dfb49edea3ddbf'
          '79459eaa00aa5de588c73f3076f0907b'
-         'f5183ec7a29254844369b08271f360d7'
+         '21f3b0a2292ccd7c0e66c0271e313eca'
          'b5ef67d6086e20de7b82265f562f88b1'
          '1d4477026533efaa0358a40855d50a83')
 

--- a/core/linux-aarch64/config
+++ b/core/linux-aarch64/config
@@ -5623,7 +5623,7 @@ CONFIG_USB_MUSB_DUAL_ROLE=y
 #
 # Platform Glue Layer
 #
-# CONFIG_USB_MUSB_SUNXI is not set
+CONFIG_USB_MUSB_SUNXI=y
 
 #
 # MUSB DMA mode


### PR DESCRIPTION
I am trying to use Arch Linux ARM on my *NanoPi Neo2* and *OrangePi Zero Plus* boards. Both have Allwinner H5 SoC onboard. You can find my U-Boot packages [here](//github.com/RoEdAl/alarm-uboot-sunxi-aarch64).

Unfortunately USB gadget support is missing in official `linux-aarch64` kernel package. 

I now these boards aren't officially supported and probably never will be but could you enable CONFIG_USB_MUSB_SUNXI in configuration file, please?