### PR TITLE
kodi-rbp4 to 18.6-2

### DIFF
--- a/alarm/kodi-rbp4/PKGBUILD
+++ b/alarm/kodi-rbp4/PKGBUILD
@@ -26,7 +26,7 @@ _prefix=/usr
 pkgbase=kodi-rbp4
 pkgname=('kodi-rbp4' 'kodi-rbp4-eventclients' 'kodi-rbp4-tools-texturepacker' 'kodi-rbp4-dev')
 pkgver=18.6
-pkgrel=1
+pkgrel=2
 _codename=Leia
 _ffmpeg_version="4.0.4-$_codename-18.4"
 _libdvdcss_version="1.4.2-$_codename-Beta-5"
@@ -69,6 +69,7 @@ source=(
   "http://mirrors.kodi.tv/build-deps/sources/fstrcmp-$_fstrcmp_version.tar.gz"
   "http://mirrors.kodi.tv/build-deps/sources/flatbuffers-$_flatbuffers_version.tar.gz"
   01-fix.in-tree.ffmpeg.paths.for.makechrootpkg.hack.patch
+  "02-ffmpeg.hevc.update.hardware.device.to.rpivid.to.match.5.4.y.kernel.patch::https://github.com/popcornmix/xbmc/commit/c6c6dc0aa9cb58701b2d8102b9a0750a7c32f840.patch"
   sysusers.conf
   tmpfiles.conf
 )
@@ -95,6 +96,7 @@ sha256sums=('afdadb63ba72010001361c622403dcb5fe6f3323849223669cb0eb9f5f59db40'
             'e4018e850f80700acee8da296e56e15b1eef711ab15157e542e7d7e1237c3476'
             '5ca5491e4260cacae30f1a5786d109230db3f3a6e5a0eb45d0d0608293d247e3'
             '70b4c7db8766761ca060c038c8abb36c8c678246ca6c5efbde84c58442748ef2'
+            '57669bba9d093a46fcea095e18694aeeb0f1637d0e10e9d0c1139792e53865f7'
             'f521b98232e5035b7cada46cf03975b8d753e93d0802bf22913fceed769f9d96'
             '9c5e79ed8719cd032a3b17dac585aeff28a198e37af1da9af68ef1b86bab4d18')
 
@@ -127,6 +129,7 @@ prepare() {
 
   # Big thanks to asavah for helpful advice here and in the cmake step
   patch -Np1 -i ../01-fix.in-tree.ffmpeg.paths.for.makechrootpkg.hack.patch
+  patch -Np1 -i ../02-ffmpeg.hevc.update.hardware.device.to.rpivid.to.match.5.4.y.kernel.patch
 }
 
 build() {
@@ -196,7 +199,7 @@ package_kodi-rbp4() {
     'bluez-libs' 'curl' 'lcms2' 'libass' 'libbluray' 'libcdio' 'libcec-rpi'
     'libinput' 'libmicrohttpd' 'libnfs' 'libpulse' 'libva' 'libxkbcommon'
     'libxslt' 'lirc' 'mariadb-libs' 'python2' 'smbclient' 'taglib'
-    'tinyxml' 'polkit'
+    'tinyxml' 'polkit' 'linux>=5.4.35'
   )
   optdepends=(
     'afpfs-ng: Apple shares support'


### PR DESCRIPTION
Kernel 5.4.y deprecated `/dev/argon-hevcmem` in favor of `/dev/rpivid-hevcmem` which breaks the HEVC decoding of this package.  The PR incorporates:
* a patch from upstream to fix this
* imposes a versioned dependency on kernel>=5.4.35