### PR TITLE
added python2-pycryptodomex to makedepends

### DIFF
--- a/alarm/kodi-rbp/PKGBUILD
+++ b/alarm/kodi-rbp/PKGBUILD
@@ -12,7 +12,7 @@ _prefix=/usr
 pkgbase=kodi-rbp
 pkgname=('kodi-rbp' 'kodi-rbp-eventclients' 'kodi-rbp-tools-texturepacker' 'kodi-rbp-dev')
 pkgver=18.6
-pkgrel=1
+pkgrel=2
 _codename=Leia
 _tag="$pkgver-$_codename"
 _ffmpeg_version="4.0.4-$_codename-18.4"
@@ -32,8 +32,8 @@ makedepends=(
   'libbluray-kodi-rbp' 'libcdio' 'mariadb-libs' 'libmicrohttpd' 'groff'
   'libmodplug' 'libmpeg2' 'libnfs' 'libplist' 'libpulse' 'libssh' 'libcec-rpi'
   'libxrandr' 'libxslt' 'lirc' 'lzo' 'nasm' 'nss-mdns' 'python2-pillow'
-  'python2-pybluez' 'python2-simplejson' 'raspberrypi-firmware' 'rtmpdump'
-  'shairplay' 'smbclient' 'speex' 'swig' 'taglib' 'tinyxml' 'unzip' 'upower'
+  'python2-pybluez' 'python2-pycryptodomex' 'python2-simplejson' 'raspberrypi-firmware'
+  'rtmpdump' 'shairplay' 'smbclient' 'speex' 'swig' 'taglib' 'tinyxml' 'unzip' 'upower'
   'yajl' 'zip' 'giflib' 'rapidjson' 'polkit' 'libinput' 'libxkbcommon' 'ghostscript'
 )
 source=("https://github.com/popcornmix/xbmc/archive/newclock5_$_tag.tar.gz"


### PR DESCRIPTION
See https://bugs.archlinux.org/task/63439
Kodi addons like the Netflix addon fail without this dependency.