### PR TITLE
Fixed typo

### DIFF
--- a/core/linux-kirkwood/linux-kirkwood.install
+++ b/core/linux-kirkwood/linux-kirkwood.install
@@ -22,7 +22,7 @@ post_install () {
 post_upgrade() {
   if grep "^[^#]*[[:space:]]/boot" etc/fstab 2>&1 >/dev/null; then
     if ! grep "[[:space:]]/boot" etc/mtab 2>&1 >/dev/null; then
-      echo "WARNING: /boot appears to be a seperate partition but is not mounted."
+      echo "WARNING: /boot appears to be a separate partition but is not mounted."
       echo "         You probably just broke your system. Congratulations."
     fi
   fi


### PR DESCRIPTION
Separate wasn't spelled correctly. This was highlighted by /u/CommonMisspellingBot [here].(https://www.reddit.com/r/linuxmemes/comments/9cv0gd/found_at_rarchlinuxarm/e5e5bl6/?st=jlo6d09g&sh=253908ea)