### PR TITLE
Add PKGBUILD for julia-bin for aarch64.

### DIFF
--- a/aur/julia-bin/PKGBUILD
+++ b/aur/julia-bin/PKGBUILD
@@ -1,0 +1,21 @@
+pkgname=julia-bin
+pkgver=1.4.2
+pkgrel=1
+arch=('aarch64')
+pkgdesc='High-level, high-performance, dynamic programming language - official binaries'
+provides=(julia)
+conflicts=(julia)
+url='https://julialang.org/'
+license=('MIT')
+source=("https://julialang-s3.julialang.org/bin/linux/aarch64/${pkgver:0:3}/julia-${pkgver}-linux-aarch64.tar.gz")
+sha256sums=('f124d1b9fa68c3049d4ffe2349454f8ba1753d17d6578bc6e7cb916aed7cff4a')
+options=(!strip)
+
+package() {
+  mkdir -p ${pkgdir}/usr/share/licenses/julia
+  cp -r julia-${pkgver}/{bin,etc,include,lib,share} ${pkgdir}/usr/
+  install -Dm644 julia-${pkgver}/LICENSE.md \
+      ${pkgdir}/usr/share/licenses/julia/LICENSE.md
+}
+
+# vim: ts=2 sw=2 et:


### PR DESCRIPTION
The Julia team maintains a build for aarch64 along with x86_64. This
PKGBUILD downloads that aarch64 build and makes an arch package out of
it.

This PKGBUILD was copied and modified from the AUR PKGBUILD for
julia-bin.