### PR TITLE
core/linux-aarch64 - add sun4i-codec module

### DIFF
--- a/core/linux-aarch64/PKGBUILD
+++ b/core/linux-aarch64/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-5.3
 _kernelname=${pkgbase#linux}
 _desc="AArch64 multi-platform"
 pkgver=5.3.8
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -33,7 +33,7 @@ md5sums=('c99feaade8047339528fb066ec5f8a49'
          '86eab100b2b6b4abff411055949329bd'
          '843e7d5c5bc47f2899632d6610b4047b'
          '138648f7eecf6db5754e25a29b1b175d'
-         '801b0cdef452f164839eb06e9dd4e03c'
+         '7211ea8063263a6240b1b675eb5532c9'
          '7f1a96e24f5150f790df94398e9525a3'
          '61c5ff73c136ed07a7aadbf58db3d96a'
          '584777ae88bce2c5659960151b64c7d8'

--- a/core/linux-aarch64/config
+++ b/core/linux-aarch64/config
@@ -1,10 +1,10 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.3.8-1 Kernel Configuration
+# Linux/arm64 5.3.8-2 Kernel Configuration
 #
 
 #
-# Compiler: gcc (GCC) 8.3.0
+# Compiler: aarch64-unknown-linux-gnu-gcc (GCC) 8.3.0
 #
 CONFIG_CC_IS_GCC=y
 CONFIG_GCC_VERSION=80300
@@ -6079,7 +6079,7 @@ CONFIG_SND_SOC_RK3399_GRU_SOUND=m
 #
 # Allwinner SoC Audio support
 #
-# CONFIG_SND_SUN4I_CODEC is not set
+CONFIG_SND_SUN4I_CODEC=m
 CONFIG_SND_SUN8I_CODEC=m
 CONFIG_SND_SUN8I_CODEC_ANALOG=m
 CONFIG_SND_SUN50I_CODEC_ANALOG=m


### PR DESCRIPTION
Add *sun4i-codec* module required by *Orange Pi PC2* board.