### PR TITLE
core/linux-odroid-c2 to 3.16.85-1

### DIFF
--- a/core/linux-odroid-c2/PKGBUILD
+++ b/core/linux-odroid-c2/PKGBUILD
@@ -4,11 +4,11 @@
 buildarch=8
 
 pkgbase=linux-odroid-c2
-_commit=2ddfe869e9964afe1175919557e6b4f18b78941a
+_commit=64c8062a2c3d89d514f92299528e771b5acf726b
 _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="ODROID-C2"
-pkgver=3.16.82
+pkgver=3.16.85
 pkgrel=1
 arch=('aarch64')
 url="https://github.com/hardkernel/linux/tree/odroidc2-v3.16.y"
@@ -34,7 +34,7 @@ source=("https://github.com/hardkernel/linux/archive/${_commit}.tar.gz"
         'amlogic.service'
         '60-linux.hook'
         '90-linux.hook')
-md5sums=('600c70d8ee79bb06425d4f97fb50bc5b'
+md5sums=('594c5a6c9d16afff5504f83ccc886c37'
          'SKIP'
          'adbecf48248cd62a5bd322750720b88b'
          '2e1437a81bdaa1ca68bb1c3f69e0548b'


### PR DESCRIPTION
Signed-off-by: graysky <graysky@archlinux.us>