### PR TITLE
kodi-rbp4 to 18.5-3

### DIFF
--- a/alarm/kodi-rbp4/PKGBUILD
+++ b/alarm/kodi-rbp4/PKGBUILD
@@ -26,7 +26,7 @@ _prefix=/usr
 pkgbase=kodi-rbp4
 pkgname=('kodi-rbp4' 'kodi-rbp4-eventclients' 'kodi-rbp4-tools-texturepacker' 'kodi-rbp4-dev')
 pkgver=18.5
-pkgrel=2
+pkgrel=3
 _codename=Leia
 _tag="$_pkgver-$_codename"
 _ffmpeg_version="4.0.4-$_codename-18.4"
@@ -71,6 +71,8 @@ source=(
   "http://mirrors.kodi.tv/build-deps/sources/fstrcmp-$_fstrcmp_version.tar.gz"
   "http://mirrors.kodi.tv/build-deps/sources/flatbuffers-$_flatbuffers_version.tar.gz"
   01-fix.in-tree.ffmpeg.paths.for.makechrootpkg.hack.patch
+  sysusers.conf
+  tmpfiles.conf
 )
 noextract=(
   "libdvdcss-$_libdvdcss_version.tar.gz"
@@ -95,7 +97,9 @@ sha256sums=('f5d48be9882af93ec3bfe94dbbddfd0224076077aff31dddb5e00245f4353b42'
             '3d77d09a5df0de510aeeb940df4cb534787ddff3bb1828779753f5dfa1229d10'
             'e4018e850f80700acee8da296e56e15b1eef711ab15157e542e7d7e1237c3476'
             '5ca5491e4260cacae30f1a5786d109230db3f3a6e5a0eb45d0d0608293d247e3'
-            '70b4c7db8766761ca060c038c8abb36c8c678246ca6c5efbde84c58442748ef2')
+            '70b4c7db8766761ca060c038c8abb36c8c678246ca6c5efbde84c58442748ef2'
+            'f521b98232e5035b7cada46cf03975b8d753e93d0802bf22913fceed769f9d96'
+            '9c5e79ed8719cd032a3b17dac585aeff28a198e37af1da9af68ef1b86bab4d18')
 
 prepare() {
   # Must use MMAL headers and pc files rather than opengl ones so we copy the
@@ -229,13 +233,19 @@ package_kodi-rbp4() {
   grep -lR '#!.*python' * | \
     while read file; do sed -s 's/\(#!.*python\)/\12/g' -i "$file"; done
 
-  install -Dm755 $srcdir/kodi-build/kodi-gbm "$pkgdir/usr/lib/kodi/kodi-gbm"
-  install -Dm0644 "$srcdir/kodi.service" "$pkgdir/usr/lib/systemd/system/kodi.service"
-  install -Dm0644 "$srcdir/polkit.rules" "$pkgdir/usr/share/polkit-1/rules.d/10-kodi.rules"
-  chmod 0750 "$pkgdir/usr/share/polkit-1/rules.d/"
+  install -Dm755 "$srcdir/kodi-build/kodi-gbm" "$pkgdir/usr/lib/kodi/kodi-gbm"
 
   # fix permissions necessary for accelerated video playback
   install -Dm0644 "$srcdir/99-kodi.rules" "$pkgdir/etc/udev/rules.d/99-kodi.rules"
+
+  # systemd manages kodi user
+  install -Dm644 "$srcdir"/sysusers.conf "$pkgdir/usr/lib/sysusers.d/kodi.conf"
+  install -Dm644 "$srcdir"/tmpfiles.conf "$pkgdir/usr/lib/tmpfiles.d/kodi.conf"
+
+  # systemd service and polkit rules
+  install -Dm0644 "$srcdir/kodi.service" "$pkgdir/usr/lib/systemd/system/kodi.service"
+  install -Dm0644 "$srcdir/polkit.rules" "$pkgdir/usr/share/polkit-1/rules.d/10-kodi.rules"
+  chmod 0750 "$pkgdir/usr/share/polkit-1/rules.d/"
 }
 
 package_kodi-rbp4-eventclients() {

--- a/alarm/kodi-rbp4/kodi.install
+++ b/alarm/kodi-rbp4/kodi.install
@@ -1,12 +1,4 @@
 post_install() {
-  [[ $(type -p gtk-update-icon-cache) ]] && usr/bin/gtk-update-icon-cache -qtf usr/share/icons/hicolor
-  [[ $(type -p update-desktop-database) ]] && usr/bin/update-desktop-database -q usr/share/applications
-  getent group kodi > /dev/null || groupadd -r kodi
-  getent passwd kodi > /dev/null || useradd -r -m -d /var/lib/kodi -g kodi -s /usr/bin/nologin kodi
-  usermod -a -G kodi,audio,video,power,network,optical,storage,disk,tty,input kodi
-  mkdir -p var/lib/kodi
-  chown -R kodi:kodi var/lib/kodi
-
   echo "****************************************************************"
   echo "Make sure the following lines are added to /boot/config.txt"
   echo "   gpu_mem=320"
@@ -17,12 +9,6 @@ post_install() {
   echo "****************************************************************"
 }
 
-post_upgrade() {
-  post_install $1
-}
-
 post_remove() {
-  [[ $(type -p gtk-update-icon-cache) ]] && usr/bin/gtk-update-icon-cache -qtf usr/share/icons/hicolor
-  [[ $(type -p update-desktop-database) ]] && usr/bin/update-desktop-database -q usr/share/applications
-  getent passwd kodi > /dev/null && userdel kodi
+  echo "==> Optionally remove /var/lib/kodi/"
 }

--- a/alarm/kodi-rbp4/sysusers.conf
+++ b/alarm/kodi-rbp4/sysusers.conf
@@ -1,0 +1,16 @@
+# override these settings by copying this to /etc/sysusers.d/ and modifying it therein
+
+#Type Name ID GECOS Home directory Shell
+g kodi - -
+u kodi - "Kodi User" /var/lib/kodi
+
+# supplemental groups
+m kodi audio
+m kodi disk
+m kodi input
+m kodi network
+m kodi optical
+m kodi power
+m kodi storage
+m kodi tty
+m kodi video

--- a/alarm/kodi-rbp4/tmpfiles.conf
+++ b/alarm/kodi-rbp4/tmpfiles.conf
@@ -1,0 +1,3 @@
+#Type Path Mode User Group Age Argument
+d /var/lib/kodi 0750 kodi kodi - -
+Z /var/lib/kodi - kodi kodi - -


### PR DESCRIPTION
PR simplifies `.install` file using systemd natives and pacman hooks.  We can consider similar changes with other kodi-rbpx packages as well.