### PR TITLE
added community/gitlab-runner

### DIFF
--- a/community/gitlab-runner/PKGBUILD
+++ b/community/gitlab-runner/PKGBUILD
@@ -1,0 +1,76 @@
+# Maintainer: Sven-Hendrik Haase <sh@lutzhaase.com>
+# Contributor: Lubomir 'Kuci' Kucera <kuci24-at-gmail-dot-com>
+
+# ALARM: Alexander Eisele <alexander@eiselecloud.de>
+#  - add _pkgarch variable for build and output filename instead of static arm64
+
+buildarch=4
+
+pkgname=gitlab-runner
+pkgver=11.10.0
+pkgrel=1
+pkgdesc="The official GitLab CI runner written in Go"
+arch=('x86_64' 'armv7h')
+url='https://gitlab.com/gitlab-org/gitlab-runner'
+license=('GPL3')
+depends=('ca-certificates' 'curl' 'git' 'glibc' 'tar')
+makedepends=('git' 'go-pie' 'git' 'mercurial')
+install='gitlab-runner.install'
+replaces=('gitlab-ci-multi-runner')
+backup=('etc/gitlab-runner/config.toml')
+noextract=("prebuilt-${pkgver}-x86_64.tar.xz"
+           "prebuilt-${pkgver}-arm.tar.xz")
+
+source=("$pkgname-$pkgver.tar.gz::https://gitlab.com/api/v4/projects/gitlab-org%2Fgitlab-runner/repository/archive?sha=v${pkgver}"
+        "prebuilt-${pkgver}-x86_64.tar.xz::https://gitlab-runner-downloads.s3.amazonaws.com/v${pkgver}/helper-images/prebuilt-x86_64.tar.xz"
+        "prebuilt-${pkgver}-arm.tar.xz::https://gitlab-runner-downloads.s3.amazonaws.com/v${pkgver}/helper-images/prebuilt-arm.tar.xz"
+        "gitlab-runner.service"
+        "gitlab-runner.sysusers"
+        "gitlab-runner.tmpfiles"
+        "config.toml")
+sha512sums=('794c4891676640234fe7cb6195021fad8a2c92fc20fcaac468b560d8b0cbc2088df0c497c1ba6674d1582235096694eaf0a757747e1e407a77beb15126234f61'
+            'f634cab44d1de577694fd8888001871a656556a80ab149ee3ce8e60fce345d335332b14f2419a060849d668185a025d8fa2ec4faad02592dad656b41d1c22f49'
+            'e206360a544d3e69cf259f29f0011248933f1ab135042de93bb38c58436ad79ca08da9a9b10928fc493f0004859f26e4585cc6ea354c823dfe0657499dd7643e'
+            '8a5a8b7654d3864722e784b2814c6278c17876f1c0c4fc0676fbcf6817ad2ba4be55501e67ce88c62b5b63ca886b01afc6feac98ba49842acd244abdd1a8296f'
+            '8aa7f08702e99053c696fcc2aaba83beb9e9cd6f31973d82862db9350ac46df3a095377625d31fe909677525290d2de922d7a97930ed235774cb8f0da8944d40'
+            '6751d9fa0b27172d1b419c4138f5ac15cbc7c9147653a7258cf1470216142c637210bb60608c7ed0974e0e4057e5ddeae32225df1bb36e7dd1f20fec71e33cc3'
+            'f39c23fc06636f31c3fadb9a630c54527e8255098f18d275772cb30875d0a7463717101704070d432f2b69ab71f076a9538172a439bc307722dad2c7e260f752')
+
+_srcdir="gitlab-runner-v${pkgver}-"
+case $CARCH in
+    x86_64) _pkgarch="amd64";;
+    armv7h) _pkgarch="arm";;
+esac
+
+prepare() {
+    local revision=$(ls -d ${_srcdir}* | rev | cut -c 33-40 | rev)
+
+    mkdir -p "${srcdir}/src/gitlab.com/gitlab-org/"
+    ln -sf "${srcdir}/${_srcdir}"* "${srcdir}/src/gitlab.com/gitlab-org/gitlab-runner"
+    cd "${srcdir}/src/gitlab.com/gitlab-org/gitlab-runner"
+
+    local version=$(cat VERSION)
+
+    sed -i "s/export VERSION.*/export VERSION = $version/" Makefile
+    sed -i "s/REVISION := .*/REVISION := $revision/" Makefile
+
+    make version
+
+    ln -sf "${srcdir}/prebuilt-${pkgver}-x86_64.tar.xz" prebuilt-x86_64.tar.xz
+    ln -sf "${srcdir}/prebuilt-${pkgver}-arm.tar.xz" prebuilt-arm.tar.xz
+}
+
+build() {
+    cd "${srcdir}/src/gitlab.com/gitlab-org/gitlab-runner"
+    make BUILD_PLATFORMS="-osarch linux/${_pkgarch}" build;
+}
+
+package() {
+    cd "${srcdir}/src/gitlab.com/gitlab-org/gitlab-runner"
+
+    install -Dm644 "${srcdir}/config.toml" "${pkgdir}/etc/gitlab-runner/config.toml"
+    install -Dm644 "${srcdir}/gitlab-runner.service" "${pkgdir}/usr/lib/systemd/system/gitlab-runner.service"
+    install -Dm644 "${srcdir}/gitlab-runner.sysusers" "${pkgdir}/usr/lib/sysusers.d/gitlab-runner.conf"
+    install -Dm644 "${srcdir}/gitlab-runner.tmpfiles" "${pkgdir}/usr/lib/tmpfiles.d/gitlab-runner.conf"
+    install -Dm755 "out/binaries/gitlab-runner-linux-${_pkgarch}" "${pkgdir}/usr/bin/gitlab-runner"
+}

