### PR TITLE
Raspberry PI 4 - make usb working

### DIFF
--- a/alarm/raspberrypi-bootloader/PKGBUILD
+++ b/alarm/raspberrypi-bootloader/PKGBUILD
@@ -9,6 +9,12 @@ pkgname=('raspberrypi-bootloader'
 pkgver=20201129
 pkgrel=1
 _commit=e15ef4e4fe8be99cd816cec901d977224a1eb07e
+#ok:
+# e15ef4e4fe8be99cd816cec901d977224a1eb07e
+# 08ed7a0c9ad4d9db559aaec462520ab435c7ce1c
+#bad:
+# 919aee0ed75f7db48a38b8b96c13228a7584cfd7
+# cfb5b76811f853612bc89c76da77d3d74d5f22ca
 arch=('any')
 url="https://github.com/raspberrypi/firmware"
 license=('custom')

--- a/alarm/raspberrypi-bootloader/PKGBUILD
+++ b/alarm/raspberrypi-bootloader/PKGBUILD
@@ -6,15 +6,15 @@ buildarch=28
 pkgbase=raspberrypi-bootloader
 pkgname=('raspberrypi-bootloader'
          'raspberrypi-bootloader-x')
-pkgver=20201220
+pkgver=20201129
 pkgrel=1
-_commit=d016a6eb01c8c7326a89cb42809fed2a21525de5
+_commit=e15ef4e4fe8be99cd816cec901d977224a1eb07e
 arch=('any')
 url="https://github.com/raspberrypi/firmware"
 license=('custom')
 options=(!strip)
 source=("https://github.com/raspberrypi/firmware/archive/${_commit}.tar.gz")
-md5sums=('11524d7daefa3c56b4679585167a0c84')
+md5sums=('4b33cd845ce9d42a13abf9a32f802243')
 
 package_raspberrypi-bootloader() {
   pkgdesc="Bootloader files for Raspberry Pi"

--- a/alarm/uboot-raspberrypi/PKGBUILD
+++ b/alarm/uboot-raspberrypi/PKGBUILD
@@ -5,7 +5,7 @@ buildarch=12
 
 pkgname=uboot-raspberrypi
 pkgver=2020.07
-pkgrel=2
+pkgrel=3
 pkgdesc="U-Boot for Raspberry Pi"
 arch=('armv7h' 'aarch64')
 url='http://www.denx.de/wiki/U-Boot/WebHome'
@@ -13,7 +13,7 @@ license=('GPL')
 backup=('boot/boot.txt' 'boot/boot.scr' 'boot/config.txt')
 makedepends=('bc' 'dtc' 'git')
 conflicts_armv7h=('linux-raspberrypi')
-_commit=f4b58692fef0b9c16bd4564edb980fff73a758b3
+_commit=d016a6eb01c8c7326a89cb42809fed2a21525de5
 source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver/rc/-rc}.tar.bz2"
         "https://github.com/raspberrypi/firmware/raw/${_commit}/boot/bcm2710-rpi-3-b.dtb"
         "https://github.com/raspberrypi/firmware/raw/${_commit}/boot/bcm2710-rpi-3-b-plus.dtb"
@@ -24,10 +24,10 @@ source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver/rc/-rc}.tar.bz2"
         'boot.txt.v3'
         'mkscr')
 md5sums=('86e51eeccd15e658ad1df943a0edf622'
-         '0c56f6b8fde06be1415b3ff85b5b5370'
-         'e4b819439961514c7441473d4733a1b4'
-         '38cab92f98944f0492c5320cf8b36870'
-         '04f2dd06c65cd7ad2932041cbe220a13'
+         '5334e61fe2dd43d5ebfa16344b51ffbf'
+         'd1c389740c3898aa172f63116f4dc295'
+         '887920b6a052070b69f2d6f47e57ee42'
+         '00c5929bd3417f0489745c53d06135a7'
          '728c4a0a542db702b8d88ffe1994660c'
          '69e883f0b8d1686b32bdf79684623f06'
          'be8abe44b86d63428d7ac3acc64ee3bf'


### PR DESCRIPTION
Hi,

This is a draft PR to make USB working on Raspberry PI 4 8GB, aarch64 archlinuxarm. (with linux-aarch64)
In this [archlinuxarm forum thread](https://archlinuxarm.org/forum/viewtopic.php?f=65&t=14734&p=65380#p65380) we found that:
* `uboot-raspberrypi`: packages too old .dtb files
* `raspberrypi-bootloader`: recent versions of raspberrypi/firmware make usb not working, so I reverted a working revision.

What do you think?

Cheers,
Pierre