### PR TITLE
alarm/raspberrypi-firmware to 20180607-1

### DIFF
--- a/alarm/raspberrypi-firmware/PKGBUILD
+++ b/alarm/raspberrypi-firmware/PKGBUILD
@@ -3,9 +3,9 @@
 buildarch=20
 
 pkgname=raspberrypi-firmware
-pkgver=20180330
+pkgver=20180607
 pkgrel=1
-_commit=c14a90333c13f507ab219d583b74a998ec11a6e7
+_commit=78841788b5b1b0de25e7cd066ec0a9c177e7a086
 pkgdesc="Firmware tools, libraries, and headers for Raspberry Pi"
 arch=('any')
 url="https://github.com/raspberrypi/firmware"
@@ -15,7 +15,7 @@ provides=('raspberrypi-firmware-tools')
 options=(!strip)
 source=("https://github.com/raspberrypi/firmware/archive/${_commit}.tar.gz"
         '00-raspberrypi-firmware.conf')
-md5sums=('f671444b8acba9b67cd04a419c6624c9'
+md5sums=('cf875cb8a9d0d2fc0bebc343ec3f38bc'
          '72e0d5818fc513ece1b964f25f7e7882')
 
 package() {


### PR DESCRIPTION
PR will bring firmware package in sync with kernel version and upstream.