### PR TITLE
wiringpi's /usr/bin/gpio lost a suid bit in a recent update

### DIFF
--- a/alarm/wiringpi/PKGBUILD
+++ b/alarm/wiringpi/PKGBUILD
@@ -6,7 +6,7 @@ buildarch=20
 pkgname=wiringpi
 _pkgname=wiringPi
 pkgver=107.8d188fa
-pkgrel=1
+pkgrel=2
 pkgdesc='GPIO Interface library for the Raspberry Pi'
 arch=('armv6h' 'armv7h')
 makedepends=('git')
@@ -45,7 +45,7 @@ package(){
   make LDCONFIG= PREFIX= DESTDIR="${pkgdir}/usr" -C wiringPi install
   make LDCONFIG= PREFIX= DESTDIR="${pkgdir}/usr" -C devLib install
   install -d "${pkgdir}/usr/bin"
-  make PREFIX= DESTDIR="${pkgdir}/usr" WIRINGPI_SUID=0 -C gpio install
+  make PREFIX= DESTDIR="${pkgdir}/usr" WIRINGPI_SUID=1 -C gpio install
   install -m0755 wiringPiD/wiringpid "${pkgdir}/usr/bin"
   install -Dm644 COPYING.LESSER "$pkgdir/usr/share/licenses/$pkgname/COPYING.LESSER"
 }


### PR DESCRIPTION
It used to be `chmod 4755` in the `PKGBUILD`. Then the `PKGBUILD` was reworked, and the bit got lost, so `gpio` refuses to run.