### PR TITLE
Updated polkit.rules of kodi to udisks2

### DIFF
--- a/alarm/kodi-c1/polkit.rules
+++ b/alarm/kodi-c1/polkit.rules
@@ -5,7 +5,7 @@ polkit.addRule(function(action, subject) {
         if (action.id.indexOf("org.freedesktop.login1.") == 0) {
             return polkit.Result.YES;
         }
-        if (action.id.indexOf("org.freedesktop.udisks.") == 0) {
+        if (action.id.indexOf("org.freedesktop.udisks2.") == 0) {
             return polkit.Result.YES;
         }
         if (action.id.indexOf("org.freedesktop.upower.") == 0) {

--- a/alarm/kodi-c2/polkit.rules
+++ b/alarm/kodi-c2/polkit.rules
@@ -5,7 +5,7 @@ polkit.addRule(function(action, subject) {
         if (action.id.indexOf("org.freedesktop.login1.") == 0) {
             return polkit.Result.YES;
         }
-        if (action.id.indexOf("org.freedesktop.udisks.") == 0) {
+        if (action.id.indexOf("org.freedesktop.udisks2.") == 0) {
             return polkit.Result.YES;
         }
         if (action.id.indexOf("org.freedesktop.upower.") == 0) {

--- a/alarm/kodi-imx/polkit.rules
+++ b/alarm/kodi-imx/polkit.rules
@@ -5,7 +5,7 @@ polkit.addRule(function(action, subject) {
         if (action.id.indexOf("org.freedesktop.login1.") == 0) {
             return polkit.Result.YES;
         }
-        if (action.id.indexOf("org.freedesktop.udisks.") == 0) {
+        if (action.id.indexOf("org.freedesktop.udisks2.") == 0) {
             return polkit.Result.YES;
         }
     }

--- a/alarm/kodi-odroid/polkit.rules
+++ b/alarm/kodi-odroid/polkit.rules
@@ -5,7 +5,7 @@ polkit.addRule(function(action, subject) {
         if (action.id.indexOf("org.freedesktop.login1.") == 0) {
             return polkit.Result.YES;
         }
-        if (action.id.indexOf("org.freedesktop.udisks.") == 0) {
+        if (action.id.indexOf("org.freedesktop.udisks2.") == 0) {
             return polkit.Result.YES;
         }
         if (action.id.indexOf("org.freedesktop.upower.") == 0) {

--- a/alarm/kodi-rbp-git/polkit.rules
+++ b/alarm/kodi-rbp-git/polkit.rules
@@ -5,7 +5,7 @@ polkit.addRule(function(action, subject) {
         if (action.id.indexOf("org.freedesktop.login1.") == 0) {
             return polkit.Result.YES;
         }
-        if (action.id.indexOf("org.freedesktop.udisks.") == 0) {
+        if (action.id.indexOf("org.freedesktop.udisks2.") == 0) {
             return polkit.Result.YES;
         }
     }

--- a/alarm/kodi-rbp/polkit.rules
+++ b/alarm/kodi-rbp/polkit.rules
@@ -5,7 +5,7 @@ polkit.addRule(function(action, subject) {
         if (action.id.indexOf("org.freedesktop.login1.") == 0) {
             return polkit.Result.YES;
         }
-        if (action.id.indexOf("org.freedesktop.udisks.") == 0) {
+        if (action.id.indexOf("org.freedesktop.udisks2.") == 0) {
             return polkit.Result.YES;
         }
     }

--- a/alarm/kodi-rbp3/polkit.rules
+++ b/alarm/kodi-rbp3/polkit.rules
@@ -5,7 +5,7 @@ polkit.addRule(function(action, subject) {
         if (action.id.indexOf("org.freedesktop.login1.") == 0) {
             return polkit.Result.YES;
         }
-        if (action.id.indexOf("org.freedesktop.udisks.") == 0) {
+        if (action.id.indexOf("org.freedesktop.udisks2.") == 0) {
             return polkit.Result.YES;
         }
     }


### PR DESCRIPTION
Udisks is needed for auto mounting USB drives with Kodi. Development of udisks has ceased in favor of udisks2 and Arch Linux only supports udisks2 in the main repository [1]. Kodi 18 supports udisks2 [2, 3] and hence the polkit rules should be adapted.

Tested with alarm/kodi-rbp on a Raspberry Pi 2.

[1] https://wiki.archlinux.org/index.php/udisks
[2] https://trac.kodi.tv/ticket/17560
[3] https://github.com/xbmc/xbmc/pull/13897