### PR TITLE
Enabling USB3 on ROC-RK3328-CC (Renegade) like on Rock64

### DIFF
--- a/core/linux-aarch64/0006-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-roc-cc.patch
+++ b/core/linux-aarch64/0006-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-roc-cc.patch
@@ -1,0 +1,30 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
+index 99d0d99..cbba3c7 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
+@@ -245,6 +245,12 @@
+ 			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
++
++	usb3 {
++		usb30_host_drv: usb30-host-drv {
++			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
+ };
+ 
+ &sdmmc {
+@@ -295,3 +301,12 @@
+ &usb_host0_ohci {
+ 	status = "okay";
+ };
++
++&usbdrd3 {
++	status = "okay";
++};
++
++&usbdrd_dwc3 {
++	dr_mode = "host";
++	status = "okay";
++};

--- a/core/linux-aarch64/PKGBUILD
+++ b/core/linux-aarch64/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-4.20
 _kernelname=${pkgbase#linux}
 _desc="AArch64 multi-platform"
 pkgver=4.20.0
-pkgrel=2
+pkgrel=3
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -21,6 +21,7 @@ source=("http://www.kernel.org/pub/linux/kernel/v4.x/${_srcname}.tar.xz"
         '0003-arm64-dts-rockchip-add-usb3-controller-node-for-RK33.patch'
         '0004-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-rock6.patch'
         '0005-mmc-sdhci-iproc-handle-mmc_of_parse-errors-during-pr.patch'
+        '0006-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-roc-cc.patch'
         'config'
         'kernel.its'
         'kernel.keyblock'
@@ -33,6 +34,7 @@ md5sums=('d39dd4ba2d5861c54b90d49be19eaf31'
          'a43dbc3cc8f52b5329accf1694bd1de9'
          'd10a52cb5878020b527cf335b74165e0'
          '66b2ce380f45395e5ad19274ea335e36'
+         '5c73ad67f3fd7093e2f0b896cf49916f'
          '38e8d478b72e09dbd952638dc4cf348e'
          '7f1a96e24f5150f790df94398e9525a3'
          '61c5ff73c136ed07a7aadbf58db3d96a'
@@ -52,6 +54,7 @@ prepare() {
   git apply ../0003-arm64-dts-rockchip-add-usb3-controller-node-for-RK33.patch
   git apply ../0004-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-rock6.patch
   git apply ../0005-mmc-sdhci-iproc-handle-mmc_of_parse-errors-during-pr.patch
+  git apply ../0006-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-roc-cc.patch
 
   cat "${srcdir}/config" > ./.config
 


### PR DESCRIPTION
I don't know if it's missing regulator stuff that needs to be added, but it does work.