### PR TITLE
Add patch to enable widevine on armv7h

### DIFF
--- a/extra/chromium/PKGBUILD
+++ b/extra/chromium/PKGBUILD
@@ -37,6 +37,7 @@ optdepends=('libpipewire02: WebRTC desktop sharing under Wayland'
 source=(https://commondatastorage.googleapis.com/chromium-browser-official/$pkgname-$pkgver.tar.xz
         https://github.com/foutrelis/chromium-launcher/archive/v$_launcher_ver/chromium-launcher-$_launcher_ver.tar.gz
         https://github.com/stha09/chromium-patches/releases/download/chromium-${pkgver%%.*}-patchset-$_gcc_patchset/chromium-${pkgver%%.*}-patchset-$_gcc_patchset.tar.xz
+        widevine-arm.patch
         chromium-glibc-2.33.patch
         subpixel-anti-aliasing-in-FreeType-2.8.1.patch
         0001-crashpad-include-limits.patch
@@ -45,6 +46,7 @@ source=(https://commondatastorage.googleapis.com/chromium-browser-official/$pkgn
 sha256sums=('30411fc3ec2d33df4c5cad41f21affa3823c80f7dbd394f6d68f9a1e81015b81'
             '86859c11cfc8ba106a3826479c0bc759324a62150b271dd35d1a0f96e890f52f'
             'e5a60a4c9d0544d3321cc241b4c7bd4adb0a885f090c6c6c21581eac8e3b4ba9'
+            '0dcd311803265b80d1d2ab525db7d2432e18f02a1333c26647a5047909398403'
             '2fccecdcd4509d4c36af873988ca9dbcba7fdb95122894a9fdf502c33a1d7a4b'
             '1e2913e21c491d546e05f9b4edf5a6c7a22d89ed0b36ef692ca6272bcd5faec6'
             'a4a429b21236b93e4b9c4b77d561c9102b38b2e5f1bc7607b4c92fb2b7a15bde'
@@ -93,6 +95,7 @@ prepare() {
     tools/generate_shim_headers/generate_shim_headers.py
 
   # Arch Linux ARM fixes
+  patch -p1 -i ../widevine-arm.patch
   patch -p1 -i ../0001-crashpad-include-limits.patch
   patch -p1 -i ../0002-Fix-sandbox-Aw-snap-for-sycalls-403-and-407.patch
   patch -p1 -i ../0003-Run-blink-bindings-generation-single-threaded.patch

--- a/extra/chromium/widevine-arm.patch
+++ b/extra/chromium/widevine-arm.patch
@@ -1,0 +1,12 @@
+diff --unified --recursive --text chromium-86.0.4240.75-unmodified/third_party/widevine/cdm/widevine.gni chromium-86.0.4240.75/third_party/widevine/cdm/widevine.gni
+--- chromium-86.0.4240.75-unmodified/third_party/widevine/cdm/widevine.gni	2020-10-13 08:34:52.557047763 +0000
++++ chromium-86.0.4240.75/third_party/widevine/cdm/widevine.gni	2020-10-13 08:18:08.646989774 +0000
+@@ -23,7 +23,7 @@
+ # supported via Android MediaDrm API.
+ library_widevine_cdm_available =
+     (is_chromeos && (target_cpu == "x64" || target_cpu == "arm")) ||
+-    (is_linux && (target_cpu == "x86" || target_cpu == "x64")) ||
++    (is_linux && (target_cpu == "x86" || target_cpu == "x64" || target_cpu == "arm")) ||
+     (is_mac && (target_cpu == "x64" || target_cpu == "arm64")) ||
+     (is_win && (target_cpu == "x86" || target_cpu == "x64"))
+ 


### PR DESCRIPTION
Since chromium 78, extra flags were added to the chromium source code
to check for the target architecture and operating system in order
to decide whether or not to look for the widevine library.  This
meant that since that version it's not possible to use a chromeos
extracted widevine library anymore (which worked perfectly).

This patch adds "arm" and "linux" as a valid combination of arch and
os in the relevant gni file (i.e. build flags).  No modification
of actual C++ source code is required.
This brings back original functionality which had worked fine in the
past (chromium 78 and before).

This patch was tested with the official archlinuxarm distcc toolchain
and it does build on armv7h and aarch64 for chromium 88.
I've also checked against the git repository, and the patch will
apply cleanly to all the foreseeable versions in the future