### PR TITLE
Add extra/xf86-video-nouveau package

### DIFF
--- a/extra/xf86-video-nouveau/PKGBUILD
+++ b/extra/xf86-video-nouveau/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Andreas Radke <andyrtr@archlinux.org>
+# Contributor: buddabrod <buddabrod@gmail.com>
+
+pkgname=xf86-video-nouveau
+pkgver=1.0.17
+pkgrel=1
+pkgdesc="Open Source 3D acceleration driver for nVidia cards"
+arch=('x86_64' 'aarch64')
+url="https://nouveau.freedesktop.org/"
+license=('GPL')
+depends=('systemd-libs' 'mesa')
+makedepends=('xorg-server-devel' 'X-ABI-VIDEODRV_VERSION=24.0' 'systemd')
+conflicts=('xorg-server<1.20' 'X-ABI-VIDEODRV_VERSION<24' 'X-ABI-VIDEODRV_VERSION>=25')
+groups=('xorg-drivers')
+source=(https://xorg.freedesktop.org/archive/individual/driver/$pkgname-$pkgver.tar.bz2{,.sig})
+sha512sums=('adba58ba5298d1a5b3f9f8540f9ef2cb2e10e47bba8e374103ec2e1f92e915f5f4393ed0021168cd649646e12315135a1efcdf77e8fb1648e1295914d87279b2'
+            'SKIP')
+validpgpkeys=('B97BD6A80CAC4981091AE547FE558C72A67013C3') # Maarten Lankhorst <maarten@debian.org>
+validpgpkeys+=('C9FA6B58BC799041500F769AC5469FB8758F9C2B') # "Lyude Paul <lyude@redhat.com>"
+validpgpkeys+=('BFB9B0C276D5767C710086EFB178BE4EA075DE07') # "Ilia Mirkin <imirkin@alum.mit.edu>"
+
+#prepare() {
+#  cd $pkgname-$pkgver
+#}
+
+build() {
+  cd $pkgname-$pkgver
+
+  # Since pacman 5.0.2-2, hardened flags are now enabled in makepkg.conf
+  # With them, module fail to load with undefined symbol.
+  # See https://bugs.archlinux.org/task/55102 / https://bugs.archlinux.org/task/54845
+  export CFLAGS=${CFLAGS/-fno-plt}
+  export CXXFLAGS=${CXXFLAGS/-fno-plt}
+  export LDFLAGS=${LDFLAGS/,-z,now}
+
+  ./configure --prefix=/usr
+  make
+}
+
+package() {
+  cd $pkgname-$pkgver
+  make DESTDIR="$pkgdir" install
+}


### PR DESCRIPTION
These video drivers are missing from the main repos. It would seem that all that's necessary is simply to add the architecture to the `arch` list. I've only added `aarch64` since that's the only place I've tested it. To build this package it will be necessary for the server to have the key `B178BE4EA075DE07`.