### PR TITLE
extra/firefox to 92.0.1-1.1

### DIFF
--- a/extra/firefox/PKGBUILD
+++ b/extra/firefox/PKGBUILD
@@ -11,7 +11,7 @@ highmem=1
 
 pkgname=firefox
 pkgver=92.0.1
-pkgrel=1
+pkgrel=1.1
 pkgdesc="Standalone web browser from mozilla.org"
 arch=(x86_64)
 license=(MPL GPL LGPL)
@@ -92,9 +92,6 @@ export MOZ_APP_REMOTINGNAME=${pkgname//-/}
 ac_add_options --with-google-location-service-api-keyfile=${PWD@Q}/google-api-key
 ac_add_options --with-google-safebrowsing-api-keyfile=${PWD@Q}/google-api-key
 ac_add_options --with-mozilla-api-keyfile=${PWD@Q}/mozilla-api-key
-
-# ALARM
-ac_add_options --disable-webrtc
 
 # System libraries
 ac_add_options --with-system-nspr


### PR DESCRIPTION
WebRTC was disabled as part of the 52.0 update, as far as I can see.
The technology is used for video streaming and conferencing.

Many users have successfully built Firefox with WebRTC support,
so I see no reason why it should not be in the official build.

So this removes the disable webrtc mozconfig option,
so it gets enabled in Firefox.

Signed-off-by: Dan Johansen <strit@manjaro.org>