### PR TITLE
alarm/kodi-rbp-git to 18.0b4.20181023-1

### DIFF
--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -12,12 +12,10 @@ _prefix=/usr
 pkgbase=kodi-rbp-git
 _suffix=rbp-git
 pkgname=("kodi-$_suffix" "kodi-eventclients-$_suffix" "kodi-tools-texturepacker-$_suffix" "kodi-dev-$_suffix")
-pkgver=18.0b3.20181002
-pkgrel=2
-_commit=5718827da2a8aea8acf8d9265689705031d73289
-_short=${_commit::+7}
+pkgver=18.0b4.20181023
+pkgrel=1
 _codename=Leia
-_tag="18.0b3-$_codename"
+_tag="18.0b4-$_codename"
 _rtype=Alpha
 _ffmpeg_version="4.0.2-$_codename-$_rtype"3
 _libdvdcss_version="1.4.1-$_codename-Beta"-3
@@ -40,8 +38,9 @@ makedepends=(
   'shairplay' 'smbclient' 'speex' 'swig' 'taglib' 'tinyxml' 'unzip' 'upower'
   'yajl' 'zip' 'giflib' 'rapidjson' 'polkit' 'libinput' 'libxkbcommon' 'ghostscript'
 )
-source=("xbmc-newclock5_$_tag-$_short.tar.gz::https://api.github.com/repos/popcornmix/xbmc/tarball/$_commit"
+source=("https://github.com/popcornmix/xbmc/archive/newclock5_$_tag.tar.gz"
   'kodi.service'
+  'kodi-framebuffer'
   '99-kodi.rules'
   'polkit.rules'
   'hifiberry_digi.patch'
@@ -64,8 +63,9 @@ noextract=(
   "fstrcmp-$_fstrcmp_version.tar.gz"
   "flatbuffers-$_flatbuffers_version.tar.gz"
 )
-sha256sums=('dc41e3c08834d84f6bb0cee9998d8f928d348f6d77ce701f627dea78054bb46a'
-            '856de10e157f44baf97140b896d9e8d8ddd6c8a422c92a5ca03a0e68444d7583'
+sha256sums=('4022a169e1467a4d5c3b338ae0882d22febe49f2e5727c83b60a6e6201e9dae7'
+            '6eded8b5f52808d5ffa77de546fbf799a255dde2473540e8a8bd46daa6f753d9'
+            'fe7a1ab2a6e2bf00f756c76545a338d2763003052764d722d492b06b1bc05f5e'
             'b31570f95654434b01fd8531612fbb6be77cbc1c519dd60f92feae26eb160f3d'
             '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96'
             '0b9d951911a8576c26dec8a31f394282677e48afff49b9579448121d27b8509e'
@@ -79,9 +79,7 @@ sha256sums=('dc41e3c08834d84f6bb0cee9998d8f928d348f6d77ce701f627dea78054bb46a'
             '5ca5491e4260cacae30f1a5786d109230db3f3a6e5a0eb45d0d0608293d247e3')
 
 prepare() {
-  cd "popcornmix-xbmc-$_short"
-
-  patch -Np1 -i ../hifiberry_digi.patch
+  cd "xbmc-newclock5_$_tag"
 
   [[ -d kodi-build ]] && rm -rf kodi-build
   mkdir $srcdir/kodi-build
@@ -126,7 +124,7 @@ build() {
     -DCROSSGUID_URL="$srcdir/crossguid-$_crossguid_version.tar.gz" \
     -DFSTRCMP_URL="$srcdir/fstrcmp-$_fstrcmp_version.tar.gz" \
     -DFLATBUFFERS_URL="$srcdir/flatbuffers-$_flatbuffers_version.tar.gz" \
-    ../"popcornmix-xbmc-$_short"
+    ../"xbmc-newclock5_$_tag"
   make
   make preinstall
 }
@@ -139,6 +137,7 @@ package_kodi-rbp-git() {
     'libmicrohttpd' 'libpulse' 'libssh' 'libxrandr' 'lirc' 'raspberrypi-firmware'
     'libxslt' 'lzo' 'python2-pillow' 'python2-simplejson' 'smbclient'
     'speex' 'taglib' 'tinyxml' 'xorg-xdpyinfo' 'yajl' 'libinput' 'libxkbcommon' 'libbluray-kodi-rbp'
+    'fbset'
   )
   optdepends=(
     'afpfs-ng: Apple shares support'
@@ -171,6 +170,7 @@ package_kodi-rbp-git() {
   grep -lR '#!.*python' * | while read file; do sed -s 's/\(#!.*python\)/\12/g' -i "$file"; done
 
   install -Dm0644 "$srcdir/kodi.service" "$pkgdir/usr/lib/systemd/system/kodi.service"
+  install -Dm0644 "$srcdir/kodi-framebuffer" "$pkgdir/etc/conf.d/kodi-framebuffer"
   install -Dm0644 "$srcdir/polkit.rules" "$pkgdir/usr/share/polkit-1/rules.d/10-kodi.rules"
   chmod 0750 "$pkgdir/usr/share/polkit-1/rules.d/"
 

--- a/alarm/kodi-rbp-git/kodi-framebuffer
+++ b/alarm/kodi-rbp-git/kodi-framebuffer
@@ -1,0 +1,9 @@
+#
+# /etc/conf.d/kodi-framebuffer
+#
+# The RESTOREMODE variable defines the preferred settings for the frame buffer
+# when kodi is stopped. Syntax is <xres> <yres> <vxres> <vyres> <depth>
+#
+# Tip: get the current frame buffer settings by running `fbset` as root
+
+RESTOREMODE="1824 984 1824 984 32"

--- a/alarm/kodi-rbp-git/kodi.service
+++ b/alarm/kodi-rbp-git/kodi.service
@@ -1,14 +1,18 @@
 [Unit]
-Description = Kodi standalone
-After = remote-fs.target
+Description=Kodi standalone
+After=remote-fs.target
 
 [Service]
-User = kodi
-Group = kodi
-Type = simple
-ExecStart = /usr/bin/kodi-standalone
-Restart = on-failure
-KillMode = mixed
+User=kodi
+Group=kodi
+ExecStartPre=+/bin/sh -c 'echo 0 > /sys/class/vtconsole/vtcon1/bind'
+ExecStartPre=+/usr/bin/fbset -g 4 2 4 2 32
+ExecStart=/usr/bin/kodi-standalone
+ExecStopPost=+/usr/bin/fbset -g $RESTOREMODE
+ExecStopPost=+/bin/sh -c 'echo 1 > /sys/class/vtconsole/vtcon1/bind'
+Restart=on-failure
+SendSIGHUP=yes
+EnvironmentFile=/etc/conf.d/kodi-framebuffer
 
 [Install]
-WantedBy = multi-user.target
+WantedBy=multi-user.target


### PR DESCRIPTION
Beyond the b3-->b4 update, I modified `kodi.service` to drop the framebuffer when kodi is launched from the systemd unit.

Advantage: Adds back ~7MB of video memory.
Disadvantage: no console FB when using kodi launched from the service.

I don't see lack of FB as impacting many since users launching kodi from the service (ie standalone) are likely using the box specifically for this purpose.

Thoughts?

