### PR TITLE
[uboot-odroid-n2] update boot.ini

### DIFF
--- a/alarm/uboot-odroid-n2/PKGBUILD
+++ b/alarm/uboot-odroid-n2/PKGBUILD
@@ -8,7 +8,7 @@ noautobuild=1
 
 pkgname=uboot-odroid-n2
 pkgver=2015.01
-pkgrel=8
+pkgrel=9
 pkgdesc="U-Boot for ODROID-N2"
 arch=('aarch64')
 url="https://github.com/hardkernel/u-boot"
@@ -24,7 +24,7 @@ source=("https://github.com/hardkernel/u-boot/archive/${_commit}.tar.gz"
         '0002-arch-linux-arm-modifications.patch'
         '91-uboot-uimg.hook')
 md5sums=('29f9c150b485ffc7043a613dc6a2e79d'
-         '547e983abeaa98d14f8d72bb5d29a277'
+         '33de84d1cc619dba9b14d87b510684ff'
          'cc18cda0bc75936e602341efd5a2fe93'
          '4d14405ba98f09c002505cbe53e2f6cb'
          '1931c8dfde7088530f173ca59fdb8989')

--- a/alarm/uboot-odroid-n2/boot.ini
+++ b/alarm/uboot-odroid-n2/boot.ini
@@ -65,6 +65,9 @@ setenv voutmode "hdmi"
 # HPD enable/disable option
 setenv disablehpd "false"
 
+# Enable/Disable CEC
+setenv cec "true"
+
 # Hardkernel ODROID-VU7 support
 # By default VU7 support is disabled
 setenv disable_vu7 "true"
@@ -95,12 +98,13 @@ setenv maxcpus "6"
 ### Normal HDMI Monitors
 if test "${display_autodetect}" = "true"; then hdmitx edid; fi
 if test "${hdmimode}" = "custombuilt"; then setenv cmode "modeline=${modeline}"; fi
+if test "${cec}" = "true"; then setenv cec_enable "hdmitx=cec3f"; fi
 
 # VU7 Settings
 if test "${disable_vu7}" = "false"; then setenv hid_quirks "usbhid.quirks=0x0eef:0x0005:0x0004"; fi
 
 # Boot Args
-setenv bootargs "root=/dev/mmcblk${devno}p2 rootwait rw ${condev} ${amlogic} no_console_suspend fsck.repair=yes net.ifnames=0 elevator=noop hdmimode=${hdmimode} cvbsmode=576cvbs max_freq_a53=${max_freq_a53} max_freq_a73=${max_freq_a73} maxcpus=${maxcpus} voutmode=${voutmode} ${cmode} disablehpd=${disablehpd} cvbscable=${cvbscable} overscan=${overscan} ${hid_quirks} monitor_onoff=${monitor_onoff} usb-xhci.tablesize=2 logo=osd0,loaded"
+setenv bootargs "root=/dev/mmcblk${devno}p2 rootwait rw ${condev} ${amlogic} no_console_suspend fsck.repair=yes net.ifnames=0 elevator=noop hdmimode=${hdmimode} cvbsmode=576cvbs max_freq_a53=${max_freq_a53} max_freq_a73=${max_freq_a73} maxcpus=${maxcpus} voutmode=${voutmode} ${cmode} disablehpd=${disablehpd} cvbscable=${cvbscable} overscan=${overscan} ${hid_quirks} monitor_onoff=${monitor_onoff} logo=osd0,loaded ${cec_enable}"
 
 # Set load addresses
 setenv dtb_loadaddr "0x1000000"


### PR DESCRIPTION
A recent kernel update for the Odroid-N2 incorporated some fixes for USB3 performance issues.  The fix is included in the "**linux-odroid-n2 4.9.190-2**" package on the ALARM side.

Along with the kernel update, you also need to remove the "**usb-xhci.tablesize=2**" parameter from bootargs in /boot/boot.ini to take advantage of the improved performance.  This parameter was an older workaround for the issue.

For reference, with 4.9.190-2 and "usb-xhci.tablesize=2" included, I get ~225 MB/s write speed to a USB SSD drive.  That speed jumps to ~320 MB/s when I remove the "usb-xhci.tablesize=2" parameter.  A pretty decent increase!

Mauro Ribeiro from Hardkernel maintains the default boot.ini template on github here https://github.com/mdrjr/n2_bootini (FWIW, there is some other new stuff in there...  like a switch to enable CEC support)

Hardkernel doesn't package /boot/boot.ini with their uboot deb package on their Ubuntu image, but ALARM does include it in the **uboot-odroid-n2** package.

It would probably be worthwhile to update the boot.ini template in a future ALARM uboot-odroid-n2 package to closely match the updated Hardkernel one -- at the very least to remove the "usb-xhci.tablesize=2" parameter to take advantage of the much-improved USB3 performance.

I did not re-build the uboot package at all...  this is just a change to the boot.ini and checksum in the PKGBUILD.