### PR TITLE
Update libbcm2835 to 1.69

### DIFF
--- a/alarm/libbcm2835/PKGBUILD
+++ b/alarm/libbcm2835/PKGBUILD
@@ -5,14 +5,14 @@ buildarch=28
 
 _pkgbasename=bcm2835
 pkgname=libbcm2835
-pkgver=1.55
+pkgver=1.69
 pkgrel=1
 pkgdesc="C library for Broadcom BCM 2835 as used in Raspberry Pi"
 url="http://www.airspayce.com/mikem/bcm2835/"
 arch=('armv6h' 'armv7h' 'aarch64')
 license=('GPL')
 source=("http://www.airspayce.com/mikem/${_pkgbasename}/${_pkgbasename}-${pkgver}.tar.gz")
-md5sums=('3f87fd17024ad20ee19f82b559e4aa14')
+sha256sums=('2914ee1102914686c98165ee719f943a6a28d8b2f8271fecdec08f51bb8a5b8d')
 
 build() {
   cd ${_pkgbasename}-${pkgver}


### PR DESCRIPTION
Includes, among other things, RPi4 support and some SPI fixes