### PR TITLE
core/linux-raspberrypi to 4.19.113-1

### DIFF
--- a/core/linux-raspberrypi/PKGBUILD
+++ b/core/linux-raspberrypi/PKGBUILD
@@ -5,11 +5,11 @@
 buildarch=20
 
 pkgbase=linux-raspberrypi
-_commit=2fab54c74bf956951e61c6d4fe473995e8d07010
+_commit=4f2a4cc501c428c940549f39d5562e60404ac4f7
 _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="Raspberry Pi"
-pkgver=4.19.108
+pkgver=4.19.113
 pkgrel=1
 arch=('armv6h' 'armv7h')
 url="http://www.kernel.org/"
@@ -23,7 +23,7 @@ source=("https://github.com/raspberrypi/linux/archive/${_commit}.tar.gz"
         'linux.preset'
         '60-linux.hook'
         '90-linux.hook')
-md5sums=('c407b01bc78f37b1eca99ebeaedf2d42'
+md5sums=('f56df887bc73557da2f25910eccece66'
          '7c6b37a1353caccf6d3786bb4161c218'
          '60bc3624123c183305677097bcd56212'
          '9d35fe64bcb9f1539c8dca41efbdb043'


### PR DESCRIPTION
Updated to 4.19.113 should also applied to core/linux-raspberrypi4.