### PR TITLE
core/nfs-utils: Fix mountd segfault

### DIFF
--- a/core/nfs-utils/0002-fix-mountd-crash.patch
+++ b/core/nfs-utils/0002-fix-mountd-crash.patch
@@ -1,0 +1,90 @@
+
+    Subject: [PATCH v2] Fix mountd segfault
+    From: Chuck Lever <chuck.lever@xxxxxxxxxx>
+    Date: Tue, 14 May 2019 11:10:15 -0400
+    User-agent: StGit/0.17.1-dirty
+
+After commit 8f459a072f93 ("Remove abuse of ai_canonname") the
+ai_canonname field in addrinfo structs returned from
+host_reliable_addrinfo() is always NULL. This results in mountd
+segfaults when there are netgroups or hostname wildcards in
+/etc/exports.
+
+Add an extra DNS query in check_wildcard() and check_netgroup() to
+obtain the client's canonical hostname instead of dereferencing
+the NULL pointer.
+
+Reported-by: Mark Wagner <mark@xxxxxxxxxxx>
+Fixes: 8f459a072f93 ("Remove abuse of ai_canonname")
+Signed-off-by: Chuck Lever <chuck.lever@xxxxxxxxxx>
+---
+
+Changes since v1:
+- Added similar fix for check_netgroup
+- Restructured exit/error paths in check_wildcard
+
+ support/export/client.c |   32 +++++++++++++++++++++-----------
+ 1 file changed, 21 insertions(+), 11 deletions(-)
+
+diff --git a/support/export/client.c b/support/export/client.c
+index a1fba01..ea4f89d 100644
+--- a/support/export/client.c
++++ b/support/export/client.c
+@@ -608,24 +608,36 @@ check_subnetwork(const nfs_client *clp, const struct addrinfo *ai)
+ static int
+ check_wildcard(const nfs_client *clp, const struct addrinfo *ai)
+ {
+-	char *cname = clp->m_hostname;
+-	char *hname = ai->ai_canonname;
++	char *hname, *cname = clp->m_hostname;
+ 	struct hostent *hp;
+ 	char **ap;
++	int match;
+ 
+-	if (wildmat(hname, cname))
+-		return 1;
++	match = 0;
++
++	hname = host_canonname(ai->ai_addr);
++	if (hname == NULL)
++		goto out;
++
++	if (wildmat(hname, cname)) {
++		match = 1;
++		goto out;
++	}
+ 
+ 	/* See if hname aliases listed in /etc/hosts or nis[+]
+ 	 * match the requested wildcard */
+ 	hp = gethostbyname(hname);
+ 	if (hp != NULL) {
+ 		for (ap = hp->h_aliases; *ap; ap++)
+-			if (wildmat(*ap, cname))
+-				return 1;
++			if (wildmat(*ap, cname)) {
++				match = 1;
++				goto out;
++			}
+ 	}
+ 
+-	return 0;
++out:
++	free(hname);
++	return match;
+ }
+ 
+ /*
+@@ -645,11 +657,9 @@ check_netgroup(const nfs_client *clp, const struct addrinfo *ai)
+ 
+ 	match = 0;
+ 
+-	hname = strdup(ai->ai_canonname);
+-	if (hname == NULL) {
+-		xlog(D_GENERAL, "%s: no memory for strdup", __func__);
++	hname = host_canonname(ai->ai_addr);
++	if (hname == NULL)
+ 		goto out;
+-	}
+ 
+ 	/* First, try to match the hostname without
+ 	 * splitting off the domain */

--- a/core/nfs-utils/PKGBUILD
+++ b/core/nfs-utils/PKGBUILD
@@ -11,7 +11,7 @@
 pkgbase=nfs-utils
 pkgname=('nfs-utils' 'nfsidmap')
 pkgver=2.3.4
-pkgrel=1
+pkgrel=2
 arch=('x86_64')
 url='http://nfs.sourceforge.net'
 makedepends=('libevent' 'sqlite' 'rpcsvc-proto')
@@ -19,19 +19,22 @@ makedepends=('libevent' 'sqlite' 'rpcsvc-proto')
 source=(https://www.kernel.org/pub/linux/utils/${pkgname}/${pkgver}/${pkgname}-${pkgver}.tar.{xz,sign}
         id_resolver.conf
         exports
-        0001-32-bit-compat.patch)
+        0001-32-bit-compat.patch
+        0002-fix-mountd-crash.patch)
 # https://www.kernel.org/pub/linux/utils/nfs-utils/2.1.1/sha256sums.asc
 sha256sums=('f8328ba386087a9926edd89f78a319ff55418a0e734dbf5f50350f465f0896cd'
             'SKIP'
             'ed31ae843cf66d3c262b39ed54533a861876231c5f5bb3811c0c498ac2ffa102'
             '610715ed3daedc43b2536f541c7c57e138fb31eab5d837d9a6187a7403e30154'
-            'a74d704d2b853400b26c261fdf880912d0645a1a592c1e69a9d86a6505ee1f1d')
+            'a74d704d2b853400b26c261fdf880912d0645a1a592c1e69a9d86a6505ee1f1d'
+            'b806392a29852322d084d408be45f49d521c15b09662b848507690d145775395')
 validpgpkeys=('E1B71E339E20A10A676F7CB69AFB1D681A125177') # Steve Dickson
 
 prepare() {
   cd ${pkgbase}-${pkgver}
 
   [[ $CARCH != "aarch64" ]] && patch -p1 -i ../0001-32-bit-compat.patch
+  patch -p1 -i ../0002-fix-mountd-crash.patch
  
   # fix hardcoded sbin path to our needs
   sed -i "s|sbindir = /sbin|sbindir = /usr/bin|g" utils/*/Makefile.am


### PR DESCRIPTION
Add patch from linux-nfs@vger.kernel.org that fixes a mountd
segfault when there are netgroups or hostname wildcards in
/etc/exports.