### PR TITLE
core/linux-aarch64: fix usb 3.0 for rk3328-roc-cc

### DIFF
--- a/core/linux-aarch64/0001-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
+++ b/core/linux-aarch64/0001-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
@@ -1,7 +1,7 @@
 From 9455b79231ace06946c9402354c698d8c690f2e9 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 18 Feb 2014 01:43:50 -0300
-Subject: [PATCH 1/5] net/smsc95xx: Allow mac address to be set as a parameter
+Subject: [PATCH 1/6] net/smsc95xx: Allow mac address to be set as a parameter
 
 ---
  drivers/net/usb/smsc95xx.c | 56 ++++++++++++++++++++++++++++++++++++++

--- a/core/linux-aarch64/0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch
+++ b/core/linux-aarch64/0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch
@@ -1,7 +1,7 @@
 From c4792b5f38f9f9b1f8feb55b808c7bbf5f54321d Mon Sep 17 00:00:00 2001
 From: Kevin Mihelich <kevin@archlinuxarm.org>
 Date: Mon, 7 Aug 2017 19:34:57 -0600
-Subject: [PATCH 2/5] arm64: dts: rockchip: disable pwm0 on rk3399-firefly
+Subject: [PATCH 2/6] arm64: dts: rockchip: disable pwm0 on rk3399-firefly
 
 Workaround for intermittent boot hangs due to pwm0 probe disabling the PWM clock.
 ---

--- a/core/linux-aarch64/0003-arm64-dts-rockchip-add-usb3-controller-node-for-RK33.patch
+++ b/core/linux-aarch64/0003-arm64-dts-rockchip-add-usb3-controller-node-for-RK33.patch
@@ -1,7 +1,7 @@
 From 6611e957265287091088c812ab5ecdf092c0cd1b Mon Sep 17 00:00:00 2001
 From: William Wu <william.wu@rock-chips.com>
 Date: Mon, 4 Dec 2017 10:40:39 +0100
-Subject: [PATCH 3/5] arm64: dts: rockchip: add usb3 controller node for RK3328
+Subject: [PATCH 3/6] arm64: dts: rockchip: add usb3 controller node for RK3328
  SoCs
 
 RK3328 has one USB 3.0 OTG controller which uses DWC_USB3

--- a/core/linux-aarch64/0004-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-rock6.patch
+++ b/core/linux-aarch64/0004-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-rock6.patch
@@ -1,7 +1,7 @@
 From 3eada47651e60376fbc4262c39ccd7bcca6b994e Mon Sep 17 00:00:00 2001
 From: Heiko Stuebner <heiko@sntech.de>
 Date: Mon, 4 Dec 2017 10:40:41 +0100
-Subject: [PATCH 4/5] arm64: dts: rockchip: enable usb3 nodes on rk3328-rock64
+Subject: [PATCH 4/6] arm64: dts: rockchip: enable usb3 nodes on rk3328-rock64
 
 Enable the nodes to make the usb3 port usable on that board.
 

--- a/core/linux-aarch64/0005-arm64-dts-rockchip-Fix-vcc_host1_5v-GPIO-polarity-on.patch
+++ b/core/linux-aarch64/0005-arm64-dts-rockchip-Fix-vcc_host1_5v-GPIO-polarity-on.patch
@@ -1,7 +1,7 @@
 From 227725c79d73765e22a50e5b00f063f2714139bf Mon Sep 17 00:00:00 2001
 From: Tomohiro Mayama <parly-gh@iris.mystia.org>
 Date: Fri, 8 Mar 2019 01:18:33 +0900
-Subject: [PATCH 5/5] arm64: dts: rockchip: Fix vcc_host1_5v GPIO polarity on
+Subject: [PATCH 5/6] arm64: dts: rockchip: Fix vcc_host1_5v GPIO polarity on
  rk3328-rock64
 
 This patch makes USB ports functioning again.

