### PR TITLE
core/pacman to 5.1.2-3

### DIFF
--- a/core/pacman/PKGBUILD
+++ b/core/pacman/PKGBUILD
@@ -11,7 +11,7 @@
 
 pkgname=pacman
 pkgver=5.1.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A library-based package manager with dependency support"
 arch=('x86_64')
 url="http://www.archlinux.org/pacman/"
@@ -40,7 +40,7 @@ sha256sums=('ce4eef1585fe64fd1c65c269e263577261edd7535fe2278240103012d74b6ef6'
             '9dc4d4b30e9c561868e89272e1867d5a009fbe6461b885c569f93069a32bdada'
             '1b7286b86499a02e63362f501209effafcd1676111d91e88253e07737ba44b89'
             'd55cd09eda56a0f19dfba8a042056fdf8d8d441d2c218fddaa30c1546a703532'
-            'edc48d8a6c051d50241fa727e948a06ece8890d9d9da80573f8894a3bf455d36')
+            'd793394ce37ac1d81eed8efb61a09e22484a9da0e5945f4e7db14f0bb15c361c')
 
 prepare() {
   cd "$pkgname-$pkgver"

--- a/core/pacman/makepkg.conf
+++ b/core/pacman/makepkg.conf
@@ -39,8 +39,8 @@ CHOST="@CHOST@"
 # -march (or -mcpu) builds exclusively for an architecture
 # -mtune optimizes for an architecture, but builds for whole processor family
 CPPFLAGS="-D_FORTIFY_SOURCE=2"
-CFLAGS="@CARCHFLAGS@-O2 -pipe -fstack-protector-strong -fno-plt"
-CXXFLAGS="@CARCHFLAGS@-O2 -pipe -fstack-protector-strong -fno-plt"
+CFLAGS="@CARCHFLAGS@-O2 -pipe -fno-plt"
+CXXFLAGS="@CARCHFLAGS@-O2 -pipe -fno-plt"
 LDFLAGS="-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now"
 #-- Make Flags: change this for DistCC/SMP systems
 #MAKEFLAGS="-j2"


### PR DESCRIPTION
If I'm not mistaken, we can drop `-fstack-protector-strong` since it's enabled by default in gcc.  Is this also true for Arch ARM toolchain?

References:
* [FS#54736](https://bugs.archlinux.org/task/54736)
* [Arch commit](https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/pacman&id=c81d3556e03d4b3da79779a4804ba8bf8b127cb3)