### PR TITLE
Added extra/graphene to fix the crash of libgstopengl on arm / armv6h

### DIFF
--- a/extra/graphene/PKGBUILD
+++ b/extra/graphene/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
+
+# ALARM: Seongyong Park <EuphoricCatface@gmail.com>
+#  - Don't add NEON support where inapplicable
+ 
+pkgname=graphene
+pkgver=1.10.6
+pkgrel=1.1
+pkgdesc="A thin layer of graphic data types"
+url="https://ebassi.github.io/graphene/"
+arch=(x86_64)
+license=(MIT)
+makedepends=(git gtk-doc gobject-introspection meson glib2)
+checkdepends=(python-gobject python-tappy)
+_commit=01c1b63e98c9191093880919fe6a8c4327515756  # tags/1.10.6^0
+source=("git+https://github.com/ebassi/graphene#commit=$_commit"
+        "git+https://github.com/ebassi/mutest")
+sha256sums=('SKIP'
+            'SKIP')
+
+pkgver() {
+  cd $pkgname
+  git describe --tags | sed 's/-/+/g'
+}
+
+prepare() {
+  cd $pkgname
+
+  git submodule init
+  git config --local submodule.subprojects/mutest.url "$srcdir/mutest"
+  git submodule update
+}
+
+build() {
+  NEON_AVAIL="true"
+  [[ "${CARCH}" == "arm" || "${CARCH}" == "armv6h" ]] && NEON_AVAIL="false"
+  arch-meson $pkgname build \
+    -D gtk_doc=true \
+    -D installed_tests=false \
+    -D arm_neon=$NEON_AVAIL
+  meson compile -C build
+}
+
+check() {
+  meson test -C build --print-errorlogs
+}
+
+package() {
+  depends=(libg{lib,object}-2.0.so)
+  provides=(libgraphene-1.0.so)
+
+  DESTDIR="$pkgdir" meson install -C build
+  install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 $pkgname/LICENSE.txt
+}
+
+# vim:set sw=2 et:


### PR DESCRIPTION
Neon is "an optional instruction set extension for ARMv7 and ARMv8"
according to https://developer.android.com/ndk/guides/cpu-arm-neon.

By default, Graphene compiles with Neon instruction on ARM. A few dependency links later,
libgstopengl **in the official repo package** crashes with Illegal instruction.
Details in the commit message.

This patch probably isn't going to make 100% coverage, but it will apply to a lot of cases.