### PR TITLE
alarm/uboot-odroid-c2-mainline to 2019.07-1

### DIFF
--- a/alarm/uboot-odroid-c2-mainline/PKGBUILD
+++ b/alarm/uboot-odroid-c2-mainline/PKGBUILD
@@ -4,7 +4,7 @@
 buildarch=8
 
 pkgname=uboot-odroid-c2-mainline
-pkgver=2018.07
+pkgver=2019.07
 pkgrel=1
 pkgdesc="Mainline U-Boot for ODROID-C2"
 arch=('aarch64')
@@ -19,7 +19,7 @@ source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver/rc/-rc}.tar.bz2"
         'sd_fusing.sh'
         'boot.txt'
         'mkscr')
-md5sums=('2b8eaa30dd118b29889669070da22bb0'
+md5sums=('73434338536c7500b4302bd0a02921ed'
          '11a49bb7e9825b05fb555ba6f2aca736'
          'c1222a54697dc5025f059024d41b9659'
          '4258258571f02d00d4b38d03b563dc2b'


### PR DESCRIPTION
**Benefits**
The recent version of U-Boot finally allows HDMI output and simple_fb handover to the Linux kernel on Odroid C2. This PR just updates the version but does not enable the video console.

**Tests done**
- Built manually on Odroid C2 via makepg and installed on Odroid C2 via pacman -U. Board still boots as with the older version. dd if=/dev/mmcblk1 bs=1M count=1 | strings | grep U-Boot shows 2019-07
- Package built using makechrootpkg -c -r "$CHROOT"
- Removed old uboot-odroid-c2-mainline via pacman -R and installed new one. Everything works.
- Removed new package via pacman -R and installed old one from repo. Rebooted and installed new one without removing the old one. Everything works.

Everything tested with MicroSD card as I don't own a eMMC module.
Tested with core/linux-aarch64 kernel only.