### PR TITLE
add fmt 4.1.0-3 now a makedepends for kodi-rbp-git

### DIFF
--- a/aur/fmt/PKGBUILD
+++ b/aur/fmt/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer: Mihai Bişog <mihai.bisog at [gmail] d0t com>
+buildarch=20
+pkgname=fmt
+pkgver=4.1.0
+pkgrel=3
+pkgdesc="Open-source formatting library for C++."
+arch=('armv6h' 'armv7h')
+url="http://fmtlib.net"
+license=("BSD")
+makedepends=("cmake")
+
+source=("https://github.com/fmtlib/fmt/archive/$pkgver.tar.gz")
+md5sums=('057d1fc49f6d3114e29e8cc72cf70e08')
+
+build() {
+    cd "$pkgname-$pkgver"
+    mkdir -p build && cd build
+
+    cmake -DCMAKE_BUILD_TYPE=Release      \
+          -DCMAKE_INSTALL_PREFIX=/usr     \
+          -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+          -DFMT_DOC=OFF                   \
+          ..
+    make
+}
+
+check() {
+    cd "$pkgname-$pkgver/build"
+    make test
+}
+
+package() {
+    cd "$pkgname-$pkgver/build"
+    make DESTDIR="$pkgdir" install
+    install -D -m644 ../LICENSE.rst "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+    install -D -m644 ../ChangeLog.rst "${pkgdir}/usr/share/doc/${pkgname}/ChangeLog.rst"
+}


### PR DESCRIPTION
This is a makedepends for the updated kodi-rbp-git package in https://github.com/archlinuxarm/PKGBUILDs/pull/1569