### PR TITLE
linux-aarch64: Generate device tree blobs with symbols

### DIFF
--- a/core/linux-aarch64/PKGBUILD
+++ b/core/linux-aarch64/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-4.18
 _kernelname=${pkgbase#linux}
 _desc="AArch64 multi-platform"
 pkgver=4.18.5
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -88,7 +88,9 @@ build() {
 
   # build!
   unset LDFLAGS
-  make ${MAKEFLAGS} Image Image.gz modules dtbs
+  make ${MAKEFLAGS} Image Image.gz modules
+  # Generate device tree blobs with symbols to support applying device tree overlays in U-Boot
+  make ${MAKEFLAGS} DTC_FLAGS="-@" dtbs
 }
 
 _package() {


### PR DESCRIPTION
This is required to support applying device tree overlays in U-Boot. Tested with `rpi-poe.dtbo` from the Raspberry Pi Foundation tree, on RPi3B+.