### PR TITLE
Fixed gigabit ethernet on A20-OLinuXino-LIME2 for uboot-a20-olinuxino-lime2

### DIFF
--- a/alarm/uboot-sunxi/PKGBUILD
+++ b/alarm/uboot-sunxi/PKGBUILD
@@ -17,17 +17,17 @@ pkgname=('uboot-a10-olinuxino-lime'
          'uboot-pcduino'
          'uboot-pcduino3'
          'uboot-pcduino3-nano')
-pkgver=2017.01
-pkgrel=2
+pkgver=2020.07_rc2
+pkgrel=1
 arch=('armv7h')
 url="http://git.denx.de/u-boot.git/"
 license=('GPL')
-makedepends=('git' 'bc' 'dtc' 'python2')
+makedepends=('git' 'bc' 'dtc' 'python' 'swig')
 backup=(boot/boot.txt boot/boot.scr)
-source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
+source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver//_/-}.tar.bz2"
         'boot.txt'
         'mkscr')
-md5sums=('ad2d82d5b4fa548b2b95bbc26c9bad79'
+md5sums=('ce3fbe043317fa229edb8c6976e7f0c4'
          '95f60c0ae1315e986d8a2aee15d5f854'
          '021623a04afd29ac3f368977140cfbfd')
 
@@ -46,13 +46,11 @@ boards=('A10-OLinuXino-Lime'
         'Linksprite_pcDuino3_Nano')
 
 prepare() {
-  cd u-boot-${pkgver}
-
-  sed -i 's/env python$/&2/' tools/binman/binman{,.py}
+  cd u-boot-${pkgver//_/-}
 }
 
 build() {
-  cd u-boot-${pkgver}
+  cd u-boot-${pkgver//_/-}
 
   unset CFLAGS CXXFLAGS LDFLAGS
 


### PR DESCRIPTION
I guess you kept Das U-Boot at 2017.01 because this is the last version with working gigabit ethernet for A20-OLinuXino-LIME2. I had this issue fixed upstream. Since many other improvements were implemented as well, I suggest you upgrade the package to the latest release candidate that has working gigabit ethernet.