### PR TITLE
core/linux-espressobin: disable LL preemption

### DIFF
--- a/core/linux-espressobin/PKGBUILD
+++ b/core/linux-espressobin/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-5.3
 _kernelname=${pkgbase#linux}
 _desc="Globalscale ESPRESSOBin"
 pkgver=5.3.13
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -27,7 +27,7 @@ md5sums=('c99feaade8047339528fb066ec5f8a49'
          '9d1a403e339e9468ed70d80b6c1efcee'
          '0ed4373219f57d869bbadafd49fa9861'
          'dac6bb686ddfb26894d4477ba61c901a'
-         '663d58687f129bd0ef5a1e1ee0979dc2'
+         'a55b8303b603ab56a55f73dc3f21e67c'
          '86d4a35722b5410e3b29fc92dae15d4b'
          'ce6c81ad1ad1f8b333fd6077d47abdaf'
          '3dc88030a8f2f5a5f97266d99b149f77'

--- a/core/linux-espressobin/config
+++ b/core/linux-espressobin/config
@@ -79,10 +79,8 @@ CONFIG_HIGH_RES_TIMERS=y
 # end of Timers subsystem
 
 # CONFIG_PREEMPT_NONE is not set
-# CONFIG_PREEMPT_VOLUNTARY is not set
-CONFIG_PREEMPT=y
-CONFIG_PREEMPT_COUNT=y
-CONFIG_PREEMPTION=y
+CONFIG_PREEMPT_VOLUNTARY=y
+# CONFIG_PREEMPT is not set
 
 #
 # CPU/Task time and stats accounting


### PR DESCRIPTION
use voluntary preemption instead.

aarch64 low latency preemption isn't compatible with ZFS: https://github.com/zfsonlinux/zfs/issues/8545
the device doesn't have very powerful CPU, and is used mostly for server stuff, so I don't think this change will hurt anyone.
also clear other undocumented options, implied by low latency preemption setting, and not normally present if these aren't enabled.

cc @kmihelich