### PR TITLE
extra/mesa: add vulkan-broadcom

### DIFF
--- a/extra/mesa/PKGBUILD
+++ b/extra/mesa/PKGBUILD
@@ -7,12 +7,13 @@
 #  - Removed DRI and Gallium3D drivers/packages for chipsets that don't exist in our ARM devices (intel, VMware svga).
 #  - disable assembly and rip out VC4 forced NEON for v6/v7
 #  - remove makedepend on valgrind, -Dvalgrind=false
+#  - add broadcom vulkan driver
 
 pkgbase=mesa
-pkgname=('vulkan-mesa-layers' 'opencl-mesa' 'vulkan-radeon' 'vulkan-swrast' 'libva-mesa-driver' 'mesa-vdpau' 'mesa')
+pkgname=('vulkan-mesa-layers' 'opencl-mesa' 'vulkan-radeon' 'vulkan-swrast' 'vulkan-broadcom' 'libva-mesa-driver' 'mesa-vdpau' 'mesa')
 pkgdesc="An open-source implementation of the OpenGL specification"
 pkgver=20.3.1
-pkgrel=1
+pkgrel=2
 arch=('x86_64')
 makedepends=('python-mako' 'libxml2' 'libx11' 'xorgproto' 'libdrm' 'libxshmfence' 'libxxf86vm'
              'libxdamage' 'libvdpau' 'libva' 'wayland' 'wayland-protocols' 'zstd' 'elfutils' 'llvm'
@@ -58,7 +59,7 @@ build() {
     -D platforms=x11,wayland \
     -D dri-drivers=r100,r200,nouveau \
     -D gallium-drivers=r300,r600,radeonsi,freedreno,nouveau,swrast,virgl,zink${GALLIUM} \
-    -D vulkan-drivers=amd,swrast \
+    -D vulkan-drivers=amd,swrast,broadcom \
     -D vulkan-overlay-layer=true \
     -D vulkan-device-select-layer=true \
     -D dri3=enabled \
@@ -155,6 +156,18 @@ package_vulkan-swrast() {
 
   _install fakeinstall/usr/share/vulkan/icd.d/lvp_icd*.json
   _install fakeinstall/usr/lib/libvulkan_lvp.so
+
+  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
+}
+
+package_vulkan-broadcom() {
+  pkgdesc="Broadcom's Vulkan mesa driver"
+  depends=('wayland' 'libx11' 'libxshmfence' 'libdrm')
+  optdepends=('vulkan-mesa-layers: additional vulkan layers')
+  provides=('vulkan-driver')
+
+  _install fakeinstall/usr/share/vulkan/icd.d/broadcom_icd*.json
+  _install fakeinstall/usr/lib/libvulkan_broadcom.so
 
   install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
 }


### PR DESCRIPTION
* Enable v3dv driver as it was upstreamed in mesa 20.3.0.

* PKGBUILD was successfuly built in a clean chroot using makechrootpkg
  on Raspberry Pi 4 (armv7h).

* namcap report:
  vulkan-broadcom W: Unused shared library '/usr/lib/libxcb-randr.so.0' by file ('usr/lib/libvulkan_broadcom.so')

  (warning seems to be harmless, it's likely a mesa issue not the PKGBUILD)

* I was able to run vkmark using X11 backend:

```
  WARNING: v3dv is neither a complete nor a conformant Vulkan implementation. Testing use only.
  =======================================================
      vkmark 2017.08
  =======================================================
      Vendor ID:      0x14E4
      Device ID:      0x2A
      Device Name:    V3D 4.2
      Driver Version: 83898368
  =======================================================
  [vertex] device-local=true: FPS: 123 FrameTime: 8.130 ms
  [vertex] device-local=false: FPS: 123 FrameTime: 8.130 ms
  [texture] anisotropy=0: FPS: 114 FrameTime: 8.772 ms
  [texture] anisotropy=16: FPS: 113 FrameTime: 8.850 ms
  [shading] shading=gouraud: FPS: 119 FrameTime: 8.403 ms
  [shading] shading=blinn-phong-inf: FPS: 110 FrameTime: 9.091 ms
  [shading] shading=phong: FPS: 97 FrameTime: 10.309 ms
  [shading] shading=cel: FPS: 97 FrameTime: 10.309 ms
  [effect2d] kernel=edge: FPS: 57 FrameTime: 17.544 ms
  [effect2d] kernel=blur: FPS: 33 FrameTime: 30.303 ms
  [desktop] <default>: FPS: 34 FrameTime: 29.412 ms
  [cube] <default>: FPS: 131 FrameTime: 7.634 ms
  [clear] <default>: FPS: 140 FrameTime: 7.143 ms
  =======================================================
                                     vkmark Score: 99
  =======================================================
```