### PR TITLE
extra/pyqt5: support webengine on armv7h and armv8

### DIFF
--- a/extra/pyqt5/PKGBUILD
+++ b/extra/pyqt5/PKGBUILD
@@ -18,6 +18,8 @@ license=('GPL')
 makedepends=('python-sip-pyqt5' 'python2-sip-pyqt5' 'sip' 'python-opengl' 'python2-opengl' 'python2-enum34'
              'python2-dbus' 'python-dbus' 'qt5-connectivity' 'qt5-multimedia' 'qt5-tools' 'qt5-serialport' 'qt5-svg'
              'qt5-webkit' 'qt5-websockets' 'qt5-x11extras' 'qt5-networkauth')
+makedepends_armv7h=('qt5-webengine')
+makedepends_aarch64=('qt5-webengine')
 source=("http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-$pkgver/PyQt5_gpl-$pkgver.tar.gz" pyqt-support-new-qt.patch)
 sha512sums=('fc60246b5e1ca0d8aeef829fe20de9dd28b77e3c151532f9dbcd92c0deec12d8308cc799901aeec3f84af745e735053d2aaad2866ef64a2426cba343e08bc2c0'
             'b94b707e4265ff8e84d52214cea7b70db33aa436440c74e4918c165a7dfae8949bf3e91491d300e68c1715b26b693ba69eca114cf42ce6114dab1b99d69d417e')


### PR DESCRIPTION
This adds architecture-specific makedepends for the architectures that
qt5-webengine is currently built for.