### PR TITLE
core/linux-raspberrypi to 4.14.81-2

### DIFF
--- a/core/linux-raspberrypi/PKGBUILD
+++ b/core/linux-raspberrypi/PKGBUILD
@@ -10,7 +10,7 @@ _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="Raspberry Pi"
 pkgver=4.14.81
-pkgrel=1
+pkgrel=2
 arch=('armv6h' 'armv7h')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -87,6 +87,8 @@ _package() {
 
   # get kernel version
   _kernver="$(make kernelrelease)"
+  _basekernel=${_kernver%%-*}
+  _basekernel=${_basekernel%.*}
 
   mkdir -p "${pkgdir}"/{lib/modules,lib/firmware}
   make INSTALL_MOD_PATH="${pkgdir}" modules_install


### PR DESCRIPTION
I believe an error was introduced into the PKGBUILD that caused `/lib/modules/extramodules--raspberrypi/` to have a null inserted between the hyphens.  This PR fixes that and is consistent with other kernel PKGBUILDs.  Let me know if I am missing something.