### PR TITLE
added alarm/uboot-odroid-c4

### DIFF
--- a/alarm/uboot-odroid-c4/0001-sd_fusing-tweaks.diff
+++ b/alarm/uboot-odroid-c4/0001-sd_fusing-tweaks.diff
@@ -1,0 +1,15 @@
+diff -u sd_fuse/sd_fusing.sh sd_fuse/sd_fusing.sh
+--- sd_fuse/sd_fusing.sh	2020-10-24 13:22:06.000000000 +0200
++++ sd_fuse/sd_fusing.sh	2020-12-15 10:59:14.400405631 +0100
+@@ -18,9 +18,8 @@
+ fi
+ [ ! -f "$UBOOT" ] && abort "error: $UBOOT is not exist"
+ 
+-sudo dd if="$UBOOT" of="$1" conv=fsync,notrunc bs=512 seek=1
++dd if="$UBOOT" of="$1" conv=fsync,notrunc bs=512 seek=1
+ 
+ sync
+ 
+-sudo eject "$1"
+-echo "Finished."
++echo "Successfully wrote U-Boot to $1"

--- a/alarm/uboot-odroid-c4/0002-arch-linux-arm-modifications.diff
+++ b/alarm/uboot-odroid-c4/0002-arch-linux-arm-modifications.diff
@@ -1,0 +1,33 @@
+diff -u include/configs/odroid-g12-common.h include/configs/odroid-g12-common.h
+--- include/configs/odroid-g12-common.h	2020-10-24 13:22:06.000000000 +0200
++++ include/configs/odroid-g12-common.h	2020-12-15 22:16:15.250716582 +0100
+@@ -96,7 +96,7 @@
+ 
+ #define ENV_BOOT_ORDER_DEFAULT			"boot_order=mmc rawimage usb pxe spi\0"
+ 
+-#define ENV_BOOTSCRIPTS_DEFAULT			"boot_scripts=boot.ini boot.scr\0"
++#define ENV_BOOTSCRIPTS_DEFAULT			"boot_scripts=/boot/boot.ini\0"
+ 
+ #define ENV_BOOT_ATTEMPT_DEFAULT			\
+ 	"boot_attempt="					\
+@@ -347,7 +347,7 @@
+ #define CONFIG_DDR_PLL_BYPASS			0 //0:disable, 1:enable. ddr pll bypass function
+ 
+ /* storage: emmc/nand/sd */
+-#define CONFIG_ENV_IS_IN_MMC			1
++#define CONFIG_ENV_IS_NOWHERE			1
+ #define 	CONFIG_ENV_OVERWRITE
+ #define 	CONFIG_CMD_SAVEENV
+ /* fixme, need fix*/
+@@ -542,6 +542,11 @@
+ #define CONFIG_CMD_UNZIP			1
+ #define CONFIG_LZMA				1
+ 
++/* Arch Linux ARM */
++#define CONFIG_IDENT_STRING		" Arch Linux ARM"
++#define CONFIG_CMD_PART
++#define CONFIG_PARTITION_UUIDS
++
+ /* other functions */
+ #define CONFIG_NEED_BL301			1
+ #define CONFIG_NEED_BL32			1

--- a/alarm/uboot-odroid-c4/PKGBUILD
+++ b/alarm/uboot-odroid-c4/PKGBUILD
@@ -1,0 +1,52 @@
+# U-Boot: ODROID-C4
+# Maintainer: sfan5 <sfan5@live.de>
+
+# Note: must be built on x86 with an old cross toolchain
+
+buildarch=8
+noautobuild=1
+
+pkgname=uboot-odroid-c4
+pkgver=2015.01
+pkgrel=1
+pkgdesc="U-Boot for ODROID-C4"
+arch=('aarch64')
+url="https://github.com/hardkernel/u-boot"
+license=('GPL')
+install=$pkgname.install
+makedepends=('bc')
+backup=('boot/boot.ini')
+_commit=e2abc5921e892c2a1a75003b5ff1fdbfa04b40a0
+source=("https://github.com/hardkernel/u-boot/archive/${_commit}.tar.gz"
+        'boot.ini'
+        '0001-sd_fusing-tweaks.diff'
+        '0002-arch-linux-arm-modifications.diff')
+sha1sums=('652747f41fd318279526c2fb466ae3c27bcf6cb9'
+          'b1ef9c359a2d370ef3f49a0c3fdd76e024d8a3ba'
+          '0a9aac03daaa4ac1929d6b4ef33569ab93eb7804'
+          '43f3e1f5ba825d16a51fe66e2169146d9b421f4d')
+
+prepare() {
+  cd u-boot-${_commit}
+
+  patch -p0 --verbose <../0001-sd_fusing-tweaks.diff
+  patch -p0 --verbose <../0002-arch-linux-arm-modifications.diff
+}
+
+build() {
+  cd u-boot-${_commit}
+
+  unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
+
+  make distclean
+  make odroidc4_config
+  make -j1 EXTRAVERSION=-${pkgrel}
+}
+
+package() {
+  cd u-boot-${_commit}/sd_fuse
+
+  install -d "${pkgdir}"/boot
+  install -t "${pkgdir}"/boot sd_fusing.sh
+  install -t "${pkgdir}"/boot -m 0644 u-boot.bin "${srcdir}"/boot.ini
+}

