### PR TITLE
alarm/uboot-espressobin: Allow booting from different devices

### DIFF
--- a/alarm/uboot-espressobin/PKGBUILD
+++ b/alarm/uboot-espressobin/PKGBUILD
@@ -4,7 +4,7 @@
 buildarch=8
 
 pkgname=uboot-espressobin
-pkgver=1.0
+pkgver=2.0
 pkgrel=1
 pkgdesc="U-Boot configuration for ESPRESSOBin"
 arch=('aarch64')
@@ -12,7 +12,7 @@ url='http://www.denx.de/wiki/U-Boot/WebHome'
 license=('GPL')
 backup=('boot/uEnv.txt')
 source=('uEnv.txt')
-md5sums=('fce851bd426b792e17bed25c09b00136')
+md5sums=('7c0a06ece02f486a0369f9ba6d96b8cc')
 
 package() {
   mkdir -p "${pkgdir}"/boot

--- a/alarm/uboot-espressobin/uEnv.txt
+++ b/alarm/uboot-espressobin/uEnv.txt
@@ -5,8 +5,14 @@ fdt_high=0xffffffffffffffff
 image_name=/boot/Image
 ramdisk_name=/boot/initramfs-linux.uimg
 fdt_name=/boot/dtbs/marvell/armada-3720-espressobin.dtb
-get_env=if ext4load mmc 0 $loadaddr /boot/uEnv.txt; then env import -t $loadaddr $filesize; if test -n ${uenvcmd}; then run uenvcmd; fi; fi
-get_images=ext4load mmc 0 $kernel_addr $image_name && ext4load mmc 0 $fdt_addr $fdt_name
-get_ramdisk=ext4load mmc 0 $ramdisk_addr $ramdisk_name
-bootargs=console=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000 root=/dev/mmcblk0p1 rw rootwait
-bootcmd=mmc dev 0; run get_env; if run get_images; then if run get_ramdisk; then booti $kernel_addr $ramdisk_addr $fdt_addr; else booti $kernel_addr - $fdt_addr; fi; fi
+boot_targets=mmc0 mmc1 usb sata
+get_env=if ext4load $boot_interface $devnum:1 $loadaddr /boot/uEnv.txt; then env import -t $loadaddr $filesize; if test -n ${uenvcmd}; then run uenvcmd; fi; fi
+get_images=ext4load $boot_interface $devnum:1 $kernel_addr $image_name && ext4load $boot_interface $devnum:1 $fdt_addr $fdt_name
+get_ramdisk=ext4load $boot_interface $devnum:1 $ramdisk_addr $ramdisk_name
+set_bootargs=setenv bootargs console=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000 root=/dev/${boot_dev} rw rootwait
+try_boot=run set_bootargs; run get_env; if run get_images; then if run get_ramdisk; then booti $kernel_addr $ramdisk_addr $fdt_addr; else booti $kernel_addr - $fdt_addr; fi; fi
+bootcmd_mmc0=setenv devnum 0; setenv boot_interface mmc; setenv boot_dev mmcblk0p1; mmc dev 0; run try_boot;
+bootcmd_mmc1=setenv devnum 1; setenv boot_interface mmc; setenv boot_dev mmcblk0p1; mmc dev 1; run try_boot;
+bootcmd_usb=setenv devnum 0; setenv boot_interface usb; setenv boot_dev sda1; usb start; run try_boot;
+bootcmd_sata=setenv devnum 0; setenv boot_interface scsi; setenv boot_dev sda1; scsi scan; scsi dev 0; run try_boot;
+bootcmd=for target in ${boot_targets}; do run bootcmd_${target}; done


### PR DESCRIPTION
## Description

The following PR is inspired by [ESPRESSObin Armbian's ability to boot from multiple devices](https://www.armbian.com/espressobin/). uEnv.txt has been updated to try booting from a predefined list of devices (```boot_targets```). U-Boot will first call ```bootcmd``` to read ```boot_targets``` and set up the environment for each device (```bootcmd_*```). After device is initialized it will call ```try_boot``` which is equivalent of the old ```bootcmd```. From here the old boot script is updated to boot arbitrary devices according to the environment variable.
Inside ```bootcmd```, if a device is unbootable (either unavailable or missing necessary files), U-Boot will continue to the next device in the list, so it is safe to add everything to the list.

## Tested and untested configuration

Since I only have a V5 board, I cannot test eMMC (```mmc1```). I also didn't test SATA (```sata```) boot, as V5 board has an odd power port and I don't have an adapter for it.
USB (```usb```)) boot and SD card (```mmc0```) boot are tested. However, when both USB3 and USB2 are connected with external drive, USB2 will be /dev/sda and USB3 will be /dev/sdb.
In addition the test is done with [the latest Armbian U-Boot binary](https://dl.armbian.com/espressobin/u-boot/), which I believe is needed to use USB 3 port with recent kernel. I think there is a post in our forum pointing this out.
Below is a sample U-Boot output when ```boot_targets=mmc1 sata usb mmc0``` and only ```mmc0``` is populated, you can see U-Boot failed on other devices without interrupting boot process:

```
Hit any key to stop autoboot:  0
Card did not respond to voltage select!
Card did not respond to voltage select!
** Bad device mmc 1 **
Card did not respond to voltage select!
** Bad device mmc 1 **
scanning bus for devices...

Device 0: unknown device
** Bad device scsi 0 **
** Bad device scsi 0 **
starting USB...
USB0:   Register 2000104 NbrPorts 2
Starting the controller
USB XHCI 1.00
USB1:   USB EHCI 1.00
scanning bus 0 for devices... 1 USB Device(s) found
scanning bus 1 for devices... 2 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
** Bad device usb 0 **
** Bad device usb 0 **
switch to partitions #0, OK
mmc0 is current device
1409 bytes read in 17 ms (80.1 KiB/s)
# ABOVE LINE IS EXECUTING get_env SO WE ARE BOOTING NOW
```

## Limitation

Current config works best when there is only one device of each type (one of SD card / eMMC and one of USB / SATA). This is because the root partition is hard coded as /dev/sda1 and /dev/mmcblk0p1. It might be OK to have a second device of same type for bulk storage, as long as that is identified as /dev/sdb or /dev/mmcblk1. However since the official guides on ALARM wiki and ESPRESSObin also hardcode the root partition, this is not a regression. This is usually handled by ```grub-install``` on a x86 PC to substitute UUID for root partition, however since the installation on ESPRESSObin doesn't explicitly install a boot loader (it was just copying rootfs), this is the best we can do at the moment.

## Impact on existing users

In this PR the default boot order is set to mmc0 mmc1 usb sata. Since the original script and ALARM wiki is booting from mmc0 only, users with the default configuration is unaffected.
Here is also [the official guide for USB boot](http://wiki.espressobin.net/tiki-index.php?page=Boot+from+removable+storage+-+ArchLinux), which uses uEnv_usb.txt instead. So they are fine as well.
The only affected users are those who run a multi devices storage layout, overwrite uEnv.txt for their boot config instead of using a seprate file (like what official guide did), have multiple devices with ALARM installation, and also their perferred device is listed later in our default boot order. They might need multiple conditions met to disrupt their currently boot setup (for example they need both overwritting uEnv, multiple ALARM, and perfered device not first to truly change the system behavior), so the affected user base should be relatively small, though not non-existing.

## Additional tips for testing

To test this script, you will need to have a serial connection to the board, and preferably have a working ALARM installation in SD card as recovery. Below are some useful U-Boot shell scripts for troubleshooting:

- Flash U-Boot script, as this is a required step in official ALARM installation guide:
  After interrupting autoboot, execute ```mmc dev 0; ext4load mmc 0:1 $loadaddr /boot/uEnv.txt; env import -t $loadaddr $filesize; saveenv; reset```
- Manually boot from U-Boot shell, due to broken script:
   Execute ```setenv bootargs 'console=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000 root=/dev/mmcblk0p1 rw rootwait'; ext4load mmc 0:1 0x2000000 /boot/Image && ext4load mmc 0:1 0x1000000 /boot/dtbs/marvell/armada-3720-espressobin.dtb; booti 0x2000000 - 0x1000000```