### PR TITLE
core/linux-raspberrypi{,4}: provide WIREGUARD-MODULE

### DIFF
--- a/core/linux-raspberrypi/PKGBUILD
+++ b/core/linux-raspberrypi/PKGBUILD
@@ -11,7 +11,7 @@ _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="Raspberry Pi"
 pkgver=5.10.10
-pkgrel=2
+pkgrel=3
 arch=('armv6h' 'armv7h')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -78,7 +78,7 @@ _package() {
   pkgdesc="The Linux Kernel and modules - ${_desc}"
   depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7' 'firmware-raspberrypi')
   optdepends=('crda: to set the correct wireless channels of your country')
-  provides=('kernel26' "linux=${pkgver}")
+  provides=('kernel26' "linux=${pkgver}" "WIREGUARD-MODULE")
   conflicts=('kernel26' 'linux')
   install=${pkgname}.install
   backup=('boot/config.txt' 'boot/cmdline.txt')

--- a/core/linux-raspberrypi4/PKGBUILD
+++ b/core/linux-raspberrypi4/PKGBUILD
@@ -11,7 +11,7 @@ _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="Raspberry Pi 4"
 pkgver=5.10.10
-pkgrel=1
+pkgrel=2
 arch=('armv7h' 'aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -88,7 +88,7 @@ _package() {
   pkgdesc="The Linux Kernel and modules - ${_desc}"
   depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7' 'firmware-raspberrypi')
   optdepends=('crda: to set the correct wireless channels of your country')
-  provides=('kernel26' "linux=${pkgver}")
+  provides=('kernel26' "linux=${pkgver}" "WIREGUARD-MODULE")
   conflicts=('kernel26' 'linux' 'uboot-raspberrypi')
   install=${pkgname}.install
   backup=('boot/config.txt' 'boot/cmdline.txt')


### PR DESCRIPTION
Wireguard got mainlined in 5.6. Provide WIREGUARD-MODULE similarly to
other 5.6+ kernel PKGBUILDs.

@graysky2 