### PR TITLE
linux-{armv7,veyron}: add FIT image for mainline u-boot

### DIFF
--- a/core/linux-armv7-rc/PKGBUILD
+++ b/core/linux-armv7-rc/PKGBUILD
@@ -386,6 +386,9 @@ _package-chromebook() {
     --bootloader bootloader.bin
 
   mkdir -p "${pkgdir}/boot"
+  # u-boot which supports FIT images
+  cp vmlinux.uimg "${pkgdir}/boot"
+  # standard chromeos coreboot+depthcharge
   cp vmlinux.kpart "${pkgdir}/boot"
 }
 

--- a/core/linux-armv7/PKGBUILD
+++ b/core/linux-armv7/PKGBUILD
@@ -392,6 +392,9 @@ _package-chromebook() {
     --bootloader bootloader.bin
 
   mkdir -p "${pkgdir}/boot"
+  # u-boot which supports FIT images
+  cp vmlinux.uimg "${pkgdir}/boot"
+  # standard chromeos coreboot+depthcharge
   cp vmlinux.kpart "${pkgdir}/boot"
 }
 

--- a/core/linux-veyron/PKGBUILD
+++ b/core/linux-veyron/PKGBUILD
@@ -135,6 +135,9 @@ _package() {
     --config cmdline \
     --bootloader bootloader.bin
 
+  # u-boot which supports FIT images
+  cp vmlinux.uimg "${pkgdir}/boot"
+  # standard chromeos coreboot+depthcharge
   cp vmlinux.kpart "${pkgdir}/boot"
 
   # set correct depmod command for install


### PR DESCRIPTION
Personally I'm doing some work on u-boot to get the asus c201 chromebook
(veyron speedy) to work with u-boot. Mostly working, waiting on some issues
with 4GiB memory to be resolved.

U-boot can boot what's called a fit image which is built during the normal build
of linux-armv7-chromebook, just before the vbutil_kernel step. Install it to /boot
so it can be used by people using my u-boot patches, or later mainline u-boot

Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>