### PR TITLE
Add community/gocryptfs

### DIFF
--- a/community/gocryptfs/PKGBUILD
+++ b/community/gocryptfs/PKGBUILD
@@ -1,6 +1,9 @@
 # Maintainer: Maxim Baz <$pkgname at maximbaz dot com>
 # Contributor: Peter Reschenhofer <peter.reschenhofer@gmail.com>
 
+# ALARM: Andrea Scarpino <andrea@archlinux.org>
+#  - disable documentation build
+
 _pkgauthor=rfjakob
 pkgname=gocryptfs
 pkgver=1.7.1
@@ -10,7 +13,7 @@ arch=('x86_64')
 url="https://github.com/${_pkgauthor}/${pkgname}"
 license=('MIT')
 depends=('gcc-libs' 'openssl' 'fuse')
-makedepends=('go-pie' 'pandoc' 'man-db')
+makedepends=('go-pie')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/${_pkgauthor}/${pkgname}/releases/download/v${pkgver}/${pkgname}_v${pkgver}_src-deps.tar.gz"
         "${pkgname}-${pkgver}.tar.gz.asc::https://github.com/${_pkgauthor}/${pkgname}/releases/download/v${pkgver}/${pkgname}_v${pkgver}_src-deps.tar.gz.asc")
 sha256sums=('d3fc2c87b869025cd51e4abea030e58e7383197a7458f26bf99a71b224402bda'
@@ -25,10 +28,12 @@ prepare() {
 build() {
     export GOPATH="${srcdir}/gopath"
     cd "${srcdir}/gopath/src/github.com/${_pkgauthor}/${pkgname}"
-    make build
+    ./build.bash
 }
 
 package() {
     cd "${srcdir}/gopath/src/github.com/${_pkgauthor}/${pkgname}"
-    make DESTDIR="${pkgdir}" install
+    install -Dm755 -t "${pkgdir}/usr/bin/" gocryptfs
+    install -Dm755 -t "${pkgdir}/usr/bin/" gocryptfs-xray/gocryptfs-xray
+    install -Dm644 -t "${pkgdir}/usr/share/licenses/gocryptfs" LICENSE
 }

--- a/community/gocryptfs/PKGBUILD
+++ b/community/gocryptfs/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Maxim Baz <$pkgname at maximbaz dot com>
+# Contributor: Peter Reschenhofer <peter.reschenhofer@gmail.com>
+
+_pkgauthor=rfjakob
+pkgname=gocryptfs
+pkgver=1.7.1
+pkgrel=2
+pkgdesc='Encrypted overlay filesystem written in Go.'
+arch=('x86_64')
+url="https://github.com/${_pkgauthor}/${pkgname}"
+license=('MIT')
+depends=('gcc-libs' 'openssl' 'fuse')
+makedepends=('go-pie' 'pandoc' 'man-db')
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/${_pkgauthor}/${pkgname}/releases/download/v${pkgver}/${pkgname}_v${pkgver}_src-deps.tar.gz"
+        "${pkgname}-${pkgver}.tar.gz.asc::https://github.com/${_pkgauthor}/${pkgname}/releases/download/v${pkgver}/${pkgname}_v${pkgver}_src-deps.tar.gz.asc")
+sha256sums=('d3fc2c87b869025cd51e4abea030e58e7383197a7458f26bf99a71b224402bda'
+            'SKIP')
+validpgpkeys=('FFF3E01444FED7C316A3545A895F5BC123A02740')
+
+prepare() {
+    mkdir -p "${srcdir}/gopath/src/github.com/${_pkgauthor}"
+    ln -rTsf "${srcdir}/${pkgname}_v${pkgver}_src-deps" "${srcdir}/gopath/src/github.com/${_pkgauthor}/${pkgname}"
+}
+
+build() {
+    export GOPATH="${srcdir}/gopath"
+    cd "${srcdir}/gopath/src/github.com/${_pkgauthor}/${pkgname}"
+    make build
+}
+
+package() {
+    cd "${srcdir}/gopath/src/github.com/${_pkgauthor}/${pkgname}"
+    make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
`gocryptfs` does require `pandoc` only to build the man pages, so I think it's OK to add it without them.