### PR TITLE
alarm/kodi-c2: Disable dmesg printing and fbcon cursor_blink for kodi

### DIFF
--- a/alarm/kodi-c2/PKGBUILD
+++ b/alarm/kodi-c2/PKGBUILD
@@ -25,7 +25,7 @@ pkgname=('kodi-c2' 'kodi-c2-eventclients' 'kodi-c2-tools-texturepacker' 'kodi-c2
 _commit=7e7160eacdcb0c5b70e91dd4265d20358ba33c26
 _codename=Krypton
 pkgver=17.6
-pkgrel=4
+pkgrel=5
 arch=('aarch64')
 url="http://kodi.tv"
 license=('GPL2')
@@ -65,7 +65,7 @@ sha256sums=('aafe2852620a6bc62c929bf1bdb24760e7e9573787ca4dd37aceed2d1dbb32dd'
             '3d77d09a5df0de510aeeb940df4cb534787ddff3bb1828779753f5dfa1229d10'
             '1c07c9fdd8e2958262cf917e4266c4933fcd06529c111e3cb0cbaaa05c934033'
             '8c606f29aa9ec90f4c93e1751cfd4000872937e604e6ad7538b96ba29612d2f6'
-            '3e4c21b376a187249a4b3195e4e88d49dbe819a55243d834a55cef86bac5ec2d'
+            '03c89e8c15603ae1f61f632da5e283adc3d30a260d83bd51199b2eaa88638ab6'
             'c68ed2bd377f80b606b8815d78239b9132b479eafc1d19797cee5824debe1800'
             '5ddf80329c9f5d054525b45f788b3405d199bfc6cf5b08c543ad29766ec27f6e')
 noextract=(

--- a/alarm/kodi-c2/kodi.service
+++ b/alarm/kodi-c2/kodi.service
@@ -6,7 +6,12 @@ After = remote-fs.target
 User = kodi
 Group = kodi
 Type = simple
+PermissionsStartOnly = true
+ExecStartPre = /bin/sh -c "dmesg -D"
+ExecStartPre = /bin/sh -c "echo 0 > /sys/class/graphics/fbcon/cursor_blink"
 ExecStart = /usr/bin/kodi
+ExecStopPost = /bin/sh -c "echo 1 > /sys/class/graphics/fbcon/cursor_blink"
+ExexStopPost = /bin/sh -c "dmesg -E"
 Restart = on-failure
 
 [Install]


### PR DESCRIPTION
This is similar to what PR #1251 did for the `kodi-imx` package:

> When messages are added to dmesg they're shown in kodi as overlay. In order to disable this behaviour the service script disable dmesg console logging before start of kodi and reenable console logging after. Since this operation needs root rights the PermissionsStartOnly was set to true.

Additionally, `cursor_blink` is also disabled. This is also consistent with what the `kodi-imx` package does.