--- a/alarm/uboot-odroid-c4/boot.ini
+++ b/alarm/uboot-odroid-c4/boot.ini
@@ -1,0 +1,22 @@
+ODROIDC4-UBOOT-CONFIG
+
+setenv condev "console=ttyAML0,115200n8"
+
+# Boot Args
+part uuid ${devtype} ${devno}:1 uuid
+setenv bootargs "root=PARTUUID=${uuid} rootwait rw ${condev}"
+
+# Load kernel, dtb and initrd
+setenv dtb_loadaddr "0x10000000"
+setenv loadaddr "0x1100000"
+setenv initrd_loadaddr "0x4000000"
+
+load ${devtype} ${devno}:1 ${loadaddr} /boot/Image
+
+load ${devtype} ${devno}:1 ${dtb_loadaddr} /boot/dtbs/amlogic/meson-sm1-odroid-c4.dtb
+fdt addr ${dtb_loadaddr}
+
+load ${devtype} ${devno}:1 ${initrd_loadaddr} /boot/initramfs-linux.img
+
+# boot
+booti ${loadaddr} ${initrd_loadaddr}:${filesize} ${dtb_loadaddr}

--- a/alarm/uboot-odroid-c4/uboot-odroid-c4.install
+++ b/alarm/uboot-odroid-c4/uboot-odroid-c4.install
@@ -1,0 +1,39 @@
+sd_fuse() {
+  device=/dev/$1
+  if [ ! -b ${device} ]; then
+    echo "No MMC device to flash, exiting."
+    exit 0
+  fi
+
+  echo "u-boot fusing"
+  dd if=/boot/u-boot.bin of=${device} conv=fsync,notrunc bs=512 seek=1
+}
+
+flash_uboot() {
+  if mountpoint -d /boot > /dev/null 2>&1; then
+    base=/boot
+  else
+    base=/
+  fi
+  major=$(mountpoint -d $base | cut -f 1 -d ':')
+  minor=$(expr $(mountpoint -d $base | cut -f 2 -d ':') - 1)
+  device=$(awk '{if($1 == "'${major}'" && $2 == "'${minor}'") print $4}' /proc/partitions)
+
+  echo "A new U-Boot version needs to be flashed onto /dev/${device}."
+  echo "Do you want to do this now? [y|N]"
+  read -r shouldwe
+  if [[ $shouldwe =~ ^([yY][eE][sS]|[yY])$ ]]; then
+    sd_fuse $device
+  else
+    echo "You can do this later by running:"
+    echo "# cd /boot; ./sd_fusing.sh /dev/${device}"
+  fi
+}
+
+post_install() {
+  flash_uboot
+}
+
+post_upgrade() {
+  flash_uboot
+}


### PR DESCRIPTION
The shipped script is only meant to boot a mainline kernel.
No unusual setup needed, u-boot will load stuff directly from `/boot` on the root partition.

Tested to work with linux-aarch64 5.8.9-2 from repos and 5.10.1 too.
eMMC booting should work too but I don't have one to test.


> `# Note: must be built on x86 with an old cross toolchain`

I used [the following toolchain](https://github.com/hardkernel/u-boot/blob/12c58e94e533b85a19d2f83d1c0a34345764ca07/.travis.yml#L30-L33) locally.

---

Edit: [Mainline U-Boot](https://u-boot.readthedocs.io/en/latest/board/amlogic/odroid-c4.html) also supports the ODROID-C4, but building it appears to be just as if not more bothersome as the vendor u-boot.