### PR TITLE
alarm/kodi-rbp to 17.6-4

### DIFF
--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -13,16 +13,16 @@ pkgbase=kodi-rbp
 pkgname=('kodi-rbp' 'kodi-rbp-eventclients' 'kodi-rbp-tools-texturepacker' 'kodi-rbp-dev')
 _codename=Krypton
 pkgver=17.6
-pkgrel=3
+pkgrel=4
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
 license=('GPL2')
 makedepends=(
-  'afpfs-ng' 'bluez-libs' 'boost' 'cmake' 'curl' 'doxygen' 'glew'
+  'afpfs-ng' 'bluez-libs' 'boost' 'cmake' 'curl' 'doxygen'
   'gperf' 'hicolor-icon-theme' 'jasper' 'java-environment' 'libaacs' 'libass'
-  'libbluray' 'libcdio' 'libcec-rpi' 'libgl' 'libmariadbclient' 'libmicrohttpd'
+  'libbluray' 'libcdio' 'libcec-rpi' 'libmariadbclient' 'libmicrohttpd'
   'libmodplug' 'libmpeg2' 'libnfs' 'libplist' 'libpulse' 'libssh'
-  'libxrandr' 'libxslt' 'lzo' 'mesa' 'nasm' 'nss-mdns' 'python2-pillow'
+  'libxrandr' 'libxslt' 'lzo' 'nasm' 'nss-mdns' 'python2-pillow'
   'python2-pybluez' 'python2-simplejson' 'raspberrypi-firmware' 'rtmpdump'
   'shairplay' 'smbclient' 'speex' 'swig' 'taglib' 'tinyxml' 'unzip' 'upower'
   'yajl' 'zip' 'giflib'
@@ -114,10 +114,10 @@ build() {
 package_kodi-rbp() {
   pkgdesc="A software media player and entertainment hub for digital media (Raspberry Pi)"
   depends=(
-    'bluez-libs' 'desktop-file-utils' 'freetype2' 'fribidi' 'glew'
+    'bluez-libs' 'desktop-file-utils' 'freetype2' 'fribidi'
     'hicolor-icon-theme' 'libass' 'libcdio' 'libjpeg-turbo' 'libmariadbclient'
     'libmicrohttpd' 'libpulse' 'libssh' 'libxrandr' 'raspberrypi-firmware'
-    'libxslt' 'lzo' 'mesa' 'python2-pillow' 'python2-simplejson' 'smbclient'
+    'libxslt' 'lzo' 'python2-pillow' 'python2-simplejson' 'smbclient'
     'speex' 'taglib' 'tinyxml' 'xorg-xdpyinfo' 'yajl'
   )
   optdepends=(


### PR DESCRIPTION
Kodi doesn't need any gl libs provided by the superfluous deps removed by this commit... it just needs the firmware gl in `/opt/vc/` which is provided by alarm/raspberrypi-firmware.