### PR TITLE
patch from https://github.com/popcornmix/omxplayer/issues/637

### DIFF
--- a/alarm/omxplayer-git/0003-reader.patch
+++ b/alarm/omxplayer-git/0003-reader.patch
@@ -1,0 +1,19 @@
+diff --git a/OMXReader.cpp b/OMXReader.cpp
+index 804233a..c9e6206 100644
+--- a/OMXReader.cpp
++++ b/OMXReader.cpp
+@@ -118,6 +118,13 @@ static int dvd_file_read(void *h, uint8_t* buf, int size)
+     return -1;
+
+   XFILE::CFile *pFile = (XFILE::CFile *)h;
+-  return pFile->Read(buf, size);
++  int ret = pFile->Read(buf, size);
++
++#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(58,12,100)
++  if (ret == 0 && pFile->IsEOF())
++    ret = AVERROR_EOF;
++#endif
++
++  return ret;
+ }
+

--- a/alarm/omxplayer-git/PKGBUILD
+++ b/alarm/omxplayer-git/PKGBUILD
@@ -5,7 +5,7 @@
 buildarch=20
 
 pkgname=omxplayer-git
-pkgver=519.b4bbef8
+pkgver=521.a447d4f
 pkgrel=1
 pkgdesc="omxplayer is a command line media player for the RaspberryPi"
 arch=('armv6h' 'armv7h')
@@ -18,10 +18,14 @@ provides=(omxplayer)
 conflicts=('omxplayer' 'omxplayer-bin')
 source=('git://github.com/popcornmix/omxplayer.git'
         '0001-alarm-fixes.patch'
-        '0002-fix-keyboard-input.patch')
+        '0002-fix-keyboard-input.patch'
+	'0003-reader.patch'
+	)
 md5sums=('SKIP'
          'fe4efaa1cf49570a65c51cef319fdf8b'
-         '28cb317db75a866b22484ac16eb3152a')
+         '28cb317db75a866b22484ac16eb3152a'
+	 'SKIP'
+	)
 
 pkgver() {
   cd omxplayer
@@ -33,6 +37,7 @@ prepare() {
 
   git apply ../0001-alarm-fixes.patch
   git apply ../0002-fix-keyboard-input.patch
+  git apply ../0003-reader.patch
 }
 
 build() {


### PR DESCRIPTION
In https://github.com/popcornmix/omxplayer/issues/637#issuecomment-450475760 jehutting proposed a solution to the "recent version of omxplayer hangs at the end"-problem I also had. I tried his patch and it worked for me. I just added a third patch file to the PKGBUILD.