### PR TITLE
kodi-c1: bump release number (libcdio)

### DIFF
--- a/alarm/kodi-c1/PKGBUILD
+++ b/alarm/kodi-c1/PKGBUILD
@@ -23,7 +23,7 @@
 buildarch=4
 pkgbase=kodi-c1
 pkgname=('kodi-c1' 'kodi-c1-eventclients' 'kodi-c1-tools-texturepacker' 'kodi-c1-dev')
-pkgver=17.6
+pkgver=17.7
 _commit=094825c86d4995bef81419cd80dab0f2ed95eb79
 pkgrel=4
 arch=('armv7h')


### PR DESCRIPTION
Rebuild against new libcdio: https://archlinuxarm.org/packages/armv7h/libcdio/log?id=ece9f5ba05eb0cde776bbeb53b98fe57533498ae
```
/usr/lib/kodi/kodi.bin: error while loading shared libraries: libcdio.so.18: cannot open shared object file: No such file or directory
```