### PR TITLE
add kodi-rbp4 18.3-1 (no hw acceleration)

### DIFF
--- a/alarm/kodi-rbp4/99-kodi.rules
+++ b/alarm/kodi-rbp4/99-kodi.rules
@@ -1,0 +1,4 @@
+SUBSYSTEM=="bcm2708_vcio",GROUP="video",MODE="0660"
+SUBSYSTEM=="vc-sm",GROUP="video",MODE="0660"
+SUBSYSTEM=="vchiq",GROUP="video",MODE="0660"
+SUBSYSTEM=="tty", KERNEL=="tty[0-9]*", GROUP="tty", MODE="0660"

--- a/alarm/kodi-rbp4/PKGBUILD
+++ b/alarm/kodi-rbp4/PKGBUILD
@@ -1,0 +1,259 @@
+# vim:set ts=2 sw=2 et:
+# Contributor: graysky <graysky AT archlinux DOT us>
+# Contributor: BlackIkeEagle < ike DOT devolder AT gmail DOT com >
+# Contributor: Oleg Rakhmanov <oleg [at] archlinuxarm [dot] com>
+# Contributor: tomasgroth at yahoo.dk
+# Contributor: WarheadsSE <max@warheads.net>
+# Contributor: Adrian Fedoreanu <adrian [dot] fedoreanu [at] gmail [dot] com>
+# Contributor: Sergej Pupykin <pupykin.s+arch@gmail.com>
+# Contributor: DonVla <donvla@users.sourceforge.net>
+# Contributor: Ulf Winkelvos <ulf [at] winkelvos [dot] de>
+# Contributor: Ralf Barth <archlinux dot org at haggy dot org>
+# Contributor: B & monty - Thanks for your hints :)
+# Contributor: marzoul
+# Contributor: Sergej Pupykin <pupykin.s+arch@gmail.com>
+# Contributor: Brad Fanella <bradfanella@archlinux.us>
+# Contributor: [vEX] <niechift.dot.vex.at.gmail.dot.com>
+# Contributor: Zeqadious <zeqadious.at.gmail.dot.com>
+# Contributor: Bartłomiej Piotrowski <bpiotrowski@archlinux.org>
+# Contributor: Maxime Gauduin <alucryd@gmail.com>
+
+buildarch=4
+
+_prefix=/usr
+
+pkgbase=kodi-rbp4
+pkgname=('kodi-rbp4' 'kodi-rbp4-eventclients' 'kodi-rbp4-tools-texturepacker' 'kodi-rbp4-dev')
+pkgver=18.3
+pkgrel=1
+_codename=Leia
+_tag="18.3-$_codename"
+_ffmpeg_version="4.0.3-$_codename-18.2"
+_libdvdcss_version="1.4.2-$_codename-Beta-5"
+_libdvdnav_version="6.0.0-$_codename-Alpha-3"
+_libdvdread_version="6.0.0-$_codename-Alpha-3"
+_fmt_version="5.1.0"
+_crossguid_version="8f399e8bd4"
+_fstrcmp_version="0.7.D001"
+_flatbuffers_version="1.9.0"
+arch=('armv7h')
+url="https://kodi.tv"
+license=('GPL2')
+makedepends=(
+  'afpfs-ng' 'bluez-libs' 'cmake' 'curl' 'doxygen' 'glew'
+  'gperf' 'hicolor-icon-theme' 'java-runtime' 'libaacs' 'libass'
+  'libbluray' 'libcdio' 'libcec-rpi' 'libgl' 'mariadb-libs' 'libmicrohttpd'
+  'libmodplug' 'libmpeg2' 'libnfs' 'libplist' 'libpulse' 'libva'
+  'libvdpau' 'libxrandr' 'libxslt' 'lirc' 'lzo' 'mesa' 'nasm'
+  'python2-pycryptodome' 'python2-pillow' 'python2-pybluez' 'python2-simplejson'
+  'shairplay' 'smbclient' 'taglib' 'tinyxml' 'swig'
+  'upower' 'giflib' 'rapidjson' 'ghostscript'
+  'libinput' 'libxkbcommon'
+)
+source=(https://github.com/xbmc/xbmc/archive/18.3-Leia.tar.gz
+  'kodi.service'
+  '99-kodi.rules'
+  'polkit.rules'
+  '00-fix.building.with.mariadb.patch::https://github.com/wsnipex/xbmc/commit/cd20c8eb8a0394db1f028b118c4ca9b91b7e746a.patch'
+  "ffmpeg-$_ffmpeg_version.tar.gz::https://github.com/xbmc/FFmpeg/archive/$_ffmpeg_version.tar.gz"
+  "libdvdcss-$_libdvdcss_version.tar.gz::https://github.com/xbmc/libdvdcss/archive/$_libdvdcss_version.tar.gz"
+  "libdvdnav-$_libdvdnav_version.tar.gz::https://github.com/xbmc/libdvdnav/archive/$_libdvdnav_version.tar.gz"
+  "libdvdread-$_libdvdread_version.tar.gz::https://github.com/xbmc/libdvdread/archive/$_libdvdread_version.tar.gz"
+  "http://mirrors.kodi.tv/build-deps/sources/fmt-$_fmt_version.tar.gz"
+  "http://mirrors.kodi.tv/build-deps/sources/crossguid-$_crossguid_version.tar.gz"
+  "http://mirrors.kodi.tv/build-deps/sources/fstrcmp-$_fstrcmp_version.tar.gz"
+  "http://mirrors.kodi.tv/build-deps/sources/flatbuffers-$_flatbuffers_version.tar.gz"
+)
+noextract=(
+  "libdvdcss-$_libdvdcss_version.tar.gz"
+  "libdvdnav-$_libdvdnav_version.tar.gz"
+  "libdvdread-$_libdvdread_version.tar.gz"
+  "ffmpeg-$_ffmpeg_version.tar.gz"
+  "fmt-$_fmt_version.tar.gz"
+  "crossguid-$_crossguid_version.tar.gz"
+  "fstrcmp-$_fstrcmp_version.tar.gz"
+  "flatbuffers-$_flatbuffers_version.tar.gz"
+)
+sha256sums=('4f265901c00f582beb8d6ad96c9c303e5ab82611e828c7121ae822b07c0915cc'
+            '585796d8a7f1ece32c24ff67b38885f0e3397372a4b9879eee3160a59391e333'
+            'b31570f95654434b01fd8531612fbb6be77cbc1c519dd60f92feae26eb160f3d'
+            '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96'
+            '849daf1d5b081ef6d0e428bbc7d448799fc43a8ac9e79cd7513de0eb5a91b0bb'
+            '68535cc2a000946b62ce4be6edf7dda7900bd524f22bcb826800b94f4a873314'
+            '38816f8373e243bc5950449b4f3b18938c4e1c59348e3411e23f31db4072e40d'
+            '071e414e61b795f2ff9015b21a85fc009dde967f27780d23092643916538a57a'
+            'a30b6aa0aad0f2c505bc77948af2d5531a80b6e68112addb4c123fca24d5d3bf'
+            '73d4cab4fa8a3482643d8703de4d9522d7a56981c938eca42d929106ff474b44'
+            '3d77d09a5df0de510aeeb940df4cb534787ddff3bb1828779753f5dfa1229d10'
+            'e4018e850f80700acee8da296e56e15b1eef711ab15157e542e7d7e1237c3476'
+            '5ca5491e4260cacae30f1a5786d109230db3f3a6e5a0eb45d0d0608293d247e3')
+
+prepare() {
+  # force python 'binary' as python2
+  [[ -d "$srcdir/path" ]] && rm -rf "$srcdir/path"
+  mkdir "$srcdir/path"
+  ln -s /usr/bin/python2 "$srcdir/path/python"
+
+  [[ -d kodi-build ]] && rm -rf kodi-build
+  mkdir $srcdir/kodi-build
+
+  cd "xbmc-$pkgver-$_codename"
+  patch -Np1 -i ../00-fix.building.with.mariadb.patch
+}
+
+build() {
+  export PATH="$srcdir/path:$PATH"
+
+  cd kodi-build
+
+  # building for RPi4
+  unset CFLAGS CXXFLAGS
+  CFLAGS=" -march=armv8-a+crc -mfpu=neon-fp-armv8 -mcpu=cortex-a72 -mfloat-abi=hard -O2 -pipe -fstack-protector-strong -fno-plt"
+  CXXFLAGS="${CFLAGS}"
+
+  cmake -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+    -DENABLE_EVENTCLIENTS=ON \
+    -DENABLE_OPENGL=OFF \
+    -DENABLE_INTERNAL_FFMPEG=ON \
+    -DENABLE_INTERNAL_FMT=ON \
+    -DENABLE_INTERNAL_CROSSGUID=ON \
+    -DENABLE_INTERNAL_FSTRCMP=ON \
+    -DENABLE_INTERNAL_FLATBUFFERS=ON \
+    -DENABLE_VAAPI=OFF \
+    -DENABLE_VDPAU=OFF \
+    -DENABLE_MARIADBCLIENT=ON \
+    -DENABLE_MYSQLCLIENT=OFF \
+    -Dlibdvdcss_URL="$srcdir/libdvdcss-$_libdvdcss_version.tar.gz" \
+    -Dlibdvdnav_URL="$srcdir/libdvdnav-$_libdvdnav_version.tar.gz" \
+    -Dlibdvdread_URL="$srcdir/libdvdread-$_libdvdread_version.tar.gz" \
+    -DFFMPEG_URL="$srcdir/ffmpeg-$_ffmpeg_version.tar.gz" \
+    -DFMT_URL="$srcdir/fmt-$_fmt_version.tar.gz" \
+    -DCROSSGUID_URL="$srcdir/crossguid-$_crossguid_version.tar.gz" \
+    -DFSTRCMP_URL="$srcdir/fstrcmp-$_fstrcmp_version.tar.gz" \
+    -DFLATBUFFERS_URL="$srcdir/flatbuffers-$_flatbuffers_version.tar.gz" \
+    -DCORE_PLATFORM_NAME=gbm \
+    -DGBM_RENDER_SYSTEM=gles \
+    ../"xbmc-$pkgver-$_codename"
+  make
+  make preinstall
+}
+
+package_kodi-rbp4() {
+  pkgdesc="A software media player and entertainment hub for digital media (Raspberry Pi 4)"
+  depends=(
+    'desktop-file-utils' 'hicolor-icon-theme' 'mesa' 'python2-pycryptodome'
+    'python2-pillow' 'python2-simplejson' 'xorg-xdpyinfo'
+    'bluez-libs' 'curl' 'lcms2' 'libass' 'libbluray' 'libcdio' 'libcec-rpi'
+    'libinput' 'libmicrohttpd' 'libnfs' 'libpulse' 'libva' 'libxkbcommon'
+    'libxslt' 'lirc' 'mariadb-libs' 'python2' 'smbclient' 'taglib'
+    'tinyxml' 'polkit'
+  )
+  optdepends=(
+    'afpfs-ng: Apple shares support'
+    'bluez: Blutooth support'
+    'python2-pybluez: Bluetooth support'
+    'libplist: AirPlay support'
+    'pulseaudio: PulseAudio support'
+    'shairplay: Limited AirPlay support'
+    'upower: Display battery level'
+  )
+  install='kodi.install'
+  provides=('xbmc' 'kodi')
+  conflicts=('xbmc' 'kodi' 'arm-mem-git' 'shairplay-git')
+  replaces=('xbmc-rbp-git')
+  _components=('kodi' 'kodi-bin')
+
+  export PATH="$srcdir/path:$PATH"
+
+  cd kodi-build
+  for _cmp in ${_components[@]}; do
+  DESTDIR="$pkgdir" /usr/bin/cmake \
+    -DCMAKE_INSTALL_COMPONENT="$_cmp" \
+     -P cmake_install.cmake
+  done
+
+  # python2 is being used
+  cd "$pkgdir"
+  grep -lR '#!.*python' * | \
+    while read file; do sed -s 's/\(#!.*python\)/\12/g' -i "$file"; done
+
+  install -Dm755 $srcdir/kodi-build/kodi-gbm "$pkgdir/usr/lib/kodi/kodi-gbm"
+  install -Dm0644 "$srcdir/kodi.service" "$pkgdir/usr/lib/systemd/system/kodi.service"
+  install -Dm0644 "$srcdir/polkit.rules" "$pkgdir/usr/share/polkit-1/rules.d/10-kodi.rules"
+  chmod 0750 "$pkgdir/usr/share/polkit-1/rules.d/"
+
+  # fix permissions necessary for accelerated video playback
+  install -Dm0644 "$srcdir/99-kodi.rules" "$pkgdir/etc/udev/rules.d/99-kodi.rules"
+}
+
+package_kodi-rbp4-eventclients() {
+  pkgdesc="Kodi Event Clients (Raspberry Pi4)"
+  provides=('kodi-eventclients')
+  conflicts=('kodi-eventclients')
+  optdepends=('python2: most eventclients are implemented in python2')
+
+  _components=(
+    'kodi-eventclients-common'
+    'kodi-eventclients-ps3'
+    'kodi-eventclients-kodi-send'
+  )
+
+  export PATH="$srcdir/path:$PATH"
+
+  cd kodi-build
+  for _cmp in ${_components[@]}; do
+    DESTDIR="$pkgdir" /usr/bin/cmake \
+      -DCMAKE_INSTALL_COMPONENT="$_cmp" \
+      -P cmake_install.cmake
+  done
+
+  # python2 is being used
+  cd "$pkgdir"
+  grep -lR '#!.*python' * | \
+    while read file; do sed -s 's/\(#!.*python\)/\12/g' -i "$file"; done
+}
+
+package_kodi-rbp4-tools-texturepacker() {
+  pkgdesc="Kodi Texturepacker tool (Raspberry Pi4)"
+  depends=('libpng' 'giflib' 'libjpeg-turbo' 'lzo')
+  _components=('kodi-tools-texturepacker')
+
+  cd kodi-build
+  # install eventclients
+  for _cmp in ${_components[@]}; do
+    DESTDIR="$pkgdir" /usr/bin/cmake \
+      -DCMAKE_INSTALL_COMPONENT="$_cmp" \
+      -P cmake_install.cmake
+  done
+}
+
+package_kodi-rbp4-dev() {
+  pkgdesc="Kodi dev files (Raspberry Pi4)"
+  depends=('kodi')
+  provides=('kodi-dev')
+
+  _components=('kodi-addon-dev'
+    'kodi-audio-dev'
+    'kodi-eventclients-dev'
+    'kodi-game-dev'
+    'kodi-inputstream-dev'
+    'kodi-peripheral-dev'
+    'kodi-pvr-dev'
+    'kodi-screensaver-dev'
+    'kodi-visualization-dev')
+
+  export PATH="$srcdir/path:$PATH"
+
+  cd kodi-build
+  for _cmp in ${_components[@]}; do
+    DESTDIR="$pkgdir" /usr/bin/cmake \
+      -DCMAKE_INSTALL_COMPONENT="$_cmp" \
+      -P cmake_install.cmake
+  done
+
+  # python2 is being used
+  cd "$pkgdir"
+  grep -lR '#!.*python' * | \
+    while read file; do sed -s 's/\(#!.*python\)/\12/g' -i "$file"; done
+}

