### PR TITLE
Make all linux>5.6 packages provide WIREGUARD-MODULE

### DIFF
--- a/core/linux-aarch64-rc/PKGBUILD
+++ b/core/linux-aarch64-rc/PKGBUILD
@@ -11,7 +11,7 @@ _srcname=linux-${_rcver}-rc${_rcrel}
 _kernelname=${pkgbase#linux}
 _desc="AArch64 multi-platform (release candidate)"
 pkgver=${_rcver}.rc${_rcrel}
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -96,7 +96,7 @@ _package() {
   pkgdesc="The Linux Kernel and modules - ${_desc}"
   depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
   optdepends=('crda: to set the correct wireless channels of your country')
-  provides=("linux=${pkgver}")
+  provides=("linux=${pkgver}" "WIREGUARD-MODULE")
   replaces=('linux-armv8-rc')
   conflicts=('linux')
   backup=("etc/mkinitcpio.d/${pkgbase}.preset")

--- a/core/linux-aarch64/PKGBUILD
+++ b/core/linux-aarch64/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-5.7
 _kernelname=${pkgbase#linux}
 _desc="AArch64 multi-platform"
 pkgver=5.7.8
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -99,7 +99,7 @@ _package() {
   pkgdesc="The Linux Kernel and modules - ${_desc}"
   depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
   optdepends=('crda: to set the correct wireless channels of your country')
-  provides=('kernel26' "linux=${pkgver}")
+  provides=('kernel26' "linux=${pkgver}" "WIREGUARD-MODULE")
   replaces=('linux-armv8')
   conflicts=('linux')
   backup=("etc/mkinitcpio.d/${pkgbase}.preset")

--- a/core/linux-am33x/PKGBUILD
+++ b/core/linux-am33x/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-5.7
 _kernelname=${pkgbase#linux}
 _desc="TI AM335x Beaglebone (Black)"
 pkgver=5.7.6
-pkgrel=1
+pkgrel=2
 rcnver=5.7.6
 rcnrel=bone13
 arch=('armv7h')
@@ -93,7 +93,7 @@ _package() {
   depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
   optdepends=('crda: to set the correct wireless channels of your country')
   backup=("etc/mkinitcpio.d/${pkgbase}.preset")
-  provides=('kernel26' "linux=${pkgver}")
+  provides=('kernel26' "linux=${pkgver}" "WIREGUARD-MODULE")
   conflicts=('linux')
   replaces=('linux-ti')
   install=${pkgname}.install

--- a/core/linux-armv5-rc/PKGBUILD
+++ b/core/linux-armv5-rc/PKGBUILD
@@ -11,7 +11,7 @@ _srcname=linux-${_rcver}-rc${_rcrel}
 _kernelname=${pkgbase#linux}
 _desc="ARMv5 multi-platform (release candidate)"
 pkgver=${_rcver}.rc${_rcrel}
-pkgrel=1
+pkgrel=2
 arch=('arm')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -101,7 +101,7 @@ _package() {
   pkgdesc="The Linux Kernel and modules - ${_desc}"
   depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
   optdepends=('crda: to set the correct wireless channels of your country')
-  provides=('kernel26' "linux=${pkgver}")
+  provides=('kernel26' "linux=${pkgver}" "WIREGUARD-MODULE")
   conflicts=('linux')
   install=${pkgname}.install
 

--- a/core/linux-armv5/PKGBUILD
+++ b/core/linux-armv5/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-5.7
 _kernelname=${pkgbase#linux}
 _desc="ARMv5 multi-platform"
 pkgver=5.7.8
-pkgrel=1
+pkgrel=2
 arch=('arm')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -103,7 +103,7 @@ _package() {
   pkgdesc="The Linux Kernel and modules - ${_desc}"
   depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
   optdepends=('crda: to set the correct wireless channels of your country')
-  provides=('kernel26' "linux=${pkgver}")
+  provides=('kernel26' "linux=${pkgver}" "WIREGUARD-MODULE")
   conflicts=('linux')
   install=${pkgname}.install
 

--- a/core/linux-armv7-rc/PKGBUILD
+++ b/core/linux-armv7-rc/PKGBUILD
@@ -12,7 +12,7 @@ _srcname=linux-${_rcver}-rc${_rcrel}
 _kernelname=${pkgbase#linux}
 _desc="ARMv7 multi-platform (release candidate)"
 pkgver=${_rcver}.rc${_rcrel}
-pkgrel=1
+pkgrel=2
 arch=('armv7h')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -115,7 +115,7 @@ _package() {
   depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
   optdepends=('crda: to set the correct wireless channels of your country')
   backup=("etc/mkinitcpio.d/${pkgbase}.preset")
-  provides=('kernel26' "linux=${pkgver}")
+  provides=('kernel26' "linux=${pkgver}" "WIREGUARD-MODULE")
   conflicts=('linux')
   replaces=('linux-mvebu')
   install=${pkgname}.install

--- a/core/linux-armv7/PKGBUILD
+++ b/core/linux-armv7/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-5.7
 _kernelname=${pkgbase#linux}
 _desc="ARMv7 multi-platform"
 pkgver=5.7.6
-pkgrel=1
+pkgrel=2
 rcnver=5.7.6
 rcnrel=armv7-x13
 arch=('armv7h')
@@ -119,7 +119,7 @@ _package() {
   depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
   optdepends=('crda: to set the correct wireless channels of your country')
   backup=("etc/mkinitcpio.d/${pkgbase}.preset")
-  provides=('kernel26' "linux=${pkgver}")
+  provides=('kernel26' "linux=${pkgver}" "WIREGUARD-MODULE")
   conflicts=('linux')
   replaces=('linux-mvebu' 'linux-udoo' 'linux-sun4i' 'linux-sun5i' 'linux-sun7i' 'linux-usbarmory' 'linux-wandboard' 'linux-clearfog')
   install=${pkgname}.install

--- a/core/linux-espressobin/PKGBUILD
+++ b/core/linux-espressobin/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-5.7
 _kernelname=${pkgbase#linux}
 _desc="Globalscale ESPRESSOBin"
 pkgver=5.7.8
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -84,7 +84,7 @@ _package() {
   pkgdesc="The Linux Kernel and modules - ${_desc}"
   depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7' 'uboot-tools')
   optdepends=('crda: to set the correct wireless channels of your country')
-  provides=("linux=${pkgver}")
+  provides=("linux=${pkgver}" "WIREGUARD-MODULE")
   conflicts=('linux')
   backup=("etc/mkinitcpio.d/${pkgbase}.preset")
   install=${pkgname}.install

--- a/core/linux-kirkwood-dt/PKGBUILD
+++ b/core/linux-kirkwood-dt/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-5.7
 _kernelname=${pkgbase#linux}
 _desc="Marvell Kirkwood DT"
 pkgver=5.7.8
-pkgrel=1
+pkgrel=2
 arch=('arm')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -94,7 +94,7 @@ _package() {
   pkgdesc="The Linux Kernel and modules - ${_desc}"
   depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
   optdepends=('crda: to set the correct wireless channels of your country')
-  provides=('kernel26' 'linux=${pkgver}')
+  provides=('kernel26' 'linux=${pkgver}' "WIREGUARD-MODULE")
   conflicts=('linux-kirkwood' 'linux' 'linux-olinuxino')
   backup=("etc/mkinitcpio.d/${pkgbase}.preset")
   install=${pkgname}.install


### PR DESCRIPTION
All Arch Linux kernel packages have been updated to provide `WIREGUARD-MODULE` since when WireGuard was merged in Linux 5.6.

This pull-requests adds `WIREGUARD-MODULE` to `provides` for the main kernel+modules package in all linux>5.6 kernels.