### PR TITLE
Actually include cryptodev support

### DIFF
--- a/core/openssl-cryptodev/PKGBUILD
+++ b/core/openssl-cryptodev/PKGBUILD
@@ -60,7 +60,7 @@ build() {
 
 	# mark stack as non-executable: http://bugs.archlinux.org/task/12434
 	./Configure --prefix=/usr --openssldir=/etc/ssl --libdir=lib \
-		-DHAVE_CRYPTODEV -DHASH_MAX_LEN=64 \
+		enable-devcryptoeng -DHASH_MAX_LEN=64 \
 		shared no-ssl3-method ${optflags} \
 		"${openssltarget}" \
 		"-Wa,--noexecstack ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"


### PR DESCRIPTION
It appears that HAVE_CRYPTODEV is no longer checked by the source code, and as a result, the cryptodev code wasn't actually being pulled in. `enable-devcryptoeng` appears to be the correct way to include support, now.