### PR TITLE
alarm/kodi-rbp4 to 18.3-3

### DIFF
--- a/alarm/kodi-rbp4/99-kodi.rules
+++ b/alarm/kodi-rbp4/99-kodi.rules
@@ -1,5 +1,6 @@
 SUBSYSTEM=="bcm2835-gpiomem", GROUP="gpio", MODE="0660"
 SUBSYSTEM=="bcm2708_vcio",GROUP="video",MODE="0660"
+SUBSYSTEM=="rpivid-*", GROUP="video", MODE="0660"
 SUBSYSTEM=="argon-*", GROUP="video", MODE="0660"
 SUBSYSTEM=="vc-sm",GROUP="video",MODE="0660"
 SUBSYSTEM=="vchiq",GROUP="video",MODE="0660"

--- a/alarm/kodi-rbp4/PKGBUILD
+++ b/alarm/kodi-rbp4/PKGBUILD
@@ -26,7 +26,7 @@ _prefix=/usr
 pkgbase=kodi-rbp4
 pkgname=('kodi-rbp4' 'kodi-rbp4-eventclients' 'kodi-rbp4-tools-texturepacker' 'kodi-rbp4-dev')
 pkgver=18.3
-pkgrel=2
+pkgrel=3
 _codename=Leia
 _tag="18.3-$_codename"
 _ffmpeg_version="4.0.3-$_codename-18.2"
@@ -85,7 +85,7 @@ noextract=(
 )
 sha256sums=('38b4b3d431fe76670bf74d8fea659c7244a5ddd927a4d703250e347a924eb798'
             '585796d8a7f1ece32c24ff67b38885f0e3397372a4b9879eee3160a59391e333'
-            '23db962574ac1f5b891502d6d627c004050023138b5819c257de0eb47f36133f'
+            '8e14cf455898246d11edd4ff7f4ed11a44c729fb40c34455a5b336a90ccc1f7b'
             '9ea592205023ba861603d74b63cdb73126c56372a366dc4cb7beb379073cbb96'
             '849daf1d5b081ef6d0e428bbc7d448799fc43a8ac9e79cd7513de0eb5a91b0bb'
             '68535cc2a000946b62ce4be6edf7dda7900bd524f22bcb826800b94f4a873314'


### PR DESCRIPTION
https://github.com/raspberrypi/linux/pull/3111 renames the device nodes which breaks hwacell decoding.  The PR covers both cases.  Eventually, they will drop the argon-* aliases.

Since https://github.com/archlinuxarm/PKGBUILDs/commit/991876d8084a43c69a82aed88d0c03aeae8bea12, the package will be broken without this modification to the udev rules.