### PR TITLE
Enable USB3 nodes for renegade (minimal patch)

### DIFF
--- a/core/linux-aarch64/0006-arm64-dts-rockchip-enable-usb3-for-roc-rk3328-cc-boa.patch
+++ b/core/linux-aarch64/0006-arm64-dts-rockchip-enable-usb3-for-roc-rk3328-cc-boa.patch
@@ -1,0 +1,30 @@
+From 41ae689ad428568a22f06fcb248f20af52770afe Mon Sep 17 00:00:00 2001
+From: Levin Du <djw@t-chip.com.cn>
+Date: Wed, 15 Aug 2018 17:22:37 +0800
+Subject: [PATCH] arm64: dts: rockchip: enable usb3 for roc-rk3328-cc board
+
+Enable the USB 3.0 OTG controller and set as static xHCI host controller to
+support USB 3.0 HOST.
+
+Signed-off-by: Levin Du <djw@t-chip.com.cn>
+---
+ arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
+index 99d0d9912950..6ba67963eaf5 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
+@@ -295,3 +295,12 @@
+ &usb_host0_ohci {
+ 	status = "okay";
+ };
++
++&usbdrd3 {
++	status = "okay";
++};
++
++&usbdrd_dwc3 {
++	dr_mode = "host";
++	status = "okay";
++};

--- a/core/linux-aarch64/PKGBUILD
+++ b/core/linux-aarch64/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-4.20
 _kernelname=${pkgbase#linux}
 _desc="AArch64 multi-platform"
 pkgver=4.20.4
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -21,6 +21,7 @@ source=("http://www.kernel.org/pub/linux/kernel/v4.x/${_srcname}.tar.xz"
         '0003-arm64-dts-rockchip-add-usb3-controller-node-for-RK33.patch'
         '0004-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-rock6.patch'
         '0005-mmc-sdhci-iproc-handle-mmc_of_parse-errors-during-pr.patch'
+        '0006-arm64-dts-rockchip-enable-usb3-for-roc-rk3328-cc-boa.patch'
         'config'
         'kernel.its'
         'kernel.keyblock'
@@ -34,6 +35,7 @@ md5sums=('d39dd4ba2d5861c54b90d49be19eaf31'
          'a43dbc3cc8f52b5329accf1694bd1de9'
          'd10a52cb5878020b527cf335b74165e0'
          '66b2ce380f45395e5ad19274ea335e36'
+         '2a4c56367967eb24e97a3d64452b8b8c'
          '38e8d478b72e09dbd952638dc4cf348e'
          '7f1a96e24f5150f790df94398e9525a3'
          '61c5ff73c136ed07a7aadbf58db3d96a'
@@ -53,6 +55,7 @@ prepare() {
   git apply ../0003-arm64-dts-rockchip-add-usb3-controller-node-for-RK33.patch
   git apply ../0004-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-rock6.patch
   git apply ../0005-mmc-sdhci-iproc-handle-mmc_of_parse-errors-during-pr.patch
+  git apply ../0006-arm64-dts-rockchip-enable-usb3-for-roc-rk3328-cc-boa.patch
 
   cat "${srcdir}/config" > ./.config
 


### PR DESCRIPTION
The same idea as with rock64. [It was added upstream but ultimately without the usb3 bits as there is a re-plugging issue.](https://patchwork.kernel.org/patch/10179473/#21440617) Pretty sure that's an rk3328 problem in general. (e.g. Rock64). This would be helpful for the same reason that the rock64 patch was added. I still remember [this forum post](https://archlinuxarm.org/forum/viewtopic.php?p=58866#p58866).