### PR TITLE
add comunity/rclone

### DIFF
--- a/community/rclone/PKGBUILD
+++ b/community/rclone/PKGBUILD
@@ -1,0 +1,53 @@
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+# Maintainer: Morten Linderud <foxboron@archlinux.org>
+
+# ALARM: Lorenz Steinert <lsteinert@uraziel.de>
+#  - remove makedepends python and pandoc
+#  - remove prepare()
+#  - remove rclone.1 MANUAL.html and MANUAL.txt targets from make in build()
+
+pkgname=rclone
+pkgver=1.52.2
+pkgrel=2.1
+pkgdesc="Sync files to and from Google Drive, S3, Swift, Cloudfiles, Dropbox and Google Cloud Storage"
+arch=('x86_64')
+url="https://rclone.org/"
+license=('MIT')
+depends=('glibc')
+optdepends=('fuse2: for rclone mount')
+makedepends=('go' 'git')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/rclone/rclone/archive/v$pkgver.tar.gz")
+sha512sums=('f49f0dcf8bfa105b01b35921daa655a6c1161f6505e2299f027a4059d196adcc673038b1718320e6f0b8bb053fad8d2de7714f66fa245dd90ea0a791e848a418')
+
+build() {
+  cd "rclone-$pkgver"
+  
+  export GOFLAGS="-buildmode=pie -trimpath"
+  export CGO_LDFLAGS="${LDFLAGS}"
+  export CGO_CFLAGS="${CFLAGS}"
+  export CGO_CPPFLAGS="${CPPFLAGS}"
+
+  PATH=".:$PATH" make TAG=v$pkgver rclone
+ ./rclone genautocomplete bash rclone.bash_completion
+ ./rclone genautocomplete zsh rclone.zsh_completion
+}
+
+check() {
+  cd "rclone-$pkgver"
+  make TAG=v$pkgver test
+}
+
+package() {
+  cd "rclone-$pkgver"
+
+  install -Dm755 rclone "$pkgdir"/usr/bin/rclone
+
+  install -Dm644 rclone.bash_completion "$pkgdir"/usr/share/bash-completion/completions/rclone
+  install -Dm644 rclone.zsh_completion "$pkgdir"/usr/share/zsh/site-functions/_rclone
+
+  install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
+
+  install -Dm644 rclone.1 "$pkgdir"/usr/share/man/man1/rclone.1
+  install -d "$pkgdir"/usr/share/doc/$pkgname
+  install -t "$pkgdir"/usr/share/doc/$pkgname -m644 MANUAL.html MANUAL.txt
+}


### PR DESCRIPTION
adds a `PKGBUILD` for `community/rclone`. 

this packages seemed to exist at some point as the current version i could find was `1.43.1`. This PR updates this to `1.52.2`.