### PR TITLE
alarm/kodi-rbp: spdif/toslink passthrough fix for hifiberry-digi+ card

### DIFF
--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -12,7 +12,7 @@ _prefix=/usr
 pkgbase=kodi-rbp
 pkgname=('kodi-rbp' 'kodi-rbp-eventclients' 'kodi-rbp-tools-texturepacker' 'kodi-rbp-dev')
 pkgver=18.0
-pkgrel=1
+pkgrel=2
 _codename=Leia
 _tag="18.0-$_codename"
 _ffmpeg_version="4.0.3-$_codename-RC5"
@@ -50,6 +50,7 @@ source=("https://github.com/popcornmix/xbmc/archive/newclock5_$_tag.tar.gz"
   "http://mirrors.kodi.tv/build-deps/sources/crossguid-$_crossguid_version.tar.gz"
   "http://mirrors.kodi.tv/build-deps/sources/fstrcmp-$_fstrcmp_version.tar.gz"
   "http://mirrors.kodi.tv/build-deps/sources/flatbuffers-$_flatbuffers_version.tar.gz"
+  "hifiberry_digi.patch"
 )
 noextract=(
   "libdvdcss-$_libdvdcss_version.tar.gz"
@@ -74,8 +75,9 @@ sha256sums=('9c056808eecc7dd2e72fffd3f3412d83c60fe3742bc0d96f16f9abdfc55c8012'
             '73d4cab4fa8a3482643d8703de4d9522d7a56981c938eca42d929106ff474b44'
             '3d77d09a5df0de510aeeb940df4cb534787ddff3bb1828779753f5dfa1229d10'
             'e4018e850f80700acee8da296e56e15b1eef711ab15157e542e7d7e1237c3476'
-            '5ca5491e4260cacae30f1a5786d109230db3f3a6e5a0eb45d0d0608293d247e3')
-
+            '5ca5491e4260cacae30f1a5786d109230db3f3a6e5a0eb45d0d0608293d247e3'
+            'a7aa50c25ff53b87c79c9235d9a3de62ccffcab4faa15b489ae2d8be9b0c0b35'
+)
 prepare() {
   cd "xbmc-newclock5_$_tag"
 
@@ -83,6 +85,9 @@ prepare() {
   mkdir $srcdir/kodi-build
 
   patch -Np1 -i ../00-fix.building.with.mariadb.patch
+
+  # fix for lack of passthrough audio with hifiberry-digi+ card
+  patch -Np1 -i "$srcdir/hifiberry_digi.patch"
 }
 
 build() {

--- a/alarm/kodi-rbp/hifiberry_digi.patch
+++ b/alarm/kodi-rbp/hifiberry_digi.patch
@@ -1,0 +1,14 @@
+diff -rupN a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp	2019-01-28 19:02:31.000000000 +0100
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp	2019-02-15 22:20:14.000000000 +0100
+@@ -1329,6 +1329,10 @@ void CAESinkALSA::EnumerateDevice(AEDevi
+     if (snd_card_get_name(cardNr, &cardName) == 0)
+       info.m_displayName = cardName;
+ 
++    /* hifiberry digi doesn't correctly report as iec958 device. Needs fixing in kernel driver */
++    if (info.m_displayName == "snd_rpi_hifiberry_digi")
++        info.m_deviceType = AE_DEVTYPE_IEC958;
++
+     if (info.m_deviceType == AE_DEVTYPE_HDMI && info.m_displayName.size() > 5 &&
+         info.m_displayName.substr(info.m_displayName.size()-5) == " HDMI")
+     {


### PR DESCRIPTION
alarm/kodi-rbp

This is a copy of pull request #1376 for 17.0 (and #1468 for 17.1) to work with kodi-rbp 18.0.

As a reminder:

> The HiFiBerry Digi+ is a S/PDIF/Toslink output board for the Raspberry Pi (rPi2 and rPi3).
> For years (I found forum topics going back to 2014) kodi is not able to use it as pass-through device for audio output. What that means is, you are not able to get DTS or DolbyD signal in your amp.
> It looks OpenELEC and Osmc already applied the patch, or rather workaround for that issue.
> More info here:
> https://support.hifiberry.com/hc/en-us/community/posts/201845791-Kodi-no-passthrough
> and here
> http://forum.kodi.tv/showthread.php?tid=261778
> Kodi won't apply the patch as in their eyes the problem should be fixed in kernel or by Hifiberry.
> I really doubt it will be fixed upstream in the near future (judging on the sheer amount of topics/issues which are open all over the web).
> It's worth applying that patch to save time and headache to arm arch users.

It looks like patch was removed when kodi-rbp package was upgraded to 18.0 release.

Could it be merged again, please?