### PR TITLE
alarm/kodi-rbp-git to 18.0a2.20180621-5

### DIFF
--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -13,14 +13,16 @@ pkgbase=kodi-rbp-git
 _suffix=rbp-git
 pkgname=("kodi-$_suffix" "kodi-eventclients-$_suffix" "kodi-tools-texturepacker-$_suffix" "kodi-dev-$_suffix")
 pkgver=18.0a2.20180621
-pkgrel=4
+pkgrel=5
 _codename=Leia
 _tag="18.0a2-$_codename"
 _rtype=Alpha
-_ffmpeg_version="4.0.1-$_codename-$_rtype"3-1
+_ffmpeg_version="4.0.2-$_codename-$_rtype"3
 _libdvdcss_version="1.4.1-$_codename-$_rtype"-3
 _libdvdnav_version="6.0.0-$_codename-$_rtype"-3
 _libdvdread_version="6.0.0-$_codename-$_rtype"-3
+_fmt_version="3.0.1"
+_crossguid_version="8f399e8bd4"
 arch=('armv6h' 'armv7h')
 url="http://kodi.tv"
 license=('GPL2')
@@ -43,27 +45,37 @@ source=("xbmc-$_tag.tar.gz::https://github.com/xbmc/xbmc/archive/$_tag.tar.gz"
   "libdvdcss-$_libdvdcss_version.tar.gz::https://github.com/xbmc/libdvdcss/archive/$_libdvdcss_version.tar.gz"
   "libdvdnav-$_libdvdnav_version.tar.gz::https://github.com/xbmc/libdvdnav/archive/$_libdvdnav_version.tar.gz"
   "libdvdread-$_libdvdread_version.tar.gz::https://github.com/xbmc/libdvdread/archive/$_libdvdread_version.tar.gz"
+  "http://mirrors.kodi.tv/build-deps/sources/fmt-$_fmt_version.tar.gz"
+  "http://mirrors.kodi.tv/build-deps/sources/crossguid-$_crossguid_version.tar.gz"
+  'fix_fmt_race_condition.patch'
 )
 noextract=(
   "libdvdcss-$_libdvdcss_version.tar.gz"
   "libdvdnav-$_libdvdnav_version.tar.gz"
   "libdvdread-$_libdvdread_version.tar.gz"
   "ffmpeg-$_ffmpeg_version.tar.gz"
+  "fmt-$_fmt_version.tar.gz"
+  "crossguid-$_crossguid_version.tar.gz"
 )
 sha256sums=('937d755c638324bf388fc9e971c5d8f90fcc0ab9362f0b15bbad5e47f0bc67d6'
             'aa96b6abb18329dcca7b5f775df69eee10beeb9ca727e867e7a96886953c66d0'
             'b31570f95654434b01fd8531612fbb6be77cbc1c519dd60f92feae26eb160f3d'
             '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96'
             '0b9d951911a8576c26dec8a31f394282677e48afff49b9579448121d27b8509e'
-            '20c38f8153384335a777806facdd4444e6b1a73bec9a16f557d6f98ca7a30f54'
+            '0e4980abac7b886e0eb5f4157941947be3c10d616a19bd311dc2f9fd2eb6a631'
             '6af3d4f60e5af2c11ebe402b530c07c8878df1a6cf19372e16c92848d69419a5'
             '071e414e61b795f2ff9015b21a85fc009dde967f27780d23092643916538a57a'
-            'a30b6aa0aad0f2c505bc77948af2d5531a80b6e68112addb4c123fca24d5d3bf')
+            'a30b6aa0aad0f2c505bc77948af2d5531a80b6e68112addb4c123fca24d5d3bf'
+            'dce62ab75a161dd4353a98364feb166d35e7eea382169d59d9ce842c49c55bad'
+            '3d77d09a5df0de510aeeb940df4cb534787ddff3bb1828779753f5dfa1229d10'
+            'd4ce2791cbf6fe6a4ea3507816e253a39d6562c7163dbf8ec30f5006484b75fa')
 
 prepare() {
   cd "$srcdir/xbmc-$_tag"
 
  patch -Np1 -i "$srcdir/hifiberry_digi.patch"
+
+ patch -Np1 -i "$srcdir/fix_fmt_race_condition.patch"
 
   [[ -d kodi-build ]] && rm -rf kodi-build
   mkdir $srcdir/kodi-build
@@ -103,6 +115,8 @@ build() {
     -Dlibdvdnav_URL="$srcdir/libdvdnav-$_libdvdnav_version.tar.gz" \
     -Dlibdvdread_URL="$srcdir/libdvdread-$_libdvdread_version.tar.gz" \
     -DFFMPEG_URL="$srcdir/ffmpeg-$_ffmpeg_version.tar.gz" \
+    -DFMT_URL="$srcdir/fmt-$_fmt_version.tar.gz" \
+    -DCROSSGUID_URL="$srcdir/crossguid-$_crossguid_version.tar.gz" \
     ../"xbmc-$_tag"
   make
   make preinstall

--- a/alarm/kodi-rbp-git/fix_fmt_race_condition.patch
+++ b/alarm/kodi-rbp-git/fix_fmt_race_condition.patch
@@ -1,0 +1,53 @@
+commit c2d8c14a29018a6dbd39a00454addd5944f67fcb
+Author: wsnipex <wsnipex@a1.net>
+Date:   Sun Jul 22 12:34:38 2018 +0200
+
+    fmt
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4350a82bd1..9676919ce5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -288,7 +288,7 @@ endif()
+ 
+ # main library (used for main binary and tests)
+ add_library(lib${APP_NAME_LC} STATIC $<TARGET_OBJECTS:compileinfo>)
+-add_dependencies(lib${APP_NAME_LC} libcpluff ffmpeg dvdnav crossguid ${PLATFORM_GLOBAL_TARGET_DEPS})
++add_dependencies(lib${APP_NAME_LC} libcpluff ffmpeg dvdnav crossguid Fmt ${PLATFORM_GLOBAL_TARGET_DEPS})
+ set_target_properties(lib${APP_NAME_LC} PROPERTIES PREFIX "")
+ 
+ # Other files (IDE)
+diff --git a/cmake/modules/FindFmt.cmake b/cmake/modules/FindFmt.cmake
+index ec0a12cb9e..60a6978a11 100644
+--- a/cmake/modules/FindFmt.cmake
++++ b/cmake/modules/FindFmt.cmake
+@@ -34,7 +34,7 @@ if(ENABLE_INTERNAL_FMT)
+ 
+   set(FMT_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/libfmt.a)
+   set(FMT_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
+-  externalproject_add(fmt
++  externalproject_add(Fmt
+                       URL ${FMT_URL}
+                       DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                       PREFIX ${CORE_BUILD_DIR}/fmt
+@@ -43,8 +43,10 @@ if(ENABLE_INTERNAL_FMT)
+                                  -DFMT_DOC=OFF
+                                  -DFMT_TEST=OFF
+                                  "${EXTRA_ARGS}"
+-                      BUILD_BYPRODUCTS ${FMT_LIBRARY})
+-  set_target_properties(fmt PROPERTIES FOLDER "External Projects")
++                      BUILD_BYPRODUCTS ${FMT_LIBRARY} ${FMT_INCLUDE_DIR})
++  set_target_properties(Fmt PROPERTIES FOLDER "External Projects"
++                                       IMPORTED_LOCATION "${FMT_LIBRARY}"
++                                       INTERFACE_INCLUDE_DIRECTORIES "${FMT_INCLUDE_DIR}")
+ 
+   include(FindPackageHandleStandardArgs)
+   find_package_handle_standard_args(Fmt
+@@ -98,6 +100,5 @@ if(FMT_FOUND)
+   endif()
+ endif()
+ 
+-mark_as_advanced(FMT_INCLUDE_DIR FMT_LIBRARY)
+-
+ endif()
++mark_as_advanced(FMT_INCLUDE_DIR FMT_LIBRARY)


### PR DESCRIPTION
* include upstream fmt and crossguid source rather than downloading it at build time
* include a fix for a race condition relating to fmt for users who do not build in a clean chroot (accepted upstream for inclusion in a3 https://github.com/xbmc/xbmc/pull/14215)
* update ffmpeg source