--- a/community/gitlab-runner/config.toml
+++ b/community/gitlab-runner/config.toml
@@ -1,0 +1,1 @@
+concurrent = 4

--- a/community/gitlab-runner/gitlab-runner.install
+++ b/community/gitlab-runner/gitlab-runner.install
@@ -1,0 +1,6 @@
+post_install() {
+  echo "Register the runner as root using"
+  echo "# gitlab-ci-multi-runner register"
+  echo "Configure the runner in /etc/gitlab-runner/config.toml"
+  echo "Use gitlab-runner.service to control the runner"
+}

--- a/community/gitlab-runner/gitlab-runner.service
+++ b/community/gitlab-runner/gitlab-runner.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=GitLab Runner
+After=syslog.target network.target
+ConditionFileIsExecutable=/usr/bin/gitlab-runner
+
+[Service]
+StartLimitInterval=5
+StartLimitBurst=10
+ExecStart=/usr/bin/gitlab-runner "run" "--working-directory" "/var/lib/gitlab-runner" "--config" "/etc/gitlab-runner/config.toml" "--service" "gitlab-runner" "--user" "gitlab-runner"
+Restart=always
+RestartSec=120
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=gitlab-runner
+
+[Install]
+WantedBy=multi-user.target

--- a/community/gitlab-runner/gitlab-runner.sysusers
+++ b/community/gitlab-runner/gitlab-runner.sysusers
@@ -1,0 +1,1 @@
+u gitlab-runner   107      "GitLab Runner" /var/lib/gitlab-runner

--- a/community/gitlab-runner/gitlab-runner.tmpfiles
+++ b/community/gitlab-runner/gitlab-runner.tmpfiles
@@ -1,0 +1,1 @@
+d /var/lib/gitlab-runner 0700 gitlab-runner gitlab-runner -


### PR DESCRIPTION
The existing package _gitlab-ci-multi-runner_ is outdated for over 2 years and replaced by _gitlab-runner_ in the x86_64 repos. My changes add cross architecture compatibility.