### PR TITLE
Enable pcie0 for the RockPro64 in the linux-aarch64 Kernel

### DIFF
--- a/core/linux-aarch64/0006-arm64-dts-rockchip-enable-pcie0-on-rockpro64.patch
+++ b/core/linux-aarch64/0006-arm64-dts-rockchip-enable-pcie0-on-rockpro64.patch
@@ -1,0 +1,46 @@
+From b877cf912da84c519a1dee7e949b90818405c9bd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kamil=20Trzci=C5=84ski?= <ayufan@ayufan.eu>
+Date: Wed, 6 Mar 2019 11:06:58 +0100
+Subject: [PATCH] ayufan: dts: rockpro64: add pcie0
+
+Change-Id: I2b4aa9d85195611475b6dee90173a17299b62244
+---
+ .../boot/dts/rockchip/rk3399-rockpro64.dts     | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
+index 9c632e7f3b015b..d58981eee6e271 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
+@@ -125,8 +125,8 @@
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&pcie_pwr_en>;
+ 		regulator-name = "vcc3v3_pcie";
+-		regulator-always-on;
+-		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
+ 		vin-supply = <&dc_12v>;
+ 	};
+ 
+@@ -543,6 +543,20 @@
+ 	gpio1830-supply = <&vcc_3v0>;
+ };
+ 
++&pcie_phy {
++	status = "okay";
++};
++
++&pcie0 {
++	ep-gpios = <&gpio2 RK_PD4 GPIO_ACTIVE_HIGH>;
++	num-lanes = <4>;
++	max-link-speed = <2>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie_clkreqn_cpm>;
++	vpcie3v3-supply = <&vcc3v3_pcie>;
++	status = "okay";
++};
++
+ &pmu_io_domains {
+ 	pmu1830-supply = <&vcc_3v0>;
+ 	status = "okay";

--- a/core/linux-aarch64/PKGBUILD
+++ b/core/linux-aarch64/PKGBUILD
@@ -21,6 +21,7 @@ source=("http://www.kernel.org/pub/linux/kernel/v5.x/${_srcname}.tar.xz"
         '0003-arm64-dts-rockchip-add-usb3-controller-node-for-RK33.patch'
         '0004-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-rock6.patch'
         '0005-arm64-dts-rockchip-Fix-vcc_host1_5v-GPIO-polarity-on.patch'
+        '0006-arm64-dts-rockchip-enable-pcie0-on-rockpro64.patch'
         'config'
         'kernel.its'
         'kernel.keyblock'
@@ -35,6 +36,7 @@ md5sums=('7381ce8aac80a01448e065ce795c19c0'
          'dc8ec5415f6a1af425316c310f747fa7'
          '4477684c49622c88884efb4bb7aeb3a3'
          'fc1413b1931091271449b9d78a05c984'
+         '37d1bc0991c93aebabad668af36c7e56'
          'e41e01df9506750e5c68d85b7b7d4cf7'
          '7f1a96e24f5150f790df94398e9525a3'
          '61c5ff73c136ed07a7aadbf58db3d96a'
@@ -55,6 +57,7 @@ prepare() {
   git apply ../0003-arm64-dts-rockchip-add-usb3-controller-node-for-RK33.patch
   git apply ../0004-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-rock6.patch
   git apply ../0005-arm64-dts-rockchip-Fix-vcc_host1_5v-GPIO-polarity-on.patch
+  git apply ../0006-arm64-dts-rockchip-enable-pcie0-on-rockpro64.patch
 
   cat "${srcdir}/config" > ./.config
 


### PR DESCRIPTION
I realize the RockPro64 isn't technically a supported device as of now, but there are lots of people who use it with Arch Linux. This PR enables the PCI Express bus, which is currently disabled upstream. Enabling this allows you to use an NVMe device for your rootfs for example, or use really any PCIe x4 (or slower) device for that matter.

Credit for this patch goes to ayufan for the work they have been doing for this (and other) Pine64 devices. Their full kernel repo is located here for reference: https://github.com/ayufan-rock64/linux-mainline-kernel

It should be noted that this change is strictly a dts change, and only for the RockPro64 as can be seen via the diff.