### PR TITLE
xf86-video-armsoc-rockchip: Initialize RandR before ARMSOCEnterVT

### DIFF
--- a/alarm/xf86-video-armsoc-rockchip/0003-Init-RandR-Before-EnterVT.patch
+++ b/alarm/xf86-video-armsoc-rockchip/0003-Init-RandR-Before-EnterVT.patch
@@ -1,0 +1,24 @@
+diff --git a/src/armsoc_driver.c b/src/armsoc_driver.c
+index d8d82a1..7914d1c 100644
+--- a/src/armsoc_driver.c
++++ b/src/armsoc_driver.c
+@@ -1125,6 +1125,9 @@ ARMSOCScreenInit(SCREEN_INIT_ARGS_DECL)
+ 	 */
+ 	pScrn->vtSema = TRUE;
+ 
++	/* Do some XRandR initialization. Return value is not useful */
++	(void)xf86CrtcScreenInit(pScreen);
++
+ 	/* Take over the virtual terminal from the console, set the
+ 	 * desired mode, etc.:
+ 	 */
+@@ -1133,9 +1136,6 @@ ARMSOCScreenInit(SCREEN_INIT_ARGS_DECL)
+ 		goto fail6;
+ 	}
+ 
+-	/* Do some XRandR initialization. Return value is not useful */
+-	(void)xf86CrtcScreenInit(pScreen);
+-
+ 	if (!miCreateDefColormap(pScreen)) {
+ 		ERROR_MSG("Cannot create colormap!");
+ 		goto fail7;

--- a/alarm/xf86-video-armsoc-rockchip/PKGBUILD
+++ b/alarm/xf86-video-armsoc-rockchip/PKGBUILD
@@ -16,10 +16,12 @@ options=('!libtool')
 source=("$pkgname::git+https://github.com/mmind/xf86-video-armsoc.git#branch=devel/rockchip"
         '0001-Adapt-Block-WakeupHandler-signature-for-ABI-23.patch'
         '0002-Use-NotifyFd-for-drm-fd.patch'
+	'0003-Init-RandR-Before-EnterVT.patch'
         '20-armsoc.conf')
 md5sums=('SKIP'
          'c9ec23461d651841b128b68f07e25c7f'
          'e7a0f28ac376f0c97a05b1bb758d36e4'
+	 'dad6718e444e52bafdb15f1bf46d8df8'
          'ca34299695813b200f0d6054c45d1f94')
 
 pkgver() {
@@ -31,6 +33,7 @@ prepare() {
   cd $pkgname
   git apply ../0001-Adapt-Block-WakeupHandler-signature-for-ABI-23.patch
   git apply ../0002-Use-NotifyFd-for-drm-fd.patch
+  git apply ../0003-Init-RandR-Before-EnterVT.patch
 }
 
 build() {

--- a/alarm/xf86-video-armsoc-rockchip/PKGBUILD
+++ b/alarm/xf86-video-armsoc-rockchip/PKGBUILD
@@ -4,7 +4,7 @@ buildarch=4
 
 pkgname=xf86-video-armsoc-rockchip
 pkgver=261.67d4cff
-pkgrel=5
+pkgrel=6
 pkgdesc='X.org graphics driver for ARM graphics - Rockchip'
 arch=('armv7h')
 url="https://github.com/mmind/xf86-video-armsoc"


### PR DESCRIPTION
This fixes a segfault caused by the use of RandR CRTCs in Xorg 1.20
before the driver had initialized them.