### PR TITLE
extra/mesa: enable etnaviv driver on aarch64

### DIFF
--- a/extra/mesa/PKGBUILD
+++ b/extra/mesa/PKGBUILD
@@ -45,7 +45,7 @@ build() {
   case "${CARCH}" in
     armv6h)  GALLIUM=",vc4" ;;
     armv7h)  GALLIUM=",etnaviv,kmsro,lima,panfrost,tegra,v3d,vc4" ;;
-    aarch64) GALLIUM=",kmsro,lima,panfrost,v3d,vc4" ;;
+    aarch64) GALLIUM=",etnaviv,kmsro,lima,panfrost,v3d,vc4" ;;
   esac
 
   arch-meson mesa-$pkgver build \


### PR DESCRIPTION
Some aarch64 devices have Vivante GPUs supported by the etnaviv driver, like some iMX8 based ones.

So enable the driver on aarch64 too.