### PR TITLE
Add grub package for aarch64

### DIFF
--- a/core/grub/0003-10_linux-detect-archlinux-initramfs.patch
+++ b/core/grub/0003-10_linux-detect-archlinux-initramfs.patch
@@ -1,0 +1,41 @@
+diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
+index f5d3e78..ef59c8c 100644
+--- a/util/grub.d/10_linux.in
++++ b/util/grub.d/10_linux.in
+@@ -83,6 +83,8 @@ linux_entry ()
+       case $type in
+ 	  recovery)
+ 	      title="$(gettext_printf "%s, with Linux %s (recovery mode)" "${os}" "${version}")" ;;
++	  fallback)
++	      title="$(gettext_printf "%s, with Linux %s (fallback initramfs)" "${os}" "${version}")" ;;
+ 	  *)
+ 	      title="$(gettext_printf "%s, with Linux %s" "${os}" "${version}")" ;;
+       esac
+@@ -186,7 +188,7 @@ while [ "x$list" != "x" ] ; do
+   basename=`basename $linux`
+   dirname=`dirname $linux`
+   rel_dirname=`make_system_path_relative_to_its_root $dirname`
+-  version=`echo $basename | sed -e "s,^[^0-9]*-,,g"`
++  version=`echo $basename | sed -e "s,vmlinuz-,,g"`
+   alt_version=`echo $version | sed -e "s,\.old$,,g"`
+   linux_root_device_thisversion="${LINUX_ROOT_DEVICE}"
+ 
+@@ -248,6 +250,18 @@ while [ "x$list" != "x" ] ; do
+ 
+   linux_entry "${OS}" "${version}" advanced \
+               "${GRUB_CMDLINE_LINUX} ${GRUB_CMDLINE_LINUX_DEFAULT}"
++
++  if test -e "${dirname}/initramfs-${version}-fallback.img" ; then
++    initrd="initramfs-${version}-fallback.img"
++
++    if test -n "${initrd}" ; then
++      gettext_printf "Found fallback initrd image(s) in %s:%s\n" "${dirname}" "${initrd_extra} ${initrd}" >&2
++    fi
++
++    linux_entry "${OS}" "${version}" fallback \
++                "${GRUB_CMDLINE_LINUX} ${GRUB_CMDLINE_LINUX_DEFAULT}"
++  fi
++
+   if [ "x${GRUB_DISABLE_RECOVERY}" != "xtrue" ]; then
+     linux_entry "${OS}" "${version}" recovery \
+                 "single ${GRUB_CMDLINE_LINUX}"

--- a/core/grub/0004-add-GRUB_COLOR_variables.patch
+++ b/core/grub/0004-add-GRUB_COLOR_variables.patch
@@ -1,0 +1,32 @@
+diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
+index 3390ba9..c416489 100644
+--- a/util/grub-mkconfig.in
++++ b/util/grub-mkconfig.in
+@@ -218,6 +218,8 @@ export GRUB_DEFAULT \
+   GRUB_THEME \
+   GRUB_GFXPAYLOAD_LINUX \
+   GRUB_DISABLE_OS_PROBER \
++  GRUB_COLOR_NORMAL \
++  GRUB_COLOR_HIGHLIGHT \
+   GRUB_INIT_TUNE \
+   GRUB_SAVEDEFAULT \
+   GRUB_ENABLE_CRYPTODISK \
+diff --git a/util/grub.d/00_header.in b/util/grub.d/00_header.in
+index d2e7252..8259f45 100644
+--- a/util/grub.d/00_header.in
++++ b/util/grub.d/00_header.in
+@@ -125,6 +125,14 @@ cat <<EOF
+ 
+ EOF
+ 
++if [ x$GRUB_COLOR_NORMAL != x ] && [ x$GRUB_COLOR_HIGHLIGHT != x ] ; then
++    cat << EOF
++set menu_color_normal=$GRUB_COLOR_NORMAL
++set menu_color_highlight=$GRUB_COLOR_HIGHLIGHT
++
++EOF
++fi
++
+ serial=0;
+ gfxterm=0;
+ for x in ${GRUB_TERMINAL_INPUT} ${GRUB_TERMINAL_OUTPUT}; do

