### PR TITLE
Re-added community/consul-1.9.1

### DIFF
--- a/community/consul/PKGBUILD
+++ b/community/consul/PKGBUILD
@@ -1,0 +1,100 @@
+# Maintainer: Thore Bödecker <foxxx0@archlinux.org>
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+
+# ALARM: Tyler Langlois <ty@tjll.net>
+#  - comment out GOOS and XC_OSARCH
+#  - change makedepends s/nodejs-lts-dubnium/nodejs-lts-fermium/ (dubnium not available on armv6)
+
+# PKGBUILD untested on armv5
+buildarch=28
+
+pkgname=consul
+pkgver=1.9.1
+pkgrel=1
+pkgdesc="A tool for service discovery, monitoring and configuration."
+arch=('x86_64')
+url="https://www.consul.io"
+license=('MPL2')
+depends=('glibc')
+makedepends=('git' 'go' 'go-bindata-assetfs' 'go-bindata-hashicorp' 'procps-ng' 'zip' 'yarn' 'bower' 'nodejs-lts-fermium' 'npm' 'zip' 'gox' 'go-tools')
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/hashicorp/consul/archive/v${pkgver}.tar.gz"
+        'consul.service'
+        'consul.default'
+        'consul.sysusers'
+        'example.json'
+        # 'fix-build-version-info.patch'
+        # 'unparallelize-or-disable-flaky-tests.patch'
+        )
+install=consul.install
+backup=('etc/default/consul')
+sha512sums=('9b983fed98499f642ac1bd8d183c2d76cbe321b8d1f7d318257c392185654e4037f7d80d39935011c0d97eb45c6686bd7c34c08908d5ad23d2c99bcee5e1fa74'
+            'c70b9d1556f6c7ecb2e915ab685f289cef0e31198bd2e50c74a0483bbfb387beec67334f539a90adbf68b61b07946e98b300ab8a8e26e53b35f4ab4894adeb04'
+            'ec5a800529a297c709fa383c094ecf106351cf0f8ac7b613b972d415d77fe001088902d7ab805e63e78a8e6360323fec1b795db5a4446df1e21b9b4ed31e7079'
+            'ef872aedb2bc022a29292b7972a792b22e684c1ccb904a2b2cfec6d8966c28fb19be1452ce060821c419f1b646b236ba2e783175595e4bb6926d164c27a15c87'
+            'c4292b8f56ee955ed7385a49843fd90d6434029891b3e1e724cb2fc841514c06e2554a26d3937c114371b18c2168c4e64319eb2cbd726ee8b35870df19089348')
+
+export CGO_LDFLAGS="${LDFLAGS}"
+export CGO_CFLAGS="${CFLAGS}"
+export CGO_CPPFLAGS="${CPPFLAGS}"
+export CGO_CXXFLAGS="${CXXFLAGS}"
+# consul is incompatible with -buildmode=pie
+export GOFLAGS="-trimpath -mod=readonly -modcacherw"
+
+export GOOS='linux'
+# export GOARCH='amd64'
+# export XC_OSARCH='linux/amd64'
+
+prepare() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+
+  local filename
+  for filename in "${source[@]}"; do
+    if [[ "$filename" =~ \.patch$ ]]; then
+      patch -p1 -N -l -i "$srcdir/${filename##*/}"
+    fi
+  done
+
+  mkdir -p build
+}
+
+build() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  go build -o build './...'
+}
+
+##############################################################################
+####
+#### test suite is currently broken and fails horribly
+#### upstream is not interested in helping to debug failures downstream
+####
+#### therefore the testsuite is disabled for the time being
+####
+##############################################################################
+# check() {
+#   cd "${srcdir}/${pkgname}-${pkgver}"
+# 
+#   # prevent e.g. syslog tests
+#   export TRAVIS='true'
+# 
+#   # some tests need the built `consul` binary in $PATH
+#   export PATH="${PWD}/build:${PATH}"
+# 
+#   # weird race conditions when being run overparallelized
+#   go test -v -p 2 -parallel 2 './...'
+# }
+
+package() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+
+  install -D -d -m750 -o 208 -g 208 "${pkgdir}/var/lib/consul"
+  install -D -d -m750 -o   0 -g 208 "${pkgdir}/etc/consul.d"
+
+  install -D -m644 "${srcdir}/consul.default" "${pkgdir}/etc/default/consul"
+  install -D -m644 -o 0 -g 0 "${srcdir}/example.json" "${pkgdir}/usr/share/doc/consul/config.example.json"
+  install -Dm755 "build/consul" "${pkgdir}/usr/bin/consul"
+
+  install -Dm644 "${srcdir}/consul.service" "${pkgdir}/usr/lib/systemd/system/consul.service"
+  install -Dm644 "${srcdir}/consul.sysusers" "${pkgdir}/usr/lib/sysusers.d/consul.conf"
+}
+
+# vim:set ts=2 sw=2 et:

