### PR TITLE
Support Linux CEC Framework

### DIFF
--- a/community/libcec/PKGBUILD
+++ b/community/libcec/PKGBUILD
@@ -39,6 +39,7 @@ build() {
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_INSTALL_LIBDIR=/usr/lib \
         -DCMAKE_INSTALL_LIBDIR_NOARCH=/usr/lib \
+        -DHAVE_LINUX_API=1 \
         ${CONFIG}
     make
 }


### PR DESCRIPTION
This needs to be enabled explicitly and allows using /dev/cec*