### PR TITLE
added alarm/dkms-8812au

### DIFF
--- a/alarm/dkms-8812au/PKGBUILD
+++ b/alarm/dkms-8812au/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Jefferson Gonzalez <jgmdev@gmail.com>
+
+pkgname=dkms-8812au
+_pkgbase=8812au
+_commit=40eafac156c1ce5e736f9767b27dd967a4ae5cbe
+pkgver=4.2.2.g${_commit:0:7}
+pkgrel=1
+pkgdesc="Driver for Realtek RTL8812AU chipset wireless adaptors."
+arch=('arm' 'armv6h' 'armv7h' 'aarch64')
+url="http://www.realtek.com.tw/"
+license=('GPL')
+depends=('dkms' 'linux-headers')
+conflicts=()
+options=(!strip)
+source=(
+  "https://github.com/gnab/rtl8812au/archive/${_commit}.zip"
+  'dkms.conf'
+  'rtl8812au.conf'
+)
+md5sums=(
+  '19f23c615a12f9038d49a5aacfffbf6e'
+  '1d9e2b78b4a2bdd48ea360550ed0aea7'
+  '6744a04569752913032ef033e1475376'
+)
+
+package() {
+  cd ${srcdir}/rtl8812au-$_commit
+
+  install -d ${pkgdir}/etc/modprobe.d
+  install -d ${pkgdir}/usr/src/${_pkgbase}-${pkgver}
+
+  cp -pr * ${pkgdir}/usr/src/${_pkgbase}-${pkgver}/
+  cp ${srcdir}/dkms.conf ${pkgdir}/usr/src/${_pkgbase}-${pkgver}/
+  cp ${srcdir}/rtl8812au.conf ${pkgdir}/etc/modprobe.d/
+
+  _arch="arm"
+  case "${CARCH}" in
+    aarch64|arm64)
+      _arch="arm64"
+      ;;
+    *)
+  esac
+
+  # Set name and version
+  sed -e "s/@PKGBASE@/${_pkgbase}/" \
+    -e "s/@PKGVER@/${pkgver}/" \
+    -e "s/@ARCH@/${_arch}/" \
+    -i "${pkgdir}"/usr/src/${_pkgbase}-${pkgver}/dkms.conf
+}

--- a/alarm/dkms-8812au/dkms.conf
+++ b/alarm/dkms-8812au/dkms.conf
@@ -1,0 +1,12 @@
+PACKAGE_NAME="@PKGBASE@"
+PACKAGE_VERSION="@PKGVER@"
+BUILT_MODULE_NAME="8812au"
+BUILD_EXCLUSIVE_ARCH="armhf|armel|armv7l|arm64|aarch64"
+PROCS_NUM=$(nproc)
+[ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
+MAKE="'make' ARCH=@ARCH@ -j$PROCS_NUM KVER=${kernelver}
+KSRC=/lib/modules/${kernelver}/build"
+CLEAN="'make' clean"
+DEST_MODULE_LOCATION="/kernel/drivers/net/wireless"
+AUTOINSTALL="yes"
+REMAKE_INITRD=no

--- a/alarm/dkms-8812au/rtl8812au.conf
+++ b/alarm/dkms-8812au/rtl8812au.conf
@@ -1,0 +1,2 @@
+# blacklist kernel built of the module if available
+blacklist rtl8812au


### PR DESCRIPTION
Add driver for wifi chipset RTL8812AU which was removed from 5.x kernel series and is actually being sold by companies like ameridroid and hardkernel branded as Wifi Module 5. This driver uses a github repository that has been updated to work with latest 5.x kernels, I have tested it with kernels from 4.9 to 5.7rc and it is more stable/reliable than the one shipped in older kernels.