### PR TITLE
core/linux-odroid-n2 to 4.9.216

### DIFF
--- a/core/linux-odroid-n2/PKGBUILD
+++ b/core/linux-odroid-n2/PKGBUILD
@@ -4,11 +4,11 @@
 buildarch=8
 
 pkgbase=linux-odroid-n2
-_commit=e68677ef5603409b3cbb4a5eee84c01dddbbc480
+_commit=c06d8635305a6116b9e0708bc2634c975c1786cf
 _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="ODROID-N2"
-pkgver=4.9.213
+pkgver=4.9.216
 pkgrel=1
 arch=('aarch64')
 url="https://github.com/hardkernel/linux/tree/odroidn2-4.9.y"
@@ -21,9 +21,9 @@ source=("https://github.com/hardkernel/linux/archive/${_commit}.tar.gz"
         'linux.preset'
         '60-linux.hook'
         '90-linux.hook')
-md5sums=('f32d9af0fe85817dc2dfa30466d6451e'
+md5sums=('b2e226d40515f2c429fdd1dc68837dc7'
          '0260cbce6933ed5f95ede70d90aad03a'
-         '463e09d2cf2948f95ab99fd8ba2daaee'
+         '8eb9056525b18a89c95dd194702b4acd'
          '86d4a35722b5410e3b29fc92dae15d4b'
          'ce6c81ad1ad1f8b333fd6077d47abdaf'
          '3dc88030a8f2f5a5f97266d99b149f77')

--- a/core/linux-odroid-n2/config
+++ b/core/linux-odroid-n2/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.9.213-1 Kernel Configuration
+# Linux/arm64 4.9.216-1 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y
@@ -4379,7 +4379,7 @@ CONFIG_USB_OHCI_HCD=y
 # USB Device Class drivers
 #
 CONFIG_USB_ACM=y
-# CONFIG_USB_PRINTER is not set
+CONFIG_USB_PRINTER=m
 CONFIG_USB_WDM=m
 # CONFIG_USB_TMC is not set
 


### PR DESCRIPTION
Updated to latest 4.9.216 and enabled usb printing support as in upstream.