### PR TITLE
alarm/kodi-rbp to 17.6-5

### DIFF
--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -13,7 +13,7 @@ pkgbase=kodi-rbp
 pkgname=('kodi-rbp' 'kodi-rbp-eventclients' 'kodi-rbp-tools-texturepacker' 'kodi-rbp-dev')
 _codename=Krypton
 pkgver=17.6
-pkgrel=4
+pkgrel=5
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
 license=('GPL2')
@@ -118,7 +118,7 @@ package_kodi-rbp() {
     'hicolor-icon-theme' 'libass' 'libcdio' 'libjpeg-turbo' 'libmariadbclient'
     'libmicrohttpd' 'libpulse' 'libssh' 'libxrandr' 'raspberrypi-firmware'
     'libxslt' 'lzo' 'python2-pillow' 'python2-simplejson' 'smbclient'
-    'speex' 'taglib' 'tinyxml' 'xorg-xdpyinfo' 'yajl'
+    'speex' 'taglib' 'tinyxml' 'xorg-xdpyinfo' 'yajl' 'polkit'
   )
   optdepends=(
     'afpfs-ng: Apple shares support'
@@ -129,7 +129,6 @@ package_kodi-rbp() {
     'libcec-rpi: Pulse-Eight USB-CEC adapter support'
     'lirc: Remote controller support'
     'lsb-release: log distro information in crashlog'
-    'polkit: Permissions for automounting external drives and power management functionality'
     'shairplay: Limited AirPlay support'
     'unrar: Archives support'
     'unzip: Archives support'


### PR DESCRIPTION
Systems without polkit are unable to the provided udev rules applied.  For example, partial keyboard support in kodi limits functionality making polkit a hard dependency.