### PR TITLE
community/mpv: fix the waf version

### DIFF
--- a/community/mpv/PKGBUILD
+++ b/community/mpv/PKGBUILD
@@ -10,8 +10,8 @@
 pkgname=mpv
 epoch=1
 pkgver=0.29.0
-pkgrel=1
-_waf_version=1.9.8
+pkgrel=1.1
+_waf_version=2.0.9
 pkgdesc='a free, open source, and cross-platform media player'
 arch=('x86_64')
 # We link against libraries that are licensed GPLv3 explicitly, libsmbclient
@@ -30,7 +30,7 @@ options=('!emptydirs')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/mpv-player/$pkgname/archive/v$pkgver.tar.gz"
   "https://waf.io/waf-${_waf_version}")
 sha256sums=('772af878cee5495dcd342788a6d120b90c5b1e677e225c7198f1e76506427319'
-  '167dc42bab6d5bd823b798af195420319cb5c9b571e00db7d83df2a0fe1f4dbf')
+  '2a8e0816f023995e557f79ea8940d322bec18f286917c8f9a6fa2dc3875dfa48')
 
 prepare() {
   cd ${pkgname}-${pkgver}


### PR DESCRIPTION
mpv 0.29.0 requires waf 2.0.9, as specified by https://github.com/mpv-player/mpv/blob/v0.29.0/bootstrap.py#L8

The old version of waf makes the build break when Python is updated: https://github.com/mpv-player/mpv/issues/5958

The official PKGBUILD for mpv uses the right version already:
https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/mpv#n10