### PR TITLE
Build u-boot.bin for uboot-odroid-n2 using native toolchain

### DIFF
--- a/alarm/uboot-odroid-n2/0001-sd_fusing-tweaks.patch
+++ b/alarm/uboot-odroid-n2/0001-sd_fusing-tweaks.patch
@@ -8,25 +8,25 @@ Subject: [PATCH 1/2] sd_fusing tweaks
  1 file changed, 3 insertions(+), 4 deletions(-)
 
 diff --git a/sd_fuse/sd_fusing.sh b/sd_fuse/sd_fusing.sh
-index 451013f119..538fdfa3b5 100755
+index 8698294..3ae1fff 100755
 --- a/sd_fuse/sd_fusing.sh
 +++ b/sd_fuse/sd_fusing.sh
-@@ -12,12 +12,11 @@ abort() {
+@@ -12,15 +12,14 @@ abort() {
  }
  
- [ -z $1 ] && abort "usage: $0 <your/memory/card/device>"
--[ -z ${UBOOT} ] && UBOOT=${PWD}/u-boot.bin
--[ ! -f ${UBOOT} ] && abort "error: ${UBOOT} is not exist"
-+[ -z ${UBOOT} ] && UBOOT=/boot/u-boot.bin
-+[ ! -f ${UBOOT} ] && abort "Error: ${UBOOT} doesn't exist"
+ [ -z "$1" ] && abort "usage: $0 <your/memory/card/device>"
+-[ -z "$UBOOT" ] && UBOOT="${PWD}/u-boot.bin"
++[ -z "$UBOOT" ] && UBOOT="/boot/u-boot.bin"
+ if [ ! -f "$UBOOT" ] ; then
+ 	UBOOT="$(echo "$0" | perl -pe 's/[^\/]*$//g')u-boot.bin"
+ fi
+-[ ! -f "$UBOOT" ] && abort "error: $UBOOT is not exist"
++[ ! -f "$UBOOT" ] && abort "Error: $UBOOT does not exist"
  
--sudo dd if=$UBOOT of=$1 conv=fsync,notrunc bs=512 seek=1
-+dd if=$UBOOT of=$1 conv=fsync,notrunc bs=512 seek=1
+-sudo dd if="$UBOOT" of="$1" conv=fsync,notrunc bs=512 seek=1
++dd if="$UBOOT" of="$1" conv=fsync,notrunc bs=512 seek=1
  
  sync
  
--sudo eject $1
- echo Finished.
--- 
-2.20.1
-
+-sudo eject "$1"
+ echo "Finished."

--- a/alarm/uboot-odroid-n2/0003-gcc-10.patch
+++ b/alarm/uboot-odroid-n2/0003-gcc-10.patch
@@ -1,0 +1,26 @@
+diff --git a/Makefile b/Makefile
+index 730e8d7..f5e7190 100644
+--- a/Makefile
++++ b/Makefile
+@@ -589,7 +589,7 @@ include $(srctree)/scripts/Makefile.extrawarn
+ KBUILD_CPPFLAGS += $(KCPPFLAGS)
+ KBUILD_AFLAGS += $(KAFLAGS)
+ KBUILD_CFLAGS += $(KCFLAGS)
+-KBUILD_CFLAGS += -Werror
++#KBUILD_CFLAGS += -Werror
+ 
+ # Use UBOOTINCLUDE when you must reference the include/ directory.
+ # Needed to be compatible with the O= option
+diff --git a/include/linux/compiler-gcc.h b/include/linux/compiler-gcc.h
+index e057bd2..6341d32 100644
+--- a/include/linux/compiler-gcc.h
++++ b/include/linux/compiler-gcc.h
+@@ -109,7 +109,7 @@
+ #define __always_unused			__attribute__((unused))
+ 
+ #define __gcc_header(x) #x
+-#define _gcc_header(x) __gcc_header(linux/compiler-gcc##x.h)
++#define _gcc_header(x) __gcc_header(linux/compiler-gcc4.h)
+ #define gcc_header(x) _gcc_header(x)
+ #include gcc_header(__GNUC__)
+ 

--- a/alarm/uboot-odroid-n2/PKGBUILD
+++ b/alarm/uboot-odroid-n2/PKGBUILD
@@ -1,14 +1,11 @@
 # U-Boot: ODROID-N2
 # Maintainer: Kevin Mihelich <kevin@archlinuxarm.org>
 
-# Note: must be built on x86 with an old cross toolchain
-
 buildarch=8
-noautobuild=1
 
 pkgname=uboot-odroid-n2
 pkgver=2015.01
-pkgrel=10
+pkgrel=11
 pkgdesc="U-Boot for ODROID-N2"
 arch=('aarch64')
 url="https://github.com/hardkernel/u-boot"
@@ -17,16 +14,18 @@ install=$pkgname.install
 depends=('uboot-tools')
 makedepends=('git' 'bc')
 backup=('boot/boot.ini')
-_commit=c989da31a5c1da3ab57d7c6dc5a3fdbcc1c3eed7
+_commit=12c58e94e533b85a19d2f83d1c0a34345764ca07
 source=("https://github.com/hardkernel/u-boot/archive/${_commit}.tar.gz"
         'boot.ini'
         '0001-sd_fusing-tweaks.patch'
         '0002-arch-linux-arm-modifications.patch'
+        '0003-gcc-10.patch'
         '91-uboot-uimg.hook')
-md5sums=('1ebd40196d6b395a22ef960dfa67c5f4'
+md5sums=('b0e7dac5be81affa98d1d088cb2e91e3'
          '33de84d1cc619dba9b14d87b510684ff'
-         'cc18cda0bc75936e602341efd5a2fe93'
+         '8ac2ffdfbef4f3ed4a08c718681c10a4'
          '4d14405ba98f09c002505cbe53e2f6cb'
+         'b53452f35853abde875e3753fc3d1254'
          '1931c8dfde7088530f173ca59fdb8989')
 
 prepare() {
@@ -34,23 +33,24 @@ prepare() {
 
   git apply ../0001-sd_fusing-tweaks.patch
   git apply ../0002-arch-linux-arm-modifications.patch
+  git apply ../0003-gcc-10.patch
 }
 
 build() {
   cd u-boot-${_commit}
 
   unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-  
-  make distclean mrproper
-  make odroidn2_config
-  make -j1 EXTRAVERSION=-${pkgrel}
+
+  make CROSS_COMPILE= -j1 distclean mrproper
+  make CROSS_COMPILE= -j1 odroidn2_config
+  make CROSS_COMPILE= EXTRAVERSION=-${pkgrel} u-boot.bin
 }
 
 package() {
   cd u-boot-${_commit}/sd_fuse
 
   mkdir -p "${pkgdir}"/boot
-  cp sd_fusing.sh u-boot.bin "${pkgdir}"/boot
+  cp sd_fusing.sh ../build/u-boot.bin "${pkgdir}"/boot
   cp "${srcdir}"/boot.ini "${pkgdir}"/boot
   install -Dm644 "${srcdir}/91-uboot-uimg.hook" "${pkgdir}/usr/share/libalpm/hooks/91-uboot-uimg.hook"
 }


### PR DESCRIPTION
This change builds the `u-boot.bin` for the odroid n2 using the native GCC10 toolchain. It removes the requirement for an x86 build host as well as an old non-Arch toolchain.

The resulting artefact will require some more testing to make sure it works reliably.