### PR TITLE
enable webrtc

### DIFF
--- a/extra/firefox/PKGBUILD
+++ b/extra/firefox/PKGBUILD
@@ -95,9 +95,6 @@ ac_add_options --with-google-location-service-api-keyfile=${PWD@Q}/google-api-ke
 ac_add_options --with-google-safebrowsing-api-keyfile=${PWD@Q}/google-api-key
 ac_add_options --with-mozilla-api-keyfile=${PWD@Q}/mozilla-api-key
 
-# ALARM
-ac_add_options --disable-webrtc
-
 # System libraries
 ac_add_options --with-system-nspr
 ac_add_options --with-system-nss


### PR DESCRIPTION
WebRTC works fine on my pinebookpro. Please enable it by default or link a relevant bug report.