### PR TITLE
core/linux-aarch64: Fix the problem that Rock64 USB ports are broken

### DIFF
--- a/core/linux-aarch64/0001-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
+++ b/core/linux-aarch64/0001-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
@@ -1,7 +1,7 @@
 From 9455b79231ace06946c9402354c698d8c690f2e9 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 18 Feb 2014 01:43:50 -0300
-Subject: [PATCH 1/4] net/smsc95xx: Allow mac address to be set as a parameter
+Subject: [PATCH 1/5] net/smsc95xx: Allow mac address to be set as a parameter
 
 ---
  drivers/net/usb/smsc95xx.c | 56 ++++++++++++++++++++++++++++++++++++++

--- a/core/linux-aarch64/0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch
+++ b/core/linux-aarch64/0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch
@@ -1,7 +1,7 @@
 From c4792b5f38f9f9b1f8feb55b808c7bbf5f54321d Mon Sep 17 00:00:00 2001
 From: Kevin Mihelich <kevin@archlinuxarm.org>
 Date: Mon, 7 Aug 2017 19:34:57 -0600
-Subject: [PATCH 2/4] arm64: dts: rockchip: disable pwm0 on rk3399-firefly
+Subject: [PATCH 2/5] arm64: dts: rockchip: disable pwm0 on rk3399-firefly
 
 Workaround for intermittent boot hangs due to pwm0 probe disabling the PWM clock.
 ---

--- a/core/linux-aarch64/0003-arm64-dts-rockchip-add-usb3-controller-node-for-RK33.patch
+++ b/core/linux-aarch64/0003-arm64-dts-rockchip-add-usb3-controller-node-for-RK33.patch
@@ -1,7 +1,7 @@
 From 6611e957265287091088c812ab5ecdf092c0cd1b Mon Sep 17 00:00:00 2001
 From: William Wu <william.wu@rock-chips.com>
 Date: Mon, 4 Dec 2017 10:40:39 +0100
-Subject: [PATCH 3/4] arm64: dts: rockchip: add usb3 controller node for RK3328
+Subject: [PATCH 3/5] arm64: dts: rockchip: add usb3 controller node for RK3328
  SoCs
 
 RK3328 has one USB 3.0 OTG controller which uses DWC_USB3

--- a/core/linux-aarch64/0004-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-rock6.patch
+++ b/core/linux-aarch64/0004-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-rock6.patch
@@ -1,7 +1,7 @@
 From 3eada47651e60376fbc4262c39ccd7bcca6b994e Mon Sep 17 00:00:00 2001
 From: Heiko Stuebner <heiko@sntech.de>
 Date: Mon, 4 Dec 2017 10:40:41 +0100
-Subject: [PATCH 4/4] arm64: dts: rockchip: enable usb3 nodes on rk3328-rock64
+Subject: [PATCH 4/5] arm64: dts: rockchip: enable usb3 nodes on rk3328-rock64
 
 Enable the nodes to make the usb3 port usable on that board.
 

--- a/core/linux-aarch64/0005-arm64-dts-rockchip-Fix-vcc_host1_5v-GPIO-polarity-on.patch
+++ b/core/linux-aarch64/0005-arm64-dts-rockchip-Fix-vcc_host1_5v-GPIO-polarity-on.patch
@@ -1,0 +1,30 @@
+From 227725c79d73765e22a50e5b00f063f2714139bf Mon Sep 17 00:00:00 2001
+From: Tomohiro Mayama <parly-gh@iris.mystia.org>
+Date: Fri, 8 Mar 2019 01:18:33 +0900
+Subject: [PATCH 5/5] arm64: dts: rockchip: Fix vcc_host1_5v GPIO polarity on
+ rk3328-rock64
+
+This patch makes USB ports functioning again.
+
+Signed-off-by: Tomohiro Mayama <parly-gh@iris.mystia.org>
+---
+ arch/arm64/boot/dts/rockchip/rk3328-rock64.dts | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts b/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
+index e37f5f4141ab..870d472bdec5 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
+@@ -46,8 +46,7 @@
+ 
+ 	vcc_host1_5v: vcc_otg_5v: vcc-host1-5v-regulator {
+ 		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpio = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
++		gpio = <&gpio0 RK_PA2 GPIO_ACTIVE_LOW>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&usb20_host_drv>;
+ 		regulator-name = "vcc_host1_5v";
+-- 
+2.21.0
+

--- a/core/linux-aarch64/PKGBUILD
+++ b/core/linux-aarch64/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-5.0
 _kernelname=${pkgbase#linux}
 _desc="AArch64 multi-platform"
 pkgver=5.0.0
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -20,6 +20,7 @@ source=("http://www.kernel.org/pub/linux/kernel/v5.x/${_srcname}.tar.xz"
         '0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch'
         '0003-arm64-dts-rockchip-add-usb3-controller-node-for-RK33.patch'
         '0004-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-rock6.patch'
+        '0005-arm64-dts-rockchip-Fix-vcc_host1_5v-GPIO-polarity-on.patch'
         'config'
         'kernel.its'
         'kernel.keyblock'
@@ -28,10 +29,11 @@ source=("http://www.kernel.org/pub/linux/kernel/v5.x/${_srcname}.tar.xz"
         '60-linux.hook'
         '90-linux.hook')
 md5sums=('7381ce8aac80a01448e065ce795c19c0'
-         'ba4daec24d71b25d6db1e29bf95ba22f'
-         'dd09eca8f8c516667e995fc3db1d2236'
-         'a8f434da98e1b192f0486b6ba6458616'
-         'a36f126cb864d14294a6735124c795c5'
+         'bca6950ebc7146384de4d37579bf576b'
+         '4aa33b50a14edcc63a406a4de744c413'
+         'dc8ec5415f6a1af425316c310f747fa7'
+         '4477684c49622c88884efb4bb7aeb3a3'
+         'fc1413b1931091271449b9d78a05c984'
          'a6f792a3813d2ae1f69a342eaf46dfd4'
          '7f1a96e24f5150f790df94398e9525a3'
          '61c5ff73c136ed07a7aadbf58db3d96a'
@@ -51,6 +53,7 @@ prepare() {
   git apply ../0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch
   git apply ../0003-arm64-dts-rockchip-add-usb3-controller-node-for-RK33.patch
   git apply ../0004-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-rock6.patch
+  git apply ../0005-arm64-dts-rockchip-Fix-vcc_host1_5v-GPIO-polarity-on.patch
 
   cat "${srcdir}/config" > ./.config
 


### PR DESCRIPTION
Rock64 USB ports are broken since linux-aarch64 4.20.0-1.
This dts patch can bring back USB again, but it might take a long time to be included in upstream kernel release.
So I would like to request to apply it to linux-aarch64 package.

Related links:
* https://archlinuxarm.org/forum/viewtopic.php?f=23&t=13321
* https://lists.infradead.org/pipermail/linux-rockchip/2019-March/023298.html
* https://patchwork.kernel.org/patch/10843309/