### PR TITLE
core/linux-espressobin: build .dtb for espressobin-v7

### DIFF
--- a/core/linux-espressobin/0003-arm64-dts-enable-v7-build.patch
+++ b/core/linux-espressobin/0003-arm64-dts-enable-v7-build.patch
@@ -1,0 +1,13 @@
+diff --git a/arch/arm64/boot/dts/marvell/Makefile b/arch/arm64/boot/dts/marvell/Makefile
+index f1b5127..4c16136 100644
+--- a/arch/arm64/boot/dts/marvell/Makefile
++++ b/arch/arm64/boot/dts/marvell/Makefile
+@@ -2,6 +2,7 @@
+ # Mvebu SoC Family
+ dtb-$(CONFIG_ARCH_MVEBU) += armada-3720-db.dtb
+ dtb-$(CONFIG_ARCH_MVEBU) += armada-3720-espressobin.dtb
++dtb-$(CONFIG_ARCH_MVEBU) += armada-3720-espressobin-v7.dtb
+ dtb-$(CONFIG_ARCH_MVEBU) += armada-3720-turris-mox.dtb
+ dtb-$(CONFIG_ARCH_MVEBU) += armada-3720-uDPU.dtb
+ dtb-$(CONFIG_ARCH_MVEBU) += armada-7040-db.dtb
+ 

--- a/core/linux-espressobin/PKGBUILD
+++ b/core/linux-espressobin/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-5.5
 _kernelname=${pkgbase#linux}
 _desc="Globalscale ESPRESSOBin"
 pkgver=5.5.8
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -18,6 +18,7 @@ source=("http://www.kernel.org/pub/linux/kernel/v5.x/${_srcname}.tar.xz"
         "http://www.kernel.org/pub/linux/kernel/v5.x/patch-${pkgver}.xz"
         '0001-arm64-dts-marvell-armada37xx-Add-eth0-alias.patch'
         '0002-PCI-aardvark-disable-LOS-state-by-default.patch'
+        '0003-arm64-dts-enable-v7-build.patch'
         'config'
         'linux.preset'
         '60-linux.hook'
@@ -27,6 +28,7 @@ md5sums=('0a78b1dc48dc032fe505b170c1b92339'
          '74fdb27ae62f3ea870a86ff3546764e5'
          '0ed4373219f57d869bbadafd49fa9861'
          'dac6bb686ddfb26894d4477ba61c901a'
+         '105b55dd7f8e2c8e46bb72eba0147ec7'
          '3e4681b810ce700e6b729752ef706c0a'
          '86d4a35722b5410e3b29fc92dae15d4b'
          'ce6c81ad1ad1f8b333fd6077d47abdaf'
@@ -42,6 +44,7 @@ prepare() {
   # ALARM patches
   git apply ../0001-arm64-dts-marvell-armada37xx-Add-eth0-alias.patch
   git apply ../0002-PCI-aardvark-disable-LOS-state-by-default.patch
+  git apply ../0003-arm64-dts-enable-v7-build.patch
 
   cat "${srcdir}/config" > ./.config
 


### PR DESCRIPTION
In Espressobin v7 Globalscale swapped around ports lan1 and wan. This is not easily fixable without modifying the device tree file.
Fortunately, upstream has implemented a .dts for v7. Unfortunately, it is not built with flag `CONFIG_ARCH_MVEBU` (or any other flag afaik). This patch fixes that.