### PR TITLE
Allow uDisks2 actions to be used by Kodi

### DIFF
--- a/alarm/kodi-rbp3/polkit.rules
+++ b/alarm/kodi-rbp3/polkit.rules
@@ -8,5 +8,8 @@ polkit.addRule(function(action, subject) {
         if (action.id.indexOf("org.freedesktop.udisks.") == 0) {
             return polkit.Result.YES;
         }
+        if (action.id.indexOf("org.freedesktop.udisks2.") == 0) {
+            return polkit.Result.YES;
+        }
     }
 });


### PR DESCRIPTION
When using uDisks2, the action id starts with `org.freedesktop.udisks2.`.