### PR TITLE
core/linux-odroid-n2 to 4.9.219

### DIFF
--- a/core/linux-odroid-n2/PKGBUILD
+++ b/core/linux-odroid-n2/PKGBUILD
@@ -4,11 +4,11 @@
 buildarch=8
 
 pkgbase=linux-odroid-n2
-_commit=c06d8635305a6116b9e0708bc2634c975c1786cf
+_commit=067572bc5d33aa39fdbb632679e43965141ea382
 _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="ODROID-N2"
-pkgver=4.9.216
+pkgver=4.9.219
 pkgrel=1
 arch=('aarch64')
 url="https://github.com/hardkernel/linux/tree/odroidn2-4.9.y"
@@ -21,9 +21,9 @@ source=("https://github.com/hardkernel/linux/archive/${_commit}.tar.gz"
         'linux.preset'
         '60-linux.hook'
         '90-linux.hook')
-md5sums=('b2e226d40515f2c429fdd1dc68837dc7'
+md5sums=('6201373509cc03ea705da2d0d6856f7e'
          '0260cbce6933ed5f95ede70d90aad03a'
-         '8eb9056525b18a89c95dd194702b4acd'
+         '97bc0593f313c84218958379fc4aa100'
          '86d4a35722b5410e3b29fc92dae15d4b'
          'ce6c81ad1ad1f8b333fd6077d47abdaf'
          '3dc88030a8f2f5a5f97266d99b149f77')

--- a/core/linux-odroid-n2/config
+++ b/core/linux-odroid-n2/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.9.216-1 Kernel Configuration
+# Linux/arm64 4.9.219-1 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y
@@ -1684,11 +1684,6 @@ CONFIG_AMLOGIC_IONVIDEO=y
 # Amlogic picture decoder support
 #
 CONFIG_AMLOGIC_PIC_DEC=y
-
-#
-# Amlogic videosync support
-#
-CONFIG_AMLOGIC_VIDEOSYNC=y
 
 #
 # Amlogic Enhancement drivers


### PR DESCRIPTION
Updated to latest upstream version which also removed CONFIG_AMLOGIC_VIDEOSYNC=y support because it isn't used by the device.