### PR TITLE
community/zam-plugins: add highmem

### DIFF
--- a/community/zam-plugins/PKGBUILD
+++ b/community/zam-plugins/PKGBUILD
@@ -1,0 +1,126 @@
+# Maintainer: David Runge <dvzrv@archlinux.org>
+
+highmem=1
+
+pkgname=zam-plugins
+pkgver=3.14
+pkgrel=1
+pkgdesc="Collection of LADSPA/LV2/VST/JACK audio plugins for high-quality processing"
+arch=('x86_64')
+url="https://github.com/zamaudio/zam-plugins"
+license=('GPL2')
+groups=('ladspa-plugins' 'lv2-plugins' 'pro-audio' 'vst-plugins')
+depends=('gcc-libs' 'glibc' 'libglvnd' 'libx11')
+makedepends=('gendesk' 'git' 'ladspa' 'libsamplerate' 'jack' 'lv2' 'zita-convolver')
+optdepends=('jack: for standalone applications')
+source=("$pkgname::git+https://github.com/zamaudio/${pkgname}.git#tag=${pkgver}?signed"
+        "git+https://github.com/distrho/dpf.git"
+        "${pkgname}.directory"
+        "${pkgname}.menu")
+sha512sums=('SKIP'
+            'SKIP'
+            'b7aa3170c14e75e1ec9aa19827a353d126a70e729491a8947b86748eb6c97489c57cb697505f209129834b837beadbbd96e8306fbd7b78cc7cfb95cd7d8b964d'
+            '0aa04bc5cc566ce616728e96fc528c4e7d43cc275cf3e58ad4005a195fbce72793497c2abc515a3926c8cc196e2e29a5534d4fb2ea3c1f348a6f1df3f8a24740')
+b2sums=('SKIP'
+        'SKIP'
+        '7b00a157f982abee0abce18e6aaf88f3464f734653ad8efcaf16c8aa8daa4d81e5648381aa16e46461d134bba536fe8f81bee3f5f0456d22f47be5f4c2f2878e'
+        '830efd881fe5f66ef51e13cf9a4026446aa185c8b161209e97212652771d1938c26eed4d9eb81849256f600ec01029f6a50dd98436856fa910aef11d22bc5715')
+validpgpkeys=('B86F8ABAEDB92DF68AE2BE40577C1739585FA920') # Damien Zammit <damien@zammit.org>
+
+_names=('zamaximx2' 'zamulticomp' 'zammulticompx2' 'zamautosat' 'zamcomp'
+'zamcompx2' 'zamdelay' 'zamdynamiceq' 'zameq2' 'zamgeq31' 'zamgate' 'zamgatex2'
+'zamgrains' 'zamheadx2' 'zamphono' 'zamtube' 'zamverb')
+
+
+prepare() {
+  cd "$pkgname"
+  git submodule init
+  git config submodule.dpf.url "${srcdir}/dpf"
+  git submodule update
+  declare -A exec_names=(
+    ["zamaximx2"]="ZaMaximX2"
+    ["zamulticomp"]="ZaMultiComp"
+    ["zamulticompx2"]="ZaMultiCompX2"
+    ["zamautosat"]="ZamAutoSat"
+    ["zamcomp"]="ZamComp"
+    ["zamcompx2"]="ZamCompX2"
+    ["zamdelay"]="ZamDelay"
+    ["zamdynamiceq"]="ZamDynamicEQ"
+    ["zameq2"]="ZamEQ2"
+    ["zamgeq31"]="ZamGEQ31"
+    ["zamgate"]="ZamGate"
+    ["zamgatex2"]="ZamGateX2"
+    ["zamgrains"]="ZamGrains"
+    ["zamheadx2"]="ZamHeadX2"
+    ["zamphono"]="ZamPhono"
+    ["zamtube"]="ZamTube"
+    ["zamverb"]="ZamVerb"
+  )
+  declare -A comments=(
+    ["zamaximx2"]="Acts as a brickwall limiter for mastering in its default state, but can also be tweaked to raise the average level as a stereo maximizer without ever clipping"
+    ["zamulticomp"]="Mono multiband compressor, with 3 adjustable bands."
+    ["zamulticompx2"]="Stereo version of ZaMultiComp, with individual threshold controls for each band and real-time visualisation of comp curves."
+    ["zamautosat"]="An automatic saturation plugin, has been known to provide smooth levelling to live mic channels."
+    ["zamcomp"]="A powerful mono compressor strip"
+    ["zamcompx2"]="Stereo version of ZamComp with knee slew control"
+    ["zamdelay"]="A simple feedback delay unit with sync-to-host BPM feature and filter."
+    ["zamdynamiceq"]="A dynamic equalizer that changes its gain based on detecting a narrow band of frequencies."
+    ["zameq2"]="Two band parametric equaliser with high and low shelving circuits."
+    ["zamgeq31"]="31 band graphic equaliser, good for eq of live spaces, removing unwanted noise from a track etc."
+    ["zamgate"]="Gate plugin for ducking low gain sounds."
+    ["zamgatex2"]="Gate plugin for ducking low gain sounds, stereo version."
+    ["zamgrains"]="Granular Synthesizer"
+    ["zamheadx2"]="HRTF acoustic filtering plugin for directional sound."
+    ["zamphono"]="A collection of phono filters for restoring vinyl records, or preparing to cut new ones."
+    ["zamtube"]="Wave digital filter physical model of a triode tube amplifier stage, with modelled tone stacks from real guitar amplifiers"
+    ["zamverb"]="Reverb"
+  )
+  declare -A generic=(
+    ["zamaximx2"]="Maximizer and brickwall limiter"
+    ["zamulticomp"]="Mono Multiband Compressor"
+    ["zamulticompx2"]="Stereo Multiband Compressor"
+    ["zamautosat"]="Automatic Saturation"
+    ["zamcomp"]="Mono Compressor"
+    ["zamcompx2"]="Stereo Compressor"
+    ["zamdelay"]="Delay"
+    ["zamdynamiceq"]="Dynamic Equalizer"
+    ["zameq2"]="2 Band Parametric Equalizer"
+    ["zamgeq31"]="31 Band Graphic Equalizer"
+    ["zamgate"]="Mono Gate"
+    ["zamgatex2"]="Stereo Gate"
+    ["zamgrains"]="Granular Synthesizer"
+    ["zamheadx2"]="HRTF Acoustic Filtering"
+    ["zamphono"]="Phono Filters"
+    ["zamtube"]="Tube Amplifier"
+    ["zamverb"]="Reverb"
+  )
+  for name in "${_names[@]}"; do
+    gendesk -n \
+            --pkgname "com.zamaudio.${name}" \
+            --name "${name}" \
+            --exec "${exec_names[$name]}" \
+            --pkgdesc "${comments[$name]}" \
+            --genericname "${generic[$name]}"
+  done
+}
+
+build() {
+  cd "$pkgname"
+  export HAVE_ZITA_CONVOLVER=true
+  make
+}
+
+package() {
+  cd "$pkgname"
+  depends+=('libsamplerate.so' 'libzita-convolver.so')
+  make DESTDIR="$pkgdir/" PREFIX='/usr' install
+  # XDG desktop integration
+  install -vDm 644 *.desktop -t "${pkgdir}/usr/share/applications"
+  install -vDm 644 "../${pkgname}.menu" \
+    -t "${pkgdir}/etc/xdg/menus/applications-merged/"
+  install -vDm 644 "../${pkgname}.directory" \
+    -t "${pkgdir}/usr/share/desktop-directories/"
+  # docs
+  install -t "${pkgdir}/usr/share/doc/${pkgname}/" \
+    -vDm 644 {README.md,changelog}
+}

