### PR TITLE
core/linux-aarch64-rc to 5.12.rc3-4 (.its & mkimage regression)

### DIFF
--- a/alarm/dtc145/PKGBUILD
+++ b/alarm/dtc145/PKGBUILD
@@ -22,6 +22,7 @@ prepare() {
   cd dtc-$pkgver
   sed -i 's/-Werror//' Makefile
   sed -i 's/python\b/python2/' tests/run_tests.sh
+  sed -i 's/YYLTYPE yylloc;//g' dtc-lexer.l # fix multiple definitions error
 }
 
 build() {


### PR DESCRIPTION
With the latest mkimage from U-Boot 2021.04, the .its we have no
longer builds, failing with:

/usr/bin/mkimage: verify_header failed for FIT Image support with exit code 1

Changes and intro section above inspired by
https://lore.kernel.org/patchwork/patch/1410873/

Since we seem to be able to name these nodes whatever we want, and since
depthcharge happily prints them, let's name them more semantically:

	kernel@1 -> kernel-archlinuxarm
	fdt@12 -> sc7180-trogdor-lazor-r3-lte.dtb.lz4
	config@12 -> sc7180-trogdor-lazor-r3-lte

Delete default configuration since it's not really needed and probably
causes harm anyway if a specific dtb were to boot on a random board
(gpio mismatches and such).

The other uses .its files in the other alarm packages are also affected
due to the mkimage update. So we should update those soon as well ;)

Proof of test:

```
Config sc7180-trogdor-lazor-r3-lte, kernel kernel-archlinuxarm, fdt sc7180-trogdor-lazor-r3-lte.dtb.lz4, compat google,lazor-sku0 (match) qcom,sc7180
...
Choosing best match sc7180-trogdor-lazor-r1-lte for compat google,lazor-rev1-sku0.
...
LZ4 decompressing kernel-archlinuxarm to 0x80c00000
...
[    0.000000] Linux version 5.12.0-rc3-4-ARCH (alex@alex-desktop) (gcc (crosstool-NG 1.23.0.418-d590) 10.2.0, GNU ld (crosstool-NG 1.23.0.418-d590) 2.35) #2 SMP Tue Apr 27 23:17:09 PDT 2021
```
PS: My https://github.com/amstan/PKGBUILDs/tree/linux-chromeos branch is still equally as cool, I almost have wifi working.