### PR TITLE
Fix unapplied ARM linux kernel patches in PKGBUILD

### DIFF
--- a/core/linux-aarch64/PKGBUILD
+++ b/core/linux-aarch64/PKGBUILD
@@ -47,14 +47,14 @@ prepare() {
   cd ${_srcname}
 
   # add upstream patch
-  git apply --whitespace=nowarn ../patch-${pkgver}
+  patch -Np1 -i ../patch-${pkgver}
 
   # ALARM patches
-  git apply ../0001-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
-  git apply ../0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch
-  git apply ../0003-arm64-dts-rockchip-add-usb3-controller-node-for-RK33.patch
-  git apply ../0004-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-rock6.patch
-  git apply ../0005-ARM-dts-bcm283x-Fix-critical-trip-point.patch
+  patch -Np1 -i ../0001-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
+  patch -Np1 -i ../0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch
+  patch -Np1 -i ../0003-arm64-dts-rockchip-add-usb3-controller-node-for-RK33.patch
+  patch -Np1 -i ../0004-arm64-dts-rockchip-enable-usb3-nodes-on-rk3328-rock6.patch
+  patch -Np1 -i ../0005-ARM-dts-bcm283x-Fix-critical-trip-point.patch
 
   cat "${srcdir}/config" > ./.config
 


### PR DESCRIPTION
PKGBUILD is wrong for aarch64 linux kernel:
The linux source code is downloaded as tgz and then patches are applied
with git apply.
It is not allowed to do so, and doing so lead to unapplied patches
without throwing error. So lots of the patches are not applied.

This patch use patch comand instead of git aply.

Signed-off-by: Abdel Benamrouche <abdel@unxp.fr>