### PR TITLE
Critical fix: extra/python to 3.9.4-1

### DIFF
--- a/extra/python/PKGBUILD
+++ b/extra/python/PKGBUILD
@@ -12,7 +12,7 @@ shopt -s extglob
 
 pkgbase=python
 pkgname=(python python-tests)
-pkgver=3.9.3
+pkgver=3.9.4
 pkgrel=1
 _pybasever=${pkgver%.*}
 pkgdesc="Next generation of the python high-level scripting language"
@@ -23,7 +23,7 @@ depends=('bzip2' 'expat' 'gdbm' 'libffi' 'libnsl' 'libxcrypt' 'openssl' 'zlib')
 makedepends=('tk' 'sqlite' 'mpdecimal' 'llvm' 'gdb' 'xorg-server-xvfb' 'ttf-font')
 source=("https://www.python.org/ftp/python/${pkgver%rc*}/Python-${pkgver}.tar.xz"{,.asc}
         mpdecimal-2.5.1.patch)
-sha512sums=('420b07c272b8da4b97f6edc21c3b51ef8ee1fffd291eebb032991ec2da4fc40ace3e9b608d7cea0c43ad3716792640c508e84a807c29cfa5a40f89d294f7b0ab'
+sha512sums=('3d8a5a38de0df6edc074d141e0b4a12b79d80439e4341cd4519218aa4bb7317be2736a17058ceec43fc987fc17ea5167c19eeafbdeef732a2f1656fe2f0f0d39'
             'SKIP'
             '58f683cbfdc6aa84c03d068c1bc2f1d8d2c17ba4f7b632c14ab1d529d8332e767354266c3815e239427497fff1a42ec2a37739ea312d24cb76a69dcf1c98c0ad')
 validpgpkeys=('0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D'  # Ned Deily (Python release signing key) <nad@python.org>


### PR DESCRIPTION
The new version of python from arch breaks the ABI and leads to segfault when using many packages, such as cython or aiohttp. Regular arch is not affected as it is a problem for 32-bit systems (in our case for armv6h and armv7h). 3.9.4 contains a hotfix for this: https://docs.python.org/release/3.9.4/whatsnew/changelog.html#changelog

The situation is made worse by the fact that cython, along with broken python, generates incorrect c code, and all packages that you rebuild from this point on will be broken and will require another rebuild. Python-aiohttp and cython was updated today and it broke too. If you don't fix this, all the cython-related packages will end up completely broken.