### PR TITLE
core/linux-raspberrypi4: cmdline.txt: ttyAMA0 -> serial0

### DIFF
--- a/core/linux-raspberrypi4/cmdline.txt
+++ b/core/linux-raspberrypi4/cmdline.txt
@@ -1,1 +1,1 @@
-root=/dev/mmcblk0p2 rw rootwait console=ttyAMA0,115200 console=tty1 selinux=0 plymouth.enable=0 smsc95xx.turbo_mode=N dwc_otg.lpm_enable=0 kgdboc=ttyAMA0,115200
+root=/dev/mmcblk0p2 rw rootwait console=serial0,115200 console=tty1 selinux=0 plymouth.enable=0 smsc95xx.turbo_mode=N dwc_otg.lpm_enable=0 kgdboc=serial0,115200


### PR DESCRIPTION
serial0 should be used instead of ttyAMA0 in console= and kgdboc=
parameters. This fixes Bluetooth issues with newer firmware versions.

Reference:
https://github.com/raspberrypi/firmware/issues/1539#issuecomment-784498108