--- a/core/grub/PKGBUILD
+++ b/core/grub/PKGBUILD
@@ -1,0 +1,306 @@
+# Maintainer : Christian Hesse <mail@eworm.de>
+# Maintainer : Ronald van Haren <ronald.archlinux.org>
+# Contributor: Tobias Powalowski <tpowa@archlinux.org>
+# Contributor: Keshav Amburay <(the ddoott ridikulus ddoott rat) (aatt) (gemmaeiil) (ddoott) (ccoomm)>
+
+# ALARM: Vasily Khoruzhick <anarsoul@gmail.com>
+#  - Removed call to _build_grub-common_and_bios() since
+#    it's not supported on aarch64
+#  - Drop everything but packaging /etc/grub/default in
+#    _package_grub-common_and_bios()
+
+## "1" to enable IA32-EFI build in Arch x86_64, "0" to disable
+_IA32_EFI_IN_ARCH_X64="1"
+
+## "1" to enable EMU build, "0" to disable
+_GRUB_EMU_BUILD="0"
+
+_GRUB_EXTRAS_COMMIT="136763a4cc9ca3a4f59d05b79eede2159d6f441e"
+_GNULIB_COMMIT="9ce9be2ef0cb1180e35dfe9dfbbe90d774b374bd"
+_UNIFONT_VER="12.1.02"
+
+[[ "${CARCH}" == "x86_64" ]] && _EFI_ARCH="x86_64"
+[[ "${CARCH}" == "i686" ]] && _EFI_ARCH="i386"
+[[ "${CARCH}" == "aarch64" ]] && _EFI_ARCH="aarch64"
+
+[[ "${CARCH}" == "x86_64" ]] && _EMU_ARCH="x86_64"
+[[ "${CARCH}" == "i686" ]] && _EMU_ARCH="i386"
+[[ "${CARCH}" == "aarch64" ]] && _EMU_ARCH="aarch64"
+
+pkgname='grub'
+pkgdesc='GNU GRand Unified Bootloader (2)'
+_pkgver=2.04
+pkgver=${_pkgver/-/}
+pkgrel=3
+epoch=2
+url='https://www.gnu.org/software/grub/'
+arch=('x86_64')
+license=('GPL3')
+backup=('etc/default/grub'
+        'etc/grub.d/40_custom')
+install="${pkgname}.install"
+options=('!makeflags')
+
+conflicts=('grub-common' 'grub-bios' 'grub-emu' "grub-efi-${_EFI_ARCH}" 'grub-legacy')
+replaces=('grub-common' 'grub-bios' 'grub-emu' "grub-efi-${_EFI_ARCH}")
+provides=('grub-common' 'grub-bios' 'grub-emu' "grub-efi-${_EFI_ARCH}")
+
+makedepends=('git' 'rsync' 'xz' 'freetype2' 'ttf-dejavu' 'python' 'autogen'
+             'texinfo' 'help2man' 'gettext' 'device-mapper' 'fuse2')
+depends=('sh' 'xz' 'gettext' 'device-mapper')
+optdepends=('freetype2: For grub-mkfont usage'
+            'fuse2: For grub-mount usage'
+            'dosfstools: For grub-mkrescue FAT FS and EFI support'
+            'efibootmgr: For grub-install EFI support'
+            'libisoburn: Provides xorriso for generating grub rescue iso using grub-mkrescue'
+            'os-prober: To detect other OSes when generating grub.cfg in BIOS systems'
+            'mtools: For grub-mkrescue FAT FS support')
+
+if [[ "${_GRUB_EMU_BUILD}" == "1" ]]; then
+    makedepends+=('libusbx' 'sdl')
+    optdepends+=('libusbx: For grub-emu USB support'
+                 'sdl: For grub-emu SDL support')
+fi
+
+validpgpkeys=('E53D497F3FA42AD8C9B4D1E835A93B74E82E4209'  # Vladimir 'phcoder' Serbinenko <phcoder@gmail.com>
+              'BE5C23209ACDDACEB20DB0A28C8189F1988C2166'  # Daniel Kiper <dkiper@net-space.pl>
+              '95D2E9AB8740D8046387FD151A09227B1F435A33') # Paul Hardy <unifoundry@unifoundry.com>
+
+source=("git+https://git.savannah.gnu.org/git/grub.git#tag=grub-${_pkgver}?signed"
+        "git+https://git.savannah.gnu.org/git/grub-extras.git#commit=${_GRUB_EXTRAS_COMMIT}"
+        "git+https://git.savannah.gnu.org/git/gnulib.git#commit=${_GNULIB_COMMIT}"
+        "https://ftp.gnu.org/gnu/unifont/unifont-${_UNIFONT_VER}/unifont-${_UNIFONT_VER}.bdf.gz"{,.sig}
+        '0003-10_linux-detect-archlinux-initramfs.patch'
+        '0004-add-GRUB_COLOR_variables.patch'
+        'grub.default')
+
+sha256sums=('SKIP'
+            'SKIP'
+            'SKIP'
+            '04d652be1e28a6d464965c75c71ac84633085cd0960c2687466651c34c94bd89'
+            'SKIP'
+            '171415ab075d1ac806f36c454feeb060f870416f24279b70104bba94bd6076d4'
+            'a5198267ceb04dceb6d2ea7800281a42b3f91fd02da55d2cc9ea20d47273ca29'
+            '690adb7943ee9fedff578a9d482233925ca3ad3e5a50fffddd27cf33300a89e3')
+
+_backports=(
+	# grub-mkconfig: Use portable "command -v" to detect installed programs
+	'28a7e597de0d5584f65e36f9588ff9041936e617'
+)
+
+_configure_options=(
+	FREETYPE="pkg-config freetype2"
+	BUILD_FREETYPE="pkg-config freetype2"
+	--enable-mm-debug
+	--enable-nls
+	--enable-device-mapper
+	--enable-cache-stats
+	--enable-grub-mkfont
+	--enable-grub-mount
+	--prefix="/usr"
+	--bindir="/usr/bin"
+	--sbindir="/usr/bin"
+	--mandir="/usr/share/man"
+	--infodir="/usr/share/info"
+	--datarootdir="/usr/share"
+	--sysconfdir="/etc"
+	--program-prefix=""
+	--with-bootdir="/boot"
+	--with-grubdir="grub"
+	--disable-silent-rules
+	--disable-werror
+)
+
+prepare() {
+	cd "${srcdir}/grub/"
+
+	echo "Apply backports..."
+	local _c
+	for _c in "${_backports[@]}"; do
+		git log --oneline -1 "${_c}"
+		git cherry-pick -n "${_c}"
+	done
+
+	echo "Patch to detect of Arch Linux initramfs images by grub-mkconfig..."
+	patch -Np1 -i "${srcdir}/0003-10_linux-detect-archlinux-initramfs.patch"
+
+	echo "Patch to enable GRUB_COLOR_* variables in grub-mkconfig..."
+	## Based on http://lists.gnu.org/archive/html/grub-devel/2012-02/msg00021.html
+	patch -Np1 -i "${srcdir}/0004-add-GRUB_COLOR_variables.patch"
+
+	echo "Fix DejaVuSans.ttf location so that grub-mkfont can create *.pf2 files for starfield theme..."
+	sed 's|/usr/share/fonts/dejavu|/usr/share/fonts/dejavu /usr/share/fonts/TTF|g' -i "configure.ac"
+
+	echo "Fix mkinitcpio 'rw' FS#36275..."
+	sed 's| ro | rw |g' -i "util/grub.d/10_linux.in"
+
+	echo "Fix OS naming FS#33393..."
+	sed 's|GNU/Linux|Linux|' -i "util/grub.d/10_linux.in"
+
+	echo "Pull in latest language files..."
+	./linguas.sh
+
+	echo "Remove not working langs which need LC_ALL=C.UTF-8..."
+	sed -e 's#en@cyrillic en@greek##g' -i "po/LINGUAS"
+
+	echo "Avoid problem with unifont during compile of grub..."
+	# http://savannah.gnu.org/bugs/?40330 and https://bugs.archlinux.org/task/37847
+	gzip -cd "${srcdir}/unifont-${_UNIFONT_VER}.bdf.gz" > "unifont.bdf"
+
+	echo "Run bootstrap..."
+	./bootstrap \
+		--gnulib-srcdir="${srcdir}/gnulib/" \
+		--no-git
+}
+
+_build_grub-common_and_bios() {
+	echo "Set ARCH dependent variables for bios build..."
+	if [[ "${CARCH}" == 'x86_64' ]]; then
+		_EFIEMU="--enable-efiemu"
+	else
+		_EFIEMU="--disable-efiemu"
+	fi
+
+	echo "Copy the source for building the bios part..."
+	cp -r "${srcdir}/grub/" "${srcdir}/grub-bios/"
+	cd "${srcdir}/grub-bios/"
+
+	echo "Add the grub-extra sources for bios build..."
+	install -d "${srcdir}/grub-bios/grub-extras"
+	cp -r "${srcdir}/grub-extras/915resolution" \
+		"${srcdir}/grub-bios/grub-extras/915resolution"
+	export GRUB_CONTRIB="${srcdir}/grub-bios/grub-extras/"
+
+	echo "Unset all compiler FLAGS for bios build..."
+	unset CFLAGS
+	unset CPPFLAGS
+	unset CXXFLAGS
+	unset LDFLAGS
+	unset MAKEFLAGS
+
+	echo "Run ./configure for bios build..."
+	./configure \
+		--with-platform="pc" \
+		--target="i386" \
+		"${_EFIEMU}" \
+		--enable-boot-time \
+		"${_configure_options[@]}"
+
+	echo "Run make for bios build..."
+	make
+}
+
+_build_grub-efi() {
+	echo "Copy the source for building the ${_EFI_ARCH} efi part..."
+	cp -r "${srcdir}/grub/" "${srcdir}/grub-efi-${_EFI_ARCH}/"
+	cd "${srcdir}/grub-efi-${_EFI_ARCH}/"
+
+	echo "Unset all compiler FLAGS for ${_EFI_ARCH} efi build..."
+	unset CFLAGS
+	unset CPPFLAGS
+	unset CXXFLAGS
+	unset LDFLAGS
+	unset MAKEFLAGS
+
+	echo "Run ./configure for ${_EFI_ARCH} efi build..."
+	./configure \
+		--with-platform="efi" \
+		--target="${_EFI_ARCH}" \
+		--disable-efiemu \
+		--enable-boot-time \
+		"${_configure_options[@]}"
+
+	echo "Run make for ${_EFI_ARCH} efi build..."
+	make
+}
+
+_build_grub-emu() {
+	echo "Copy the source for building the emu part..."
+	cp -r "${srcdir}/grub/" "${srcdir}/grub-emu/"
+	cd "${srcdir}/grub-emu/"
+
+	echo "Unset all compiler FLAGS for emu build..."
+	unset CFLAGS
+	unset CPPFLAGS
+	unset CXXFLAGS
+	unset LDFLAGS
+	unset MAKEFLAGS
+
+	echo "Run ./configure for emu build..."
+	./configure \
+		--with-platform="emu" \
+		--target="${_EMU_ARCH}" \
+		--enable-grub-emu-usb=no \
+		--enable-grub-emu-sdl=no \
+		--disable-grub-emu-pci \
+		"${_configure_options[@]}"
+
+	echo "Run make for emu build..."
+	make
+}
+
+build() {
+	cd "${srcdir}/grub/"
+
+	echo "Build grub ${_EFI_ARCH} efi stuff..."
+	_build_grub-efi
+
+	if [[ "${CARCH}" == "x86_64" ]] && [[ "${_IA32_EFI_IN_ARCH_X64}" == "1" ]]; then
+		echo "Build grub i386 efi stuff..."
+		_EFI_ARCH="i386" _build_grub-efi
+	fi
+
+	if [[ "${_GRUB_EMU_BUILD}" == "1" ]]; then
+		echo "Build grub emu stuff..."
+		_build_grub-emu
+	fi
+}
+
+_package_grub-common_and_bios() {
+	echo "Install /etc/default/grub (used by grub-mkconfig)..."
+	install -D -m0644 "${srcdir}/grub.default" "${pkgdir}/etc/default/grub"
+}
+
+_package_grub-efi() {
+	cd "${srcdir}/grub-efi-${_EFI_ARCH}/"
+
+	echo "Run make install for ${_EFI_ARCH} efi build..."
+	make DESTDIR="${pkgdir}/" bashcompletiondir="/usr/share/bash-completion/completions" install
+
+	echo "Remove gdb debugging related files for ${_EFI_ARCH} efi build..."
+	rm -f "${pkgdir}/usr/lib/grub/${_EFI_ARCH}-efi"/*.module || true
+	rm -f "${pkgdir}/usr/lib/grub/${_EFI_ARCH}-efi"/*.image || true
+	rm -f "${pkgdir}/usr/lib/grub/${_EFI_ARCH}-efi"/{kernel.exec,gdb_grub,gmodule.pl} || true
+}
+
+_package_grub-emu() {
+	cd "${srcdir}/grub-emu/"
+
+	echo "Run make install for emu build..."
+	make DESTDIR="${pkgdir}/" bashcompletiondir="/usr/share/bash-completion/completions" install
+
+	echo "Remove gdb debugging related files for emu build..."
+	rm -f "${pkgdir}/usr/lib/grub/${_EMU_ARCH}-emu"/*.module || true
+	rm -f "${pkgdir}/usr/lib/grub/${_EMU_ARCH}-emu"/*.image || true
+	rm -f "${pkgdir}/usr/lib/grub/${_EMU_ARCH}-emu"/{kernel.exec,gdb_grub,gmodule.pl} || true
+}
+
+package() {
+	cd "${srcdir}/grub/"
+
+	echo "Package grub ${_EFI_ARCH} efi stuff..."
+	_package_grub-efi
+
+	if [[ "${CARCH}" == "x86_64" ]] && [[ "${_IA32_EFI_IN_ARCH_X64}" == "1" ]]; then
+		echo "Package grub i386 efi stuff..."
+		_EFI_ARCH="i386" _package_grub-efi
+	fi
+
+	if [[ "${_GRUB_EMU_BUILD}" == "1" ]]; then
+		echo "Package grub emu stuff..."
+		_package_grub-emu
+	fi
+
+	echo "Package grub bios stuff..."
+	_package_grub-common_and_bios
+}

--- a/core/grub/grub.default
+++ b/core/grub/grub.default
@@ -1,0 +1,54 @@
+# GRUB boot loader configuration
+
+GRUB_DEFAULT=0
+GRUB_TIMEOUT=5
+GRUB_DISTRIBUTOR="Arch"
+GRUB_CMDLINE_LINUX_DEFAULT="loglevel=3 quiet"
+GRUB_CMDLINE_LINUX=""
+
+# Preload both GPT and MBR modules so that they are not missed
+GRUB_PRELOAD_MODULES="part_gpt part_msdos"
+
+# Uncomment to enable booting from LUKS encrypted devices
+#GRUB_ENABLE_CRYPTODISK=y
+
+# Set to 'countdown' or 'hidden' to change timeout behavior,
+# press ESC key to display menu.
+GRUB_TIMEOUT_STYLE=menu
+
+# Uncomment to use basic console
+GRUB_TERMINAL_INPUT=console
+
+# Uncomment to disable graphical terminal
+#GRUB_TERMINAL_OUTPUT=console
+
+# The resolution used on graphical terminal
+# note that you can use only modes which your graphic card supports via VBE
+# you can see them in real GRUB with the command `vbeinfo'
+GRUB_GFXMODE=auto
+
+# Uncomment to allow the kernel use the same resolution used by grub
+GRUB_GFXPAYLOAD_LINUX=keep
+
+# Uncomment if you want GRUB to pass to the Linux kernel the old parameter
+# format "root=/dev/xxx" instead of "root=/dev/disk/by-uuid/xxx"
+#GRUB_DISABLE_LINUX_UUID=true
+
+# Uncomment to disable generation of recovery mode menu entries
+GRUB_DISABLE_RECOVERY=true
+
+# Uncomment and set to the desired menu colors.  Used by normal and wallpaper
+# modes only.  Entries specified as foreground/background.
+#GRUB_COLOR_NORMAL="light-blue/black"
+#GRUB_COLOR_HIGHLIGHT="light-cyan/blue"
+
+# Uncomment one of them for the gfx desired, a image background or a gfxtheme
+#GRUB_BACKGROUND="/path/to/wallpaper"
+#GRUB_THEME="/path/to/gfxtheme"
+
+# Uncomment to get a beep at GRUB start
+#GRUB_INIT_TUNE="480 440 1"
+
+# Uncomment to make GRUB remember the last selection. This requires
+# setting 'GRUB_DEFAULT=saved' above.
+#GRUB_SAVEDEFAULT="true"

--- a/core/grub/grub.install
+++ b/core/grub/grub.install
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+post_upgrade() {
+  # We used to package /boot/grub/grub.cfg, but there is no reason to.
+  # Remove the file from package, but move real file back in place.
+  if [ ! -f /boot/grub/grub.cfg -a -f /boot/grub/grub.cfg.pacsave ]; then
+    mv /boot/grub/grub.cfg.pacsave /boot/grub/grub.cfg
+  fi
+}
+
+post_install() {
+  cat << 'EOM'
+Generate your bootloader configuration with:
+  grub-mkconfig -o /boot/grub/grub.cfg
+EOM
+}
+


### PR DESCRIPTION
Majority of aarch64 boards use u-boot as firmware. Since modern u-boot supports subset of UEFI that is enough to boot grub (and linux) we can actually make generic image even more generic by adding grub into it.

Unfortunately u-boot doesn't support persistent UEFI vars, so grub has to be installed as on removable media, i.e.:

`grub-install --no-nvram --removable --efi-directory=/boot/efi`

With grub installed and configured I was able to boot handcrafted image that contains 2 gpt partitions - 1st ESP mounted into /boot/efi, 2nd rootfs) on two different boards that have u-boot flashed into SPI flash - La Frite and Pine64-LTS.

Since grub-mkconfig expects linux image to be named vmlinuz-* it's also necessary to add `vmlinuz-linux` symlink to `Image.gz` otherwise it won't pick up kernel from linux-aarch64 package.

In theory now it's possible to create installation media like for x86/x86_64 platforms that can be flashed onto USB and used to install archlinux on aarch64 platforms.