### PR TITLE
alarm/kodi-rbp-git to 18.0b3.20181002-2

### DIFF
--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -13,7 +13,7 @@ pkgbase=kodi-rbp-git
 _suffix=rbp-git
 pkgname=("kodi-$_suffix" "kodi-eventclients-$_suffix" "kodi-tools-texturepacker-$_suffix" "kodi-dev-$_suffix")
 pkgver=18.0b3.20181002
-pkgrel=1
+pkgrel=2
 _commit=5718827da2a8aea8acf8d9265689705031d73289
 _short=${_commit::+7}
 _codename=Leia
@@ -138,7 +138,7 @@ package_kodi-rbp-git() {
     'hicolor-icon-theme' 'libass' 'libcdio' 'libjpeg-turbo' 'libmariadbclient'
     'libmicrohttpd' 'libpulse' 'libssh' 'libxrandr' 'lirc' 'raspberrypi-firmware'
     'libxslt' 'lzo' 'python2-pillow' 'python2-simplejson' 'smbclient'
-    'speex' 'taglib' 'tinyxml' 'xorg-xdpyinfo' 'yajl' 'libinput' 'libxkbcommon' 'libbluray'
+    'speex' 'taglib' 'tinyxml' 'xorg-xdpyinfo' 'yajl' 'libinput' 'libxkbcommon' 'libbluray-kodi-rbp'
   )
   optdepends=(
     'afpfs-ng: Apple shares support'


### PR DESCRIPTION
I missed an instance in the dependency array which will pull down the non-patched version which will not run.