### PR TITLE
extra/bind: Re-enable armv5 now that upstream fixed the build

### DIFF
--- a/extra/bind/PKGBUILD
+++ b/extra/bind/PKGBUILD
@@ -7,8 +7,6 @@
 #  - !makeflags - bind build doesn't like concurrency
 #  - build v6 as armv6kz
 
-buildarch=28
-
 pkgbase=bind
 pkgname=(bind bind-tools)
 _pkgver=9.14.3


### PR DESCRIPTION
Build of extra/bind for armv5 was broken since v9.13.4, and was disabled in f3ff0f41d
The 9.14.3 upstream release fixed the build on armv5.
This pull request removes the `buildarch`variable to build extra/bind on all platforms.
Since there is no change other than the selection of platforms to build for, I did not see fit to increment the `pkgrel` variable.
I was able to build bind and bind-tools for armv5, and run `named` successfully.