### PR TITLE
kodi-rbp-git needs libnfs as dependency

### DIFF
--- a/alarm/kodi-rbp-git/PKGBUILD
+++ b/alarm/kodi-rbp-git/PKGBUILD
@@ -13,7 +13,7 @@ pkgbase=kodi-rbp-git
 _suffix=rbp-git
 pkgname=("kodi-$_suffix" "kodi-eventclients-$_suffix" "kodi-tools-texturepacker-$_suffix" "kodi-dev-$_suffix")
 pkgver=18.0rc1.20181121
-pkgrel=1
+pkgrel=2
 _codename=Leia
 _tag="18.0rc1-$_codename"
 _rtype=Alpha
@@ -134,13 +134,12 @@ package_kodi-rbp-git() {
     'libmicrohttpd' 'libpulse' 'libssh' 'libxrandr' 'lirc' 'raspberrypi-firmware'
     'libxslt' 'lzo' 'python2-pillow' 'python2-simplejson' 'smbclient'
     'speex' 'taglib' 'tinyxml' 'xorg-xdpyinfo' 'yajl' 'libinput' 'libxkbcommon' 'libbluray-kodi-rbp'
-    'fbset'
+    'fbset' 'libnfs'
   )
   optdepends=(
     'afpfs-ng: Apple shares support'
     'bluez: Blutooth support'
     'python2-pybluez: Bluetooth support'
-    'libnfs: NFS shares support'
     'libplist: Limited AirPlay support'
     'lsb-release: log distro information in crashlog'
     'shairplay: Limited AirPlay support'


### PR DESCRIPTION
So it seems kodi-rbp-git needs libnfs as dependency otherwise, kodi bails out at start with this error:

    /usr/lib/kodi/kodi-rbpi: error while loading shared libraries: libnfs.so.12: cannot open shared object: No such file or directory

This is a quick fix to let you know of the problem.
I haven't looked at how to do it with cmake variable

RANT:
Why can't we simply create issue and you deal with the problem ? Instead I have to create a pull request just to notify of the problem, and that pull request will never be accepted anyway ? wtf !