### PR TITLE
Add community/python-xcffib, removed haskell-xcffib dep

### DIFF
--- a/community/python-xcffib/PKGBUILD
+++ b/community/python-xcffib/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+# Contributor: Roger Duran <rogerduran@gmail.com>
+
+# ALARM: dequis <dx@dxzone.com.ar>
+#  - remove haskell-xcffib dependency by using the pypi release instead
+
+pkgbase=python-xcffib
+pkgname=(python-xcffib python2-xcffib)
+pkgver=0.9.0
+pkgrel=1
+pkgdesc="Python3 drop in replacement for xpyb, an XCB python binding"
+arch=('any')
+url="https://pypi.python.org/pypi/xcffib"
+license=('Apache')
+makedepends=('python-setuptools' 'python2-setuptools' 'python-cffi' 'python2-cffi' 'python-six'
+             'python2-six' 'libxcb')
+checkdepends=('python-nose' 'python2-nose' 'xorg-server-xvfb' 'xorg-xeyes')
+_name=${pkgname#python-}
+source=("https://files.pythonhosted.org/packages/source/${_name::1}/$_name/$_name-$pkgver.tar.gz")
+sha512sums=('e5891f080fcf1df596c37bb64a70e0de4a41d83b4675dac3b1c128656ab1b09d865e3ab0bfe0e5cc523e89a75dc6127dfc455ab66ca543ba6eeae9ee5bdae168')
+
+
+prepare() {
+  touch xcffib-$pkgver/test/__init__.py
+  cp -a xcffib-$pkgver{,-py2}
+}
+
+build() {
+  cd "$srcdir"/xcffib-$pkgver
+  python setup.py build
+
+  cd "$srcdir"/xcffib-$pkgver-py2
+  python2 setup.py build
+}
+
+check() {
+  cd "$srcdir"/xcffib-$pkgver
+  xvfb-run nosetests3
+
+  cd "$srcdir"/xcffib-$pkgver-py2
+  xvfb-run nosetests2
+}
+
+package_python-xcffib() {
+  depends=('python-six' 'python-cffi' 'libxcb')
+
+  cd xcffib-$pkgver
+  python setup.py install --root="$pkgdir/" --optimize=1
+}
+
+package_python2-xcffib() {
+  depends=('python2-six' 'python2-cffi' 'libxcb')
+
+  cd xcffib-$pkgver-py2
+  python2 setup.py install --root="$pkgdir/" --optimize=1
+}


### PR DESCRIPTION
The 'haskell-xcffib' package contains the code generator used to build
python-xcffib from scratch. The stable pypi releases of xcffib just
include the .py file generated by it, so they don't depend on haskell.

---

Reference: https://github.com/tych0/xcffib#installation

I chose to keep a minimal diff with the upstream pkgbuild, but honestly the python2 part stuff could be removed entirely, no one depends on that anymore. I'm also not sure why upstream isn't just using the pypi release, seems to make the whole build process more complicated for little benefit. cc @felixonmars

I guess this is what resulted in the `qtile` package disappearing from the repo. Forum thread for that: https://archlinuxarm.org/forum/viewtopic.php?f=15&t=14247

Not sure if anything special needs to be done to trigger rebuilds of `python-cairocffi` and `qtile`.