### PR TITLE
core/linux-armv7: support flashing to chromebook internal storage

### DIFF
--- a/core/linux-armv7/linux-armv7-chromebook.install
+++ b/core/linux-armv7/linux-armv7-chromebook.install
@@ -2,7 +2,9 @@ flash_kernel() {
   major=$(mountpoint -d / | cut -f 1 -d ':')
   minor=$(mountpoint -d / | cut -f 2 -d ':')
   device=$(cat /proc/partitions | awk {'if ($1 == "'${major}'" && $2 == "'${minor}'") print $4 '})
-  device="/dev/${device/%2/1}"
+  partno=$(echo "$device" | sed -e 's/.*[^0-9]//')
+  partno=$((partno - 1))
+  device=$(echo "$device" | sed -e 's/\(.*[^0-9]\).*/\1'"$partno"'/')
 
   echo "A new kernel version needs to be flashed onto ${device}."
   echo "Do you want to do this now? [y|N]"


### PR DESCRIPTION
The current code assumes that the installation is done to partition
number 2, and consequently that the kernel is in partition number 1. I
installed Arch on an ARM Chromebook by first resizing the ChromeOS state
partition, and them using partitions 6 and 7 from the internal MMC for
kernel and rootfs, respectively.

This change makes the code generic: if the root partition is on
/dev/xxx(N), then it will flash (or suggest the user flashes) the kernel
to /dev/xxx(N-1).