--- a/alarm/kodi-rbp4/kodi.install
+++ b/alarm/kodi-rbp4/kodi.install
@@ -1,0 +1,26 @@
+post_install() {
+  [[ $(type -p gtk-update-icon-cache) ]] && usr/bin/gtk-update-icon-cache -qtf usr/share/icons/hicolor
+  [[ $(type -p update-desktop-database) ]] && usr/bin/update-desktop-database -q usr/share/applications
+  getent group kodi > /dev/null || groupadd -r kodi
+  getent passwd kodi > /dev/null || useradd -r -m -d /var/lib/kodi -g kodi -s /usr/bin/nologin kodi
+  usermod -a -G kodi,audio,video,power,network,optical,storage,disk,tty,input kodi
+  mkdir -p var/lib/kodi
+  chown -R kodi:kodi var/lib/kodi
+
+  echo "****************************************************************"
+  echo "Make sure the following lines are added to /boot/config.txt"
+  echo "gpu_mem=320"
+  echo "dtoverlay=vc4-fkms-v3d"
+  echo "dtparam=audio=on"
+  echo "****************************************************************"
+}
+
+post_upgrade() {
+  post_install $1
+}
+
+post_remove() {
+  [[ $(type -p gtk-update-icon-cache) ]] && usr/bin/gtk-update-icon-cache -qtf usr/share/icons/hicolor
+  [[ $(type -p update-desktop-database) ]] && usr/bin/update-desktop-database -q usr/share/applications
+  getent passwd kodi > /dev/null && userdel kodi
+}

