### PR TITLE
alarm/kodi-rbp-git to 18.0a2.20180621-4

### DIFF
--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -13,7 +13,7 @@ pkgbase=kodi-rbp-git
 _suffix=rbp-git
 pkgname=("kodi-$_suffix" "kodi-eventclients-$_suffix" "kodi-tools-texturepacker-$_suffix" "kodi-dev-$_suffix")
 pkgver=18.0a2.20180621
-pkgrel=3
+pkgrel=4
 _codename=Leia
 _tag="18.0a2-$_codename"
 _rtype=Alpha
@@ -28,7 +28,7 @@ makedepends=(
   'afpfs-ng' 'bluez-libs' 'boost' 'cmake' 'curl' 'doxygen'
   'gperf' 'hicolor-icon-theme' 'jasper' 'java-environment' 'libaacs' 'libass'
   'libbluray' 'libcdio' 'libmariadbclient' 'libmicrohttpd'
-  'libmodplug' 'libmpeg2' 'libnfs' 'libplist' 'libpulse' 'libssh'
+  'libmodplug' 'libmpeg2' 'libnfs' 'libplist' 'libpulse' 'libssh' 'libcec-rpi'
   'libxrandr' 'libxslt' 'lirc' 'lzo' 'nasm' 'nss-mdns' 'python2-pillow'
   'python2-pybluez' 'python2-simplejson' 'raspberrypi-firmware' 'rtmpdump'
   'shairplay' 'smbclient' 'speex' 'swig' 'taglib' 'tinyxml' 'unzip' 'upower'
@@ -51,7 +51,7 @@ noextract=(
   "ffmpeg-$_ffmpeg_version.tar.gz"
 )
 sha256sums=('937d755c638324bf388fc9e971c5d8f90fcc0ab9362f0b15bbad5e47f0bc67d6'
-            '5235068d5800d69f0287087815990e7fe8d6572733d60c8800546d35f608e87f'
+            'aa96b6abb18329dcca7b5f775df69eee10beeb9ca727e867e7a96886953c66d0'
             'b31570f95654434b01fd8531612fbb6be77cbc1c519dd60f92feae26eb160f3d'
             '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96'
             '0b9d951911a8576c26dec8a31f394282677e48afff49b9579448121d27b8509e'
@@ -111,7 +111,7 @@ build() {
 package_kodi-rbp-git() {
   pkgdesc="A software media player and entertainment hub for digital media (Raspberry Pi)"
   depends=(
-    'bluez-libs' 'desktop-file-utils' 'freetype2' 'fribidi'
+    'bluez-libs' 'desktop-file-utils' 'freetype2' 'fribidi' 'libcec-rpi'
     'hicolor-icon-theme' 'libass' 'libcdio' 'libjpeg-turbo' 'libmariadbclient'
     'libmicrohttpd' 'libpulse' 'libssh' 'libxrandr' 'lirc' 'raspberrypi-firmware'
     'libxslt' 'lzo' 'python2-pillow' 'python2-simplejson' 'smbclient'
@@ -123,7 +123,6 @@ package_kodi-rbp-git() {
     'python2-pybluez: Bluetooth support'
     'libnfs: NFS shares support'
     'libplist: Limited AirPlay support'
-    'libcec-rpi: Pulse-Eight USB-CEC adapter support'
     'lsb-release: log distro information in crashlog'
     'shairplay: Limited AirPlay support'
     'unrar: Archives support'

--- a/alarm/kodi-rbp-git/kodi.service
+++ b/alarm/kodi-rbp-git/kodi.service
@@ -6,7 +6,7 @@ After = remote-fs.target
 User = kodi
 Group = kodi
 Type = simple
-ExecStart = /usr/bin/kodi-standalone -l /run/lirc/lircd
+ExecStart = /usr/bin/kodi-standalone
 Restart = on-failure
 
 [Install]


### PR DESCRIPTION
* libcec is no longer linked so it's either compiled it as a dep or not compiled it without support (https://github.com/xbmc/xbmc/pull/13926)
* no need to specify the path to lirc's socket path starting with v18