### PR TITLE
alarm/kodi-rpi{-git,-legacy,}: provide also kodi-common

### DIFF
--- a/alarm/kodi-rpi-git/PKGBUILD
+++ b/alarm/kodi-rpi-git/PKGBUILD
@@ -17,7 +17,7 @@ _commitnumber=57039
 _commit=46685b10c76b523eac8f38119c4705b618213235
 
 pkgver="19.0rc1.$_commitnumber.${_commit:0:10}"
-pkgrel=2
+pkgrel=3
 arch=('armv7h' 'aarch64')
 url="https://github.com/popcornmix/xbmc/tree/gbm"
 license=('GPL2')
@@ -197,7 +197,7 @@ package_kodi-rpi-git() {
     'lsb-release: log distro information in crashlog'
   )
   install='kodi.install'
-  provides=('xbmc' "kodi=${pkgver}")
+  provides=('xbmc' "kodi=${pkgver}" "kodi-common=${pkgver}")
   conflicts=('xbmc' 'kodi' 'arm-mem-git' 'shairplay-git' 'kodi-rbp4-git' 'kodi-rpi' 'kodi-rpi-legacy')
   replaces=('xbmc-rbp-git' 'kodi-rbp4-git')
   _components=('kodi' 'kodi-bin')

--- a/alarm/kodi-rpi-legacy/PKGBUILD
+++ b/alarm/kodi-rpi-legacy/PKGBUILD
@@ -13,7 +13,7 @@ _prefix=/usr
 pkgbase=kodi-rpi-legacy
 pkgname=('kodi-rpi-legacy' 'kodi-rpi-legacy-eventclients' 'kodi-rpi-legacy-tools-texturepacker' 'kodi-rpi-legacy-dev')
 pkgver=19.0
-pkgrel=4
+pkgrel=5
 arch=('armv7h')
 url="https://github.com/popcornmix/xbmc/tree/gbm"
 license=('GPL2')
@@ -184,7 +184,7 @@ package_kodi-rpi-legacy() {
     'lsb-release: log distro information in crashlog'
   )
   install='kodi.install'
-  provides=('xbmc' "kodi=${pkgver}")
+  provides=('xbmc' "kodi=${pkgver}" "kodi-common=${pkgver}")
   conflicts=('xbmc' 'kodi' 'arm-mem-git' 'shairplay-git' 'kodi-rpi' 'kodi-rbp' 'kodi-rbp3' 'kodi-rbp4')
   replaces=('xbmc-rbp-git' 'kodi-rbp' 'kodi-rbp3')
   _components=('kodi' 'kodi-bin')

--- a/alarm/kodi-rpi/PKGBUILD
+++ b/alarm/kodi-rpi/PKGBUILD
@@ -13,7 +13,7 @@ _prefix=/usr
 pkgbase=kodi-rpi
 pkgname=('kodi-rpi' 'kodi-rpi-eventclients' 'kodi-rpi-tools-texturepacker' 'kodi-rpi-dev')
 pkgver=19.0
-pkgrel=4
+pkgrel=5
 arch=('armv7h' 'aarch64')
 url="https://github.com/popcornmix/xbmc/tree/gbm"
 license=('GPL2')
@@ -193,7 +193,7 @@ package_kodi-rpi() {
     'lsb-release: log distro information in crashlog'
   )
   install='kodi.install'
-  provides=('xbmc' "kodi=${pkgver}")
+  provides=('xbmc' "kodi=${pkgver}" "kodi-common=${pkgver}")
   conflicts=('xbmc' 'kodi' 'arm-mem-git' 'shairplay-git' 'kodi-rbp' 'kodi-rbp3' 'kodi-rbp4' 'kodi-rpi-legacy')
   replaces=('xbmc-rbp-git' 'kodi-rbp4')
   _components=('kodi' 'kodi-bin')


### PR DESCRIPTION
Kodi Matrix in ABS has introduced a new package called kodi-common [1].
Since then it is a dependency of kodi-platform [2]. Add kodi-common
into "provides" array in order to satisfy new dependency model.

[1]: https://github.com/archlinux/svntogit-community/commit/8df9c13d3151b2f574cf34c6a8f63c16b81169c7#diff-37538beb61ff63edebbf735dfcf39e5d732f49183d6beb097169d971875ca422R163
[2]: https://github.com/archlinux/svntogit-community/commit/0a37bc89112c7705213d50264dbd14970e17d305#diff-3e341d2d9c67be01819b25b25d5e53ea3cdf3a38d28846cda85a195eb9b7203a

@graysky2 