### PR TITLE
linux-raspberrypi - build rtc_pcf8563 as module.

### DIFF
--- a/core/linux-raspberrypi/PKGBUILD
+++ b/core/linux-raspberrypi/PKGBUILD
@@ -10,7 +10,7 @@ _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="Raspberry Pi"
 pkgver=4.19.108
-pkgrel=1
+pkgrel=2
 arch=('armv6h' 'armv7h')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -26,7 +26,7 @@ source=("https://github.com/raspberrypi/linux/archive/${_commit}.tar.gz"
 md5sums=('c407b01bc78f37b1eca99ebeaedf2d42'
          '7c6b37a1353caccf6d3786bb4161c218'
          '60bc3624123c183305677097bcd56212'
-         '9d35fe64bcb9f1539c8dca41efbdb043'
+         '6a2b1e17667ee9458c3386e5e7ef17bf'
          '86d4a35722b5410e3b29fc92dae15d4b'
          'ce6c81ad1ad1f8b333fd6077d47abdaf'
          '69e1db90d78f691dc446fe2ab94727eb')

--- a/core/linux-raspberrypi/config
+++ b/core/linux-raspberrypi/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 4.19.108-1 Kernel Configuration
+# Linux/arm 4.19.108-2 Kernel Configuration
 #
 
 #
@@ -5591,7 +5591,7 @@ CONFIG_RTC_DRV_X1205=m
 CONFIG_RTC_DRV_PCF8523=m
 # CONFIG_RTC_DRV_PCF85063 is not set
 CONFIG_RTC_DRV_PCF85363=m
-CONFIG_RTC_DRV_PCF8563=y
+CONFIG_RTC_DRV_PCF8563=m
 CONFIG_RTC_DRV_PCF8583=m
 CONFIG_RTC_DRV_M41T80=m
 # CONFIG_RTC_DRV_M41T80_WDT is not set


### PR DESCRIPTION
There's no reason to build this specific driver into the kernel.