--- a/community/consul/consul-ldflags.patch
+++ b/community/consul/consul-ldflags.patch
@@ -1,0 +1,31 @@
+diff -upr b/build-support/functions/20-build.sh c/build-support/functions/20-build.sh
+--- b/build-support/functions/20-build.sh	2020-03-04 10:15:04.066148196 +0100
++++ c/build-support/functions/20-build.sh	2020-03-04 10:13:54.354670580 +0100
+@@ -458,7 +458,7 @@ function build_consul_local {
+          if [ $os == "windows" ];then
+                binname="consul.exe"
+          fi
+-         debug_run env CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go install -ldflags "${GOLDFLAGS}" -tags "${GOTAGS}" && cp "${MAIN_GOPATH}/bin/${GOBIN_EXTRA}${binname}" "${outdir}/${binname}"
++         debug_run env CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go install -ldflags "-linkmode external -extldflags ${EXTLDFLAGS} -s -w ${GOLDFLAGS}" -tags "${GOTAGS}" && cp "${MAIN_GOPATH}/bin/${GOBIN_EXTRA}${binname}" "${outdir}/${binname}"
+          if test $? -ne 0
+          then
+             err "ERROR: Failed to build Consul for ${osarch}"
+diff -upr b/GNUmakefile c/GNUmakefile
+--- b/GNUmakefile	2020-03-04 10:14:46.245770467 +0100
++++ c/GNUmakefile	2020-03-04 10:15:32.286746368 +0100
+@@ -17,6 +17,7 @@ MAIN_GOPATH=$(shell go env GOPATH | cut
+ 
+ ASSETFS_PATH?=agent/bindata_assetfs.go
+ GOLDFLAGS=
++EXTLDFLAGS := ${LDFLAGS}
+ 
+ PROTOFILES?=$(shell find . -name '*.proto' | grep -v 'vendor/')
+ PROTOGOFILES=$(PROTOFILES:.proto=.pb.go)
+@@ -120,6 +121,7 @@ export GIT_DIRTY
+ export GIT_DESCRIBE
+ export GOTAGS
+ export GOLDFLAGS
++export EXTLDFLAGS
+ 
+ # Allow skipping docker build during integration tests in CI since we already
+ # have a built binary

--- a/community/consul/consul.default
+++ b/community/consul/consul.default
@@ -1,0 +1,1 @@
+CONSUL_FLAGS=""

--- a/community/consul/consul.install
+++ b/community/consul/consul.install
@@ -1,0 +1,9 @@
+post_upgrade() {
+	# improved permissions since 0.9.3-1
+	if  [ "$(vercmp "$2" "0.9.3")" -lt 0 ]; then
+		chown 0:208 /etc/consul.d
+		chmod 0750 /etc/consul.d
+		echo -en "----\nThe directory permissions for /etc/consul.d/ have been fixed.\n----\n"
+	fi
+	true
+}

--- a/community/consul/consul.service
+++ b/community/consul/consul.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Consul Agent
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+User=consul
+Group=consul
+EnvironmentFile=-/etc/default/consul
+Restart=on-failure
+ExecStart=/usr/bin/consul agent $CONSUL_FLAGS -config-dir=/etc/consul.d
+ExecReload=/usr/bin/kill -HUP $MAINPID
+KillSignal=SIGINT
+
+[Install]
+WantedBy=multi-user.target

--- a/community/consul/consul.sysusers
+++ b/community/consul/consul.sysusers
@@ -1,0 +1,1 @@
+u consul 208 - /var/lib/consul

--- a/community/consul/example.json
+++ b/community/consul/example.json
@@ -1,0 +1,7 @@
+{
+  "data_dir": "/var/lib/consul",
+  "disable_update_check": true,
+  "log_level": "INFO",
+  "node_name": "example.localdomain",
+  "server": true
+}

--- a/community/consul/fix-build-version-info.patch
+++ b/community/consul/fix-build-version-info.patch
@@ -1,0 +1,75 @@
+--- a/version/version.go	2018-06-26 09:57:33.703932696 +0200
++++ b/version/version.go	2018-06-26 09:59:05.986536238 +0200
+@@ -1,7 +1,6 @@
+ package version
+ 
+ import (
+-	"fmt"
+ 	"strings"
+ )
+ 
+@@ -27,24 +26,6 @@ var (
+ // for displaying to humans.
+ func GetHumanVersion() string {
+ 	version := Version
+-	if GitDescribe != "" {
+-		version = GitDescribe
+-	}
+-
+-	release := VersionPrerelease
+-	if GitDescribe == "" && release == "" {
+-		release = "dev"
+-	}
+-
+-	if release != "" {
+-		if !strings.HasSuffix(version, "-"+release) {
+-			// if we tagged a prerelease version then the release is in the version already
+-			version += fmt.Sprintf("-%s", release)
+-		}
+-		if GitCommit != "" {
+-			version += fmt.Sprintf(" (%s)", GitCommit)
+-		}
+-	}
+ 
+ 	// Strip off any single quotes added by the git information.
+ 	return strings.Replace(version, "'", "", -1)
+--- a/GNUmakefile	2020-02-20 16:40:00.000000000 +0100
++++ b/GNUmakefile	2020-03-04 09:48:52.279500949 +0100
+@@ -16,13 +16,7 @@ GOPATH=$(shell go env GOPATH)
+ MAIN_GOPATH=$(shell go env GOPATH | cut -d: -f1)
+ 
+ ASSETFS_PATH?=agent/bindata_assetfs.go
+-# Get the git commit
+-GIT_COMMIT?=$(shell git rev-parse --short HEAD)
+-GIT_COMMIT_YEAR?=$(shell git show -s --format=%cd --date=format:%Y HEAD)
+-GIT_DIRTY?=$(shell test -n "`git status --porcelain`" && echo "+CHANGES" || true)
+-GIT_DESCRIBE?=$(shell git describe --tags --always --match "v*")
+-GIT_IMPORT=github.com/hashicorp/consul/version
+-GOLDFLAGS=-X $(GIT_IMPORT).GitCommit=$(GIT_COMMIT)$(GIT_DIRTY) -X $(GIT_IMPORT).GitDescribe=$(GIT_DESCRIBE)
++GOLDFLAGS=
+ 
+ PROTOFILES?=$(shell find . -name '*.proto' | grep -v 'vendor/')
+ PROTOGOFILES=$(PROTOFILES:.proto=.pb.go)
+@@ -348,16 +342,6 @@ tools:
+ 	fi
+ 	cd .gotools && go get -v $(GOTOOLS)
+ 
+-version:
+-	@echo -n "Version:                    "
+-	@$(SHELL) $(CURDIR)/build-support/scripts/version.sh
+-	@echo -n "Version + release:          "
+-	@$(SHELL) $(CURDIR)/build-support/scripts/version.sh -r
+-	@echo -n "Version + git:              "
+-	@$(SHELL) $(CURDIR)/build-support/scripts/version.sh  -g
+-	@echo -n "Version + release + git:    "
+-	@$(SHELL) $(CURDIR)/build-support/scripts/version.sh -r -g
+-
+ 
+ docker-images: go-build-image ui-build-image
+ 
+@@ -409,4 +393,4 @@ proto: $(PROTOGOFILES) $(PROTOGOBINFILES
+ 
+ .PHONY: all ci bin dev dist cov test test-ci test-internal cover format vet ui static-assets tools
+ .PHONY: docker-images go-build-image ui-build-image static-assets-docker consul-docker ui-docker
+-.PHONY: version proto proto-rebuild proto-delete test-envoy-integ
++.PHONY: proto proto-rebuild proto-delete test-envoy-integ

--- a/community/consul/fix-test.patch
+++ b/community/consul/fix-test.patch
@@ -1,0 +1,11 @@
+--- a/GNUmakefile	2020-02-20 16:40:00.000000000 +0100
++++ b/GNUmakefile	2020-03-04 09:51:30.786193388 +0100
+@@ -212,7 +212,7 @@ cov: other-consul dev-build
+ 	rm -f coverage.{sdk,api}.part
+ 	go tool cover -html=coverage.out
+ 
+-test: other-consul dev-build vet test-internal
++test: other-consul dev-build test-internal
+ 
+ go-mod-tidy:
+ 	@echo "--> Running go mod tidy"

--- a/community/consul/unparallelize-or-disable-flaky-tests.patch
+++ b/community/consul/unparallelize-or-disable-flaky-tests.patch
@@ -1,0 +1,54 @@
+diff -upr a/agent/cache/cache_test.go b/agent/cache/cache_test.go
+--- a/agent/cache/cache_test.go	2018-11-14 23:37:47.000000000 +0100
++++ b/agent/cache/cache_test.go	2019-01-08 15:23:12.540631267 +0100
+@@ -213,7 +213,6 @@ func TestCacheGet_blockingInitSameKey(t
+ // Test that Get with different cache keys both block on initial value
+ // but that the fetches were both properly called.
+ func TestCacheGet_blockingInitDiffKeys(t *testing.T) {
+-	t.Parallel()
+ 
+ 	require := require.New(t)
+ 
+@@ -299,7 +298,6 @@ func TestCacheGet_blockingIndex(t *testi
+ // Test a get with an index set will timeout if the fetch doesn't return
+ // anything.
+ func TestCacheGet_blockingIndexTimeout(t *testing.T) {
+-	t.Parallel()
+ 
+ 	typ := TestType(t)
+ 	defer typ.AssertExpectations(t)
+@@ -438,7 +436,6 @@ func TestCacheGet_emptyFetchResult(t *te
+ // Test that a type registered with a periodic refresh will perform
+ // that refresh after the timer is up.
+ func TestCacheGet_periodicRefresh(t *testing.T) {
+-	t.Parallel()
+ 
+ 	typ := TestType(t)
+ 	defer typ.AssertExpectations(t)
+@@ -525,7 +522,6 @@ func TestCacheGet_periodicRefreshMultipl
+ 
+ // Test that a refresh performs a backoff.
+ func TestCacheGet_periodicRefreshErrorBackoff(t *testing.T) {
+-	t.Parallel()
+ 
+ 	typ := TestType(t)
+ 	defer typ.AssertExpectations(t)
+@@ -566,7 +562,6 @@ func TestCacheGet_periodicRefreshErrorBa
+ 
+ // Test that a badly behaved RPC that returns 0 index will perform a backoff.
+ func TestCacheGet_periodicRefreshBadRPCZeroIndexErrorBackoff(t *testing.T) {
+-	t.Parallel()
+ 
+ 	typ := TestType(t)
+ 	defer typ.AssertExpectations(t)
+diff -upr a/agent/cache-types/connect_ca_leaf_test.go b/agent/cache-types/connect_ca_leaf_test.go
+--- a/agent/cache-types/connect_ca_leaf_test.go	2018-11-14 23:37:47.000000000 +0100
++++ b/agent/cache-types/connect_ca_leaf_test.go	2019-01-08 15:23:55.670339830 +0100
+@@ -870,7 +870,6 @@ func TestConnectCALeaf_changingRoots(t *
+ // Test that after an initial signing, an expiringLeaf will trigger a
+ // blocking query to resign.
+ func TestConnectCALeaf_expiringLeaf(t *testing.T) {
+-	t.Parallel()
+ 
+ 	require := require.New(t)
+ 	rpc := TestRPC(t)


### PR DESCRIPTION
I make pretty heavy use of consul in my homelab and was missing the latest updates and noticed that the package had been removed a while ago. The older `PKGBUILD` had to do some surgery on the `GNUmakefile` to make it work, but the latest `PKGBUILD` from upstream Arch now calls `go build` directly and is much less problematic to get building right.

I've built, installed, and tested this out on armv6/7/8 and it seems to work. There's another small tweak here aside from snipping `GOOS` and `XC_OSARCH` but the small tweak seems to have no negative effects.

@kmihelich I noted that you've been making updates to this previously, so you might know about some other reasons why the package should be removed, but if there's something I'm unaware of that would make this bad to reintroduce let me know.

The details are in the commit body, as well:


```
The last committed version of consul was 1.5, when the upstream
community package was still relying on make targets. As of at least 1.9,
upstream packages now build via explicit calls to `go build` which is
less problematic in terms of how the upstream GNUmakefile makes
assumptions about amd4.

Changes from upstream:
- GOOS and XC_OSARCH can be safely omitted, the build process detects these
- A nodejs makedep is not present on armv6. Using another lts node
  release has been tested and confirmed to work after building the
  package with this change (on armv6, armv7, and aarch64)

I have built this on armv6, armv7, and armv8. I've defined a buildarch
to exclude armv5 since I can't definitively confirm it works on that
arch, but the rest build and run great.
```