### PR TITLE
Splitting linux-firmware into a full version and stripped version

### DIFF
--- a/core/linux-firmware/PKGBUILD
+++ b/core/linux-firmware/PKGBUILD
@@ -1,0 +1,52 @@
+# Maintainer: Thomas Bächler <thomas@archlinux.org>
+
+pkgbase=linux-firmware
+pkgname=(linux-firmware linux-firmware-full)
+#_commit=7a30af16115959cf5a817ae51429e72c0084fc0c  # tags/20200817^0
+_tag=20200918
+pkgver=20200916.00a84c5
+pkgrel=1
+pkgdesc="Firmware files for Linux"
+url="https://git.kernel.org/?p=linux/kernel/git/firmware/linux-firmware.git;a=summary"
+license=('GPL2' 'GPL3' 'custom')
+arch=('any')
+makedepends=('git')
+options=(!strip)
+source=("git+https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git#tag=${_tag}")
+sha256sums=('SKIP')
+#validpgpkeys=('4CDE8575E547BF835FE15807A31B6BD72486CFD6') # Josh Boyer <jwboyer@fedoraproject.org>
+
+prepare() {
+  cd ${pkgbase}
+}
+
+pkgver() {
+  cd ${pkgbase}
+
+  # Commit date + short rev
+  echo $(TZ=UTC git show -s --pretty=%cd --date=format-local:%Y%m%d HEAD).$(git rev-parse --short HEAD)
+}
+
+
+package_linux-firmware-full() {
+  provides=('linux-firmware')
+  conflicts=('linux-firmware')
+  cd ${pkgbase}
+  make DESTDIR="${pkgdir}" FIRMWAREDIR=/usr/lib/firmware install
+  install -Dt "${pkgdir}/usr/share/licenses/${pkgname}" -m644 LICEN* WHENCE
+}
+
+package_linux-firmware() {
+  pkgdesc="Slightly trimmed Linux firmware files"
+  optdepends=('linux-firmware-full: Full Linux firmware package')
+  conflicts=('linux-firmware-full')
+  replaces=('linux-firmware-full')
+  cd ${pkgbase}
+  make DESTDIR="${pkgdir}" FIRMWAREDIR=/usr/lib/firmware install
+  rm -rf ${pkgdir}/usr/lib/firmware/{netronome,amdgpu,liquidio,mellanox,i915,amd,3com,ascenic,adaptec,cxgb4,amd,amd-ucode,radeon,advansys,qlogic,keyspan_pda,edgeport,sb16,slicoss,cxgp3,tehuti,cis,ositech,usbdux,r128}
+  install -Dt "${pkgdir}/usr/share/licenses/${pkgname}" -m644 LICEN* WHENCE
+}
+
+
+
+# vim:set sw=2 et:


### PR DESCRIPTION
Saves ~200M of space by doing some cursory removals and then adding a linux-firmware-full package for complete firmware. Since not all kernels support compressed firmware, this is just a quick way to reduce the size of an install.