### PR TITLE
Add kodi-rbp3-addon-visualization-spectrum plugin

### DIFF
--- a/alarm/kodi-rbp3-addon-visualization-spectrum/PKGBUILD
+++ b/alarm/kodi-rbp3-addon-visualization-spectrum/PKGBUILD
@@ -1,0 +1,55 @@
+# Contributor lynix < lynix47 AT gmail DOT com >
+# Contributor BlackIkeEagle < ike DOT devolder AT gmail DOT com >
+# Contributor Oleg Rakhmanov <oleg [at] archlinuxarm [dot] com>
+
+buildarch=4
+
+pkgname=kodi-rbp3-addon-visualization-spectrum
+_commit=51dd253
+pkgver=20190227.51dd253
+pkgrel=1
+pkgdesc="Spectrum visualizer for Kodi on Raspberry Pi 3"
+arch=('armv7h')
+url='https://github.com/notspiff/visualization.spectrum'
+license=('GPL')
+groups=('kodi-rbp3-addons' 'kodi-rbp3-addons-visualization')
+depends=('kodi-rbp3')
+makedepends=('git' 'cmake' 'kodi-rbp3-dev')
+source=("$pkgname::git://github.com/notspiff/visualization.spectrum.git#commit=$_commit")
+sha256sums=('SKIP')
+
+pkgver() {
+    cd "$pkgname"
+    git log -1 --date=short --format="%cd.%h" | tr -d '-'
+}
+
+build() {
+    cd "$pkgname"
+
+    export CFLAGS="-march=armv8-a+crc -mcpu=cortex-a53 -mfpu=neon-fp-armv8 \
+        -Ofast -fexcess-precision=fast -mfloat-abi=hard -mabi=aapcs-linux \
+        -pipe -fstack-protector --param=ssp-buffer-size=4 \
+        -I/opt/vc/include/ \
+        -I/opt/vc/include/IL \
+        -I/opt/vc/include/interface/vcos/pthreads \
+        -I/opt/vc/include/interface/vmcs_host/linux"
+
+    # Note: '-DOPENGLES2_INCLUDE_DIR(S)' duplication works around an upstream
+    #       bug. Remove once fixed.
+    cmake \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=1 \
+        -DUSE_LTO=0 \
+        -DOPENGLES2_INCLUDE_DIRS=/opt/vc/include \
+        -DOPENGLES2_INCLUDE_DIR=/opt/vc/include \
+        -DOPENGLES2_gl_LIBRARY=/opt/vc/lib/libbrcmGLESv2.so \
+        -DOPENGLES2_egl_LIBRARY=/opt/vc/lib/libbrcmEGL.so
+
+    make
+}
+
+package() {
+    cd "$pkgname"
+    make DESTDIR="$pkgdir/" install
+}


### PR DESCRIPTION
Add Pi3 port of kodi-rbp-addon-visualization-spectrum, updated to use newer
upstream sources and Pi3-specific optimization.

This has been tested and confirmed to work on a Pi3 B+ running kodi-18.1-1.