--- a/community/zam-plugins/zam-plugins.directory
+++ b/community/zam-plugins/zam-plugins.directory
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=zam-plugins
+Icon=zam-plugins
+Type=Directory
+Keywords=audio;sound;jackd;zam-plugins;

--- a/community/zam-plugins/zam-plugins.menu
+++ b/community/zam-plugins/zam-plugins.menu
@@ -1,0 +1,30 @@
+<!DOCTYPE Menu PUBLIC "-//freedesktop//DTD Menu 1.0//EN" "http://www.freedesktop.org/standards/menu-spec/menu-1.0.dtd">
+<Menu>
+  <Name>Applications</Name>
+  <Menu>
+    <Name>Multimedia</Name>
+    <Menu>
+      <Name>zam-plugins</Name>
+      <Directory>zam-plugins.directory</Directory>
+      <Include>
+        <Filename>com.zamaudio.zamautosat.desktop</Filename>
+        <Filename>com.zamaudio.zamaximx2.desktop</Filename>
+        <Filename>com.zamaudio.zamcomp.desktop</Filename>
+        <Filename>com.zamaudio.zamcompx2.desktop</Filename>
+        <Filename>com.zamaudio.zamdelay.desktop</Filename>
+        <Filename>com.zamaudio.zamdynamiceq.desktop</Filename>
+        <Filename>com.zamaudio.zameq2.desktop</Filename>
+        <Filename>com.zamaudio.zamgate.desktop</Filename>
+        <Filename>com.zamaudio.zamgatex2.desktop</Filename>
+        <Filename>com.zamaudio.zamgeq31.desktop</Filename>
+        <Filename>com.zamaudio.zamgrains.desktop</Filename>
+        <Filename>com.zamaudio.zamheadx2.desktop</Filename>
+        <Filename>com.zamaudio.zammulticompx2.desktop</Filename>
+        <Filename>com.zamaudio.zamphono.desktop</Filename>
+        <Filename>com.zamaudio.zamtube.desktop</Filename>
+        <Filename>com.zamaudio.zamulticomp.desktop</Filename>
+        <Filename>com.zamaudio.zamverb.desktop</Filename>
+      </Include>
+    </Menu>
+  </Menu>
+</Menu>


### PR DESCRIPTION
`zam-plugins` needs more than 2GB RAM to build (more along the lines of 4GB+) so add `highmem=1`.

This change will have the added benefit of meeting a makedepend of `pulseeffects`.