### PR TITLE
alarm/uboot-raspberrypi to 2020.10-1

### DIFF
--- a/alarm/uboot-raspberrypi/PKGBUILD
+++ b/alarm/uboot-raspberrypi/PKGBUILD
@@ -4,8 +4,8 @@
 buildarch=12
 
 pkgname=uboot-raspberrypi
-pkgver=2020.07
-pkgrel=2
+pkgver=2020.10
+pkgrel=1
 pkgdesc="U-Boot for Raspberry Pi"
 arch=('armv7h' 'aarch64')
 url='http://www.denx.de/wiki/U-Boot/WebHome'
@@ -23,7 +23,7 @@ source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver/rc/-rc}.tar.bz2"
         'boot.txt.v2'
         'boot.txt.v3'
         'mkscr')
-md5sums=('86e51eeccd15e658ad1df943a0edf622'
+md5sums=('14656f08aa73a8dbbde2424fe78bbe3b'
          '0c56f6b8fde06be1415b3ff85b5b5370'
          'e4b819439961514c7441473d4733a1b4'
          '38cab92f98944f0492c5320cf8b36870'


### PR DESCRIPTION
Fixes the inability to boot from usb