### PR TITLE
upgraded devtools-alarm to 20191227

### DIFF
--- a/alarm/devtools-alarm/0001-makechrootpkg-cache-dir.patch
+++ b/alarm/devtools-alarm/0001-makechrootpkg-cache-dir.patch
@@ -15,7 +15,7 @@ index 2407115..f60d978 100644
  	echo 'Flags:'
  	echo '-h         This help'
  	echo '-c         Clean the chroot before building'
-+	echo '-C <dir>   Set pacman cache to pass to arch-nspawn'
++	echo '-X <dir>   Set pacman cache to pass to arch-nspawn'
  	echo '-d <dir>   Bind directory into build chroot as read-write'
  	echo '-D <dir>   Bind directory into build chroot as read-only'
  	echo '-u         Update the working copy of the chroot before building'
@@ -23,14 +23,14 @@ index 2407115..f60d978 100644
  }
  # }}}
  
--while getopts 'hcur:I:l:nTD:d:U:' arg; do
-+while getopts 'hcuC:r:I:l:nTD:d:U:' arg; do
+-while getopts 'hcur:I:l:nCTD:d:U:' arg; do
++while getopts 'hcuX:r:I:l:nCTD:d:U:' arg; do
  	case "$arg" in
  		c) clean_first=1 ;;
  		D) bindmounts_ro+=("--bind-ro=$OPTARG") ;;
  		d) bindmounts_rw+=("--bind=$OPTARG") ;;
  		u) update_first=1 ;;
-+		C) cache_dir="$OPTARG" ;;
++		X) cache_dir="$OPTARG" ;;
  		r) passeddir="$OPTARG" ;;
  		I) install_pkgs+=("$OPTARG") ;;
  		l) copy="$OPTARG" ;;

--- a/alarm/devtools-alarm/0002-arch-nspawn-keep-mirrorlist.patch
+++ b/alarm/devtools-alarm/0002-arch-nspawn-keep-mirrorlist.patch
@@ -15,6 +15,7 @@ index 5817143..496fbd4 100644
  copy_hostconf () {
  	unshare --fork --pid gpg --homedir "$working_dir"/etc/pacman.d/gnupg/ --no-permission-warning --quiet --batch --import --import-options import-local-sigs "$(pacman-conf GpgDir)"/pubring.gpg >/dev/null 2>&1
  	pacman-key --gpgdir "$working_dir"/etc/pacman.d/gnupg/ --import-trustdb "$(pacman-conf GpgDir)" >/dev/null 2>&1
+ 
 -	printf 'Server = %s\n' "${host_mirrors[@]}" >"$working_dir/etc/pacman.d/mirrorlist"
 +	#printf 'Server = %s\n' "${host_mirrors[@]}" >"$working_dir/etc/pacman.d/mirrorlist"
  

--- a/alarm/devtools-alarm/0006-archbuild-no-setarch.patch
+++ b/alarm/devtools-alarm/0006-archbuild-no-setarch.patch
@@ -14,7 +14,7 @@ index 69bb029..53d60a5 100644
 @@ -69,7 +69,7 @@ if ${clean_first} || [[ ! -d "${chroots}/${repo}-${arch}" ]]; then
  
  	rm -rf --one-file-system "${chroots}/${repo}-${arch}"
- 	mkdir -m755 -p "${chroots}/${repo}-${arch}"
+ 	(umask 0022; mkdir -p "${chroots}/${repo}-${arch}")
 -	setarch "${arch}" mkarchroot \
 +	mkarchroot \
  		-C "${pacman_config}" \

--- a/alarm/devtools-alarm/PKGBUILD
+++ b/alarm/devtools-alarm/PKGBUILD
@@ -6,7 +6,7 @@
 
 pkgname=devtools-alarm
 _pkgname=devtools
-pkgver=20190912
+pkgver=20191227
 pkgrel=1
 pkgdesc='Tools for Arch Linux ARM package maintainers'
 arch=('any')
@@ -35,14 +35,14 @@ validpgpkeys=('487EACC08557AD082088DABA1EB2638FF56C0C53'
               'F3691687D867B81B51CE07D9BBE43771487328A9'
               '6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'
               'E240B57E2C4630BA768E2F26FC1B547C8D8172C8')
-sha256sums=('0f6c83cdfb13b27292b034a5f4bfa46293830f879d4af5226079af30795992fb'
+sha256sums=('f217571e33d7e336336ad02df3e7e6318c175bf16ed44ad732cfee73cd9ca42b'
             'SKIP'
-            'd562fda07e66ff8f4228abda31ba4abf26561c203234baa479891e1b6e8e286f'
-            'd2201d40292832363188fb9a0541dd20af7c9feb71e62db6077926f8ce52315a'
+            '6022d44a7a839e264f3f7cf0806e062380de947e522eee3c0bae609a4399e3a5'
+            'bc4b6fd2a2ab19f1e81375a6aca9bf5e2181d386f1fee156744ff22cb05163ba'
             'edfe6b8dd600ca16116860ffb0fa0a998d78d5951f9aad581a3c5b1a40ac0630'
             '57bbf498932a454bd51f825f09fbe0066d6588f1b41978c09ce337c079758dc2'
             '0917f6aaabf75f75b74a08f3f244dbe5f6369d115d6e65c8c2fb0b91bc71e3ca'
-            '892c9705e3d37b9a2fc72b60fae798127864a01bab40e825f1a0bc910ee7e330'
+            '14acbf04eae2c63d1a3f55be603d58888e8e55e21d87103d5c018923d6193933'
             '26acd09ac3ee2424dc0f93a51472ad4644cd442a44a6fb87efb23e5ea2c2416e')
 
 prepare() {


### PR DESCRIPTION
I've only tested it with [devtools-qemu](https://github.com/arch4edu/devtools-qemu).

### Important changes
I  moved
```
-C <dir>   Set pacman cache to pass to arch-nspawn
```
to
```
-X <dir>   Set pacman cache to pass to arch-nspawn
```
since `-C` is occupied by the official devtools now.