--- a/alarm/kodi-rbp4/kodi.service
+++ b/alarm/kodi-rbp4/kodi.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Kodi standalone (GBM)
+After=systemd-user-sessions.service network.target network-online.target sound.target upower.service mysqld.service
+Requires=graphical.target
+Wants=network.target network-online.target
+Conflicts=getty@tty1.service
+
+[Service]
+User=kodi
+Group=kodi
+PAMName=login
+TTYPath=/dev/tty1
+Environment=WINDOWING=gbm
+ExecStart=/usr/bin/kodi-standalone
+Restart=on-abort
+StandardInput=tty
+
+[Install]
+WantedBy=graphical.target

--- a/alarm/kodi-rbp4/polkit.rules
+++ b/alarm/kodi-rbp4/polkit.rules
@@ -1,0 +1,12 @@
+polkit.addRule(function(action, subject) {
+    if (subject.user == "kodi") {
+        polkit.log("action=" + action);
+        polkit.log("subject=" + subject);
+        if (action.id.indexOf("org.freedesktop.login1.") == 0) {
+            return polkit.Result.YES;
+        }
+        if (action.id.indexOf("org.freedesktop.udisks.") == 0) {
+            return polkit.Result.YES;
+        }
+    }
+});


### PR DESCRIPTION
This gbm kodi package for RPi4 can only use sw decoding but does work.  I was able to playback even x265 content with it, but it does require all of the CPU to decode the sample I played.  As you know, I am working with @popcornmix to adapt his https://github.com/popcornmix/xbmc/commits/leia_pi4 fork (enables MMAL decoding for RPi4) which is what LibreLE uses, but it's not ready yet.  This would provide users with RPi4 hardware an option in the meantime.