### PR TITLE
Introduced uboot-orangepi_r1 package and bumped uboot-sunxi to 2020.04

### DIFF
--- a/alarm/uboot-sunxi/PKGBUILD
+++ b/alarm/uboot-sunxi/PKGBUILD
@@ -14,20 +14,21 @@ pkgname=('uboot-a10-olinuxino-lime'
          'uboot-cubieboard'
          'uboot-cubieboard2'
          'uboot-cubietruck'
+         'uboot-orangepi_r1'
          'uboot-pcduino'
          'uboot-pcduino3'
          'uboot-pcduino3-nano')
-pkgver=2017.01
-pkgrel=2
+pkgver=2020.04
+pkgrel=1
 arch=('armv7h')
 url="http://git.denx.de/u-boot.git/"
 license=('GPL')
-makedepends=('git' 'bc' 'dtc' 'python2')
+makedepends=('git' 'bc' 'dtc' 'python' 'swig')
 backup=(boot/boot.txt boot/boot.scr)
 source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
         'boot.txt'
         'mkscr')
-md5sums=('ad2d82d5b4fa548b2b95bbc26c9bad79'
+md5sums=('51113d2288c55110e33a895c65ab9f60'
          '95f60c0ae1315e986d8a2aee15d5f854'
          '021623a04afd29ac3f368977140cfbfd')
 
@@ -41,15 +42,10 @@ boards=('A10-OLinuXino-Lime'
         'Cubieboard'
         'Cubieboard2'
         'Cubietruck'
+        'orangepi_r1'
         'Linksprite_pcDuino'
         'Linksprite_pcDuino3'
         'Linksprite_pcDuino3_Nano')
-
-prepare() {
-  cd u-boot-${pkgver}
-
-  sed -i 's/env python$/&2/' tools/binman/binman{,.py}
-}
 
 build() {
   cd u-boot-${pkgver}
@@ -59,9 +55,9 @@ build() {
   for i in ${boards[@]}; do
     mkdir ../bin_${i}
     make distclean
-    make ${i}_config
+    make ${i}_defconfig
     echo 'CONFIG_IDENT_STRING=" Arch Linux ARM"' >> .config
-    make EXTRAVERSION=-${pkgrel}
+    make -j 5 EXTRAVERSION=-${pkgrel}
     mv u-boot-sunxi-with-spl.bin ../bin_${i}
   done
 
@@ -160,6 +156,20 @@ package_uboot-a20-olinuxino-micro() {
 
   install -d "${pkgdir}"/boot
   install -Dm644 bin_A20-OLinuXino_MICRO/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
+
+  install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
+  install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr
+  install -Dm755 mkscr "${pkgdir}"/boot/mkscr
+}
+
+package_uboot-orangepi_r1() {
+  pkgdesc="U-Boot for Orange Pi R1"
+  install=${pkgbase}.install
+  provides=('uboot-sunxi')
+  conflicts=('uboot-sunxi')
+
+  install -d "${pkgdir}"/boot
+  install -Dm644 bin_orangepi_r1/u-boot-sunxi-with-spl.bin "${pkgdir}"/boot
 
   install -Dm644 boot.txt "${pkgdir}"/boot/boot.txt
   install -Dm644 boot.scr "${pkgdir}"/boot/boot.scr


### PR DESCRIPTION
I would like to introduce Orange Pi R1 officially.
This is a tiny cheap SBC having two Ethernet interfaces.
I have two of these boards running without issues for about a year and I have successfully flashed both with the bootloader I have built with this package.
Alas, I don't have any other boards to try the rest of bootloaders that this package builds.
If you need me to update installation instructions for this board I can do that.
Basically I have used https://wiki.archlinux.org/index.php/Orange_Pi as a guide.