### PR TITLE
GHC 8.6.5 fixes

### DIFF
--- a/community/ghc/PKGBUILD
+++ b/community/ghc/PKGBUILD
@@ -18,7 +18,7 @@ shopt -s extglob
 pkgbase=ghc
 pkgname=(ghc-libs ghc ghc-static)
 pkgver=8.6.5
-pkgrel=1
+pkgrel=1.1
 pkgdesc='The Glasgow Haskell Compiler'
 arch=('x86_64')
 url='http://www.haskell.org/ghc/'
@@ -26,14 +26,12 @@ license=('custom')
 makedepends=('ghc-static' 'perl' 'libxslt' 'docbook-xsl' 'python-sphinx' 'haskell-hscolour'
              'texlive-bin' 'texlive-latexextra' 'ttf-dejavu')
 source=("https://downloads.haskell.org/~ghc/$pkgver/$pkgbase-${pkgver}-src.tar.xz"
-        ghc-rebuild-doc-index.hook ghc-register.hook ghc-unregister.hook
-        0001-llvm-targets-Add-armv6l-unknown-linux-gnueabihf-and-.patch)
+	ghc-rebuild-doc-index.hook ghc-register.hook ghc-unregister.hook)
 noextract=("$pkgbase-${pkgver}-src.tar.xz")
 sha512sums=('c08a7480200cb99e1ffbe4ce7669f552b1054054966f7e7efcbc5f98af8032e1249fa391c4fc4c7d62cc8e0be5d17fa05845177f3cea3dbcf86e6c92d40fc0f9'
             'afb119e4f665770c5704b97034d2488504eaa7afcddca2fb6b554079921cd2330599bcb5c36669f0d0e7856dd99ae1deeca1b0e97e2371a783f26e5ef9776ba9'
             'bd65a369b618ec9bee46c028c2b6acff8f883f60f6cad6e5be8561fbcef6118278abec11bb86f9e6f92cb2e05ad74ec54611c1788e8ed95187d0091fcbbf8767'
-            'd4bfdd4c8ad9ac612cf187fec150850e9f4068a4a4202503c00dba07ba26f804bc11d7181249f7e3452d7ede60dc5dedea34e73fdb584ac2953068b51c6fd5ad'
-            '0d46375b5d864d8e8268becf52ab66d9d51e459a1ff7ef71ca77c4d8bc65e2952b29be6acc55750aaab07c52fcb9e9bddc279d7292696fcfc578a44e5eca16a3')
+	    'd4bfdd4c8ad9ac612cf187fec150850e9f4068a4a4202503c00dba07ba26f804bc11d7181249f7e3452d7ede60dc5dedea34e73fdb584ac2953068b51c6fd5ad')
 
 prepare() {
   # Need to extract this tarball with a UTF-8 locale instead of a chroot's "C"
@@ -45,8 +43,6 @@ prepare() {
 
   cp mk/build.mk{.sample,}
   sed -i '1iBuildFlavour = perf' mk/build.mk
-
-  patch -p1 -i ../0001-llvm-targets-Add-armv6l-unknown-linux-gnueabihf-and-.patch
 }
 
 build() {

--- a/community/ghc/PKGBUILD
+++ b/community/ghc/PKGBUILD
@@ -18,7 +18,7 @@ shopt -s extglob
 pkgbase=ghc
 pkgname=(ghc-libs ghc ghc-static)
 pkgver=8.6.5
-pkgrel=1.1
+pkgrel=1.2
 pkgdesc='The Glasgow Haskell Compiler'
 arch=('x86_64')
 url='http://www.haskell.org/ghc/'
@@ -100,7 +100,7 @@ package_ghc() {
 package_ghc-libs() {
   pkgdesc='The Glasgow Haskell Compiler - Dynamic Libraries'
   install='ghc.install'
-  depends=('gmp' 'libffi' 'perl' 'llvm50')
+  depends=('gmp' 'libffi' 'perl' 'llvm6')
   provides=('haskell-array=0.5.3.0'
             'haskell-base=4.12.0.0'
             'haskell-binary=0.8.6.0'


### PR DESCRIPTION
This package currently does not build. The first commit should fix that (stop trying to apply a patch that has now landed upstream), and the second changes to a supported LLVM.

I have not tested this package in a clean chroot, as ghc requires ghc to build, but we then need both llvm50 (for old ghc) and llvm6 (for the ghc we wish to build), and these conflict. I don't know how to resolve this, but I expect this has been done before in commit 32e26f1087b1f2aecca72c2cbd7fe1ffd1e2e158 (upgrading llvm39 -> llvm50).

I have manually verified that ghc builds with these changes, by keeping ghc-8.6.1-1 installed from the repositories and forcibly replacing llvm50 with llvm6 before doing the build.