### PR TITLE
alarm/kodi-rbp4: Explicitly specify the provided version of the kodi packages

### DIFF
--- a/alarm/kodi-rbp4/PKGBUILD
+++ b/alarm/kodi-rbp4/PKGBUILD
@@ -26,7 +26,7 @@ _prefix=/usr
 pkgbase=kodi-rbp4
 pkgname=('kodi-rbp4' 'kodi-rbp4-eventclients' 'kodi-rbp4-tools-texturepacker' 'kodi-rbp4-dev')
 pkgver=18.4
-pkgrel=1
+pkgrel=2
 _codename=Leia
 _tag="18.4-$_codename"
 _ffmpeg_version="4.0.4-$_codename-18.4"
@@ -210,7 +210,7 @@ package_kodi-rbp4() {
     'upower: Display battery level'
   )
   install='kodi.install'
-  provides=('xbmc' 'kodi')
+  provides=('xbmc' 'kodi=$pkgver')
   conflicts=('xbmc' 'kodi' 'arm-mem-git' 'shairplay-git')
   replaces=('xbmc-rbp-git')
   _components=('kodi' 'kodi-bin')
@@ -240,7 +240,7 @@ package_kodi-rbp4() {
 
 package_kodi-rbp4-eventclients() {
   pkgdesc="Kodi Event Clients (Raspberry Pi4)"
-  provides=('kodi-eventclients')
+  provides=('kodi-eventclients=$pkgver')
   conflicts=('kodi-eventclients')
   optdepends=('python2: most eventclients are implemented in python2')
 
@@ -281,7 +281,7 @@ package_kodi-rbp4-tools-texturepacker() {
 package_kodi-rbp4-dev() {
   pkgdesc="Kodi dev files (Raspberry Pi4)"
   depends=('kodi')
-  provides=('kodi-dev')
+  provides=('kodi-dev=$pkgver')
 
   _components=('kodi-addon-dev'
     'kodi-audio-dev'


### PR DESCRIPTION
Arch Linux wiki states the following: "The version that the package provides should be mentioned (pkgver and potentially the pkgrel), in case packages referencing the software require one. For instance, a modified qt package version 3.3.8, named qt-foobar, should use provides=('qt=3.3.8'); omitting the version number would cause the dependencies that require a specific version of qt to fail." Source: https://wiki.archlinux.org/index.php/PKGBUILD#provides

This commit fixes building for example [`kodi-addon-inputstream-adaptive`](https://aur.archlinux.org/packages/kodi-addon-inputstream-adaptive/) from AUR, because it explicitly requests [`kodi-dev>=18`](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=kodi-addon-inputstream-adaptive&id=3cba01f7d208b8dab47caee8f987020220411a47).

See also: https://archlinuxarm.org/forum/viewtopic.php?f=15&t=13810