--- a/core/linux-aarch64/0006-arm64-dts-rockchip-enable-usb3-for-roc-rk3328-cc-boa.patch
+++ b/core/linux-aarch64/0006-arm64-dts-rockchip-enable-usb3-for-roc-rk3328-cc-boa.patch
@@ -1,0 +1,30 @@
+From 41ae689ad428568a22f06fcb248f20af52770afe Mon Sep 17 00:00:00 2001
+From: Levin Du <djw@t-chip.com.cn>
+Date: Wed, 15 Aug 2018 17:22:37 +0800
+Subject: [PATCH 6/6] arm64: dts: rockchip: enable usb3 for roc-rk3328-cc board
+
+Enable the USB 3.0 OTG controller and set as static xHCI host controller to
+support USB 3.0 HOST.
+
+Signed-off-by: Levin Du <djw@t-chip.com.cn>
+---
+ arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
+index 99d0d9912950..6ba67963eaf5 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
+@@ -295,3 +295,12 @@
+ &usb_host0_ohci {
+ 	status = "okay";
+ };
++
++&usbdrd3 {
++	status = "okay";
++};
++
++&usbdrd_dwc3 {
++	dr_mode = "host";
++	status = "okay";
++};

--- a/core/linux-aarch64/PKGBUILD
+++ b/core/linux-aarch64/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-5.0
 _kernelname=${pkgbase#linux}
 _desc="AArch64 multi-platform"
 pkgver=5.0.1
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -21,6 +21,7 @@ source=("http://www.kernel.org/pub/linux/kernel/v5.x/${_srcname}.tar.xz"
         '0003-arm64-dts-rockchip-add-usb3-controller-node-for-RK33.patch'
         '0004-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-rock6.patch'
         '0005-arm64-dts-rockchip-Fix-vcc_host1_5v-GPIO-polarity-on.patch'
+        '0006-arm64-dts-rockchip-enable-usb3-for-roc-rk3328-cc-boa.patch'
         'config'
         'kernel.its'
         'kernel.keyblock'
@@ -30,11 +31,12 @@ source=("http://www.kernel.org/pub/linux/kernel/v5.x/${_srcname}.tar.xz"
         '90-linux.hook')
 md5sums=('7381ce8aac80a01448e065ce795c19c0'
          '488f0f1b00a0861b4c3ddf578f1bd548'
-         'bca6950ebc7146384de4d37579bf576b'
-         '4aa33b50a14edcc63a406a4de744c413'
-         'dc8ec5415f6a1af425316c310f747fa7'
-         '4477684c49622c88884efb4bb7aeb3a3'
-         'fc1413b1931091271449b9d78a05c984'
+         '24facf685647f214faa83cff407c0d75'
+         '31de7feb010bd74176b726eb4a8d11ae'
+         '73e11d3ed431a361d851effe54b7ff11'
+         'ac5ba323982a56052cda7068431eb390'
+         '02563a361dc288105337295c2797f47f'
+         '045a44117ad007f3aec771411fc9432c'
          'a6f792a3813d2ae1f69a342eaf46dfd4'
          '7f1a96e24f5150f790df94398e9525a3'
          '61c5ff73c136ed07a7aadbf58db3d96a'
@@ -55,6 +57,7 @@ prepare() {
   git apply ../0003-arm64-dts-rockchip-add-usb3-controller-node-for-RK33.patch
   git apply ../0004-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-rock6.patch
   git apply ../0005-arm64-dts-rockchip-Fix-vcc_host1_5v-GPIO-polarity-on.patch
+  git apply ../0006-arm64-dts-rockchip-enable-usb3-for-roc-rk3328-cc-boa.patch
 
   cat "${srcdir}/config" > ./.config
 


### PR DESCRIPTION
Enable the USB3 port on the rk3328-roc-cc board
IT is a very important feature of the board, and useful when it's used as a NAS for example

Links:
- http://lists.infradead.org/pipermail/linux-rockchip/2018-January/019032.html (patch that added the board)
It was picked up by Heiko for 4.17 with the exception of the usb3 port due to a replug issue.

- https://raw.githubusercontent.com/armbian/build/master/patch/kernel/rockchip64-dev/board-renegade-add-enable-usb3.patch (just the usb3 bits for the dts, used in rockchip64-dev in armbian)