### PR TITLE
aur/cower: update to 18

### DIFF
--- a/aur/cower/PKGBUILD
+++ b/aur/cower/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Dave Reisner <d@falconindy.com>
 
 pkgname=cower
-pkgver=17
-pkgrel=2
+pkgver=18
+pkgrel=1
 pkgdesc="A simple AUR agent with a pretentious name"
 arch=('i686' 'x86_64')
 url="http://github.com/falconindy/cower"
@@ -11,7 +11,7 @@ depends=('curl' 'pacman' 'yajl')
 makedepends=('perl')
 source=("https://pkgbuild.com/~dreisner/sources/$pkgname/$pkgname-$pkgver.tar.gz"{,.sig})
 validpgpkeys=('487EACC08557AD082088DABA1EB2638FF56C0C53')  # Dave Reisner
-md5sums=('263c216e6643751b6c96eebfdd70c359'
+md5sums=('ce5993a79d7e1cc33016e06e32af03e7'
          'SKIP')
 
 build() {


### PR DESCRIPTION
Update to the likely latest version. Just doing the update, because currently cower needs a libalpm rebuild due to pacman 5.1.0 update.