### PR TITLE
Added community/vivaldi

### DIFF
--- a/community/vivaldi/PKGBUILD
+++ b/community/vivaldi/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: BlackIkeEagle <ike DOT devolder AT gmail DOT com>
+# Contributor: TZ86
+# Contributer: NeoTheFox <alarm at reprator.33mail.com>
+
+pkgname=vivaldi
+_debversion=4.2.2406.54-1
+pkgver=4.2.2406.54
+pkgrel=1
+pkgdesc='An advanced browser made with the power user in mind.'
+url="https://vivaldi.com"
+options=(!strip !zipman)
+license=('custom')
+arch=('aarch64' 'armv7h')
+depends=('gtk3' 'libcups' 'nss' 'alsa-lib' 'libxss' 'ttf-font' 'desktop-file-utils' 'shared-mime-info' 'hicolor-icon-theme')
+makedepends=('w3m')
+optdepends=(
+    'vivaldi-ffmpeg-codecs: playback of proprietary video/audio'
+    'libnotify: native notifications'
+)
+source_aarch64=("https://downloads.vivaldi.com/stable/vivaldi-stable_${_debversion}_arm64.deb")
+source_armv7h=("https://downloads.vivaldi.com/stable/vivaldi-stable_${_debversion}_armhf.deb")
+sha512sums_aarch64=('dfb80f16d6369b7bd4f7d665fee0abfc888cd4e80afdfa5978cf21364bc04814d94507fab4e32459122b719705208f1181a45056ba9f92e3c1117d514f597896')
+sha512sums_armv7h=('df1566f03fef7baa31c299d8f043fb2f2f0f68772180fd197a4c2fe9445cda023416972921420644313e725fdb7685b8713cf24efed421418e869c5f6b1a85ef')
+
+package() {
+    tar -xf data.tar.xz -C "$srcdir"
+    cp --parents -a {opt,usr/bin,usr/share} "$pkgdir"
+
+    # suid sandbox
+    chmod 4755 "$pkgdir/opt/$pkgname/vivaldi-sandbox"
+
+    # make /usr/bin/vivaldi-stable available
+    binf="$pkgdir/usr/bin/vivaldi-stable"
+    if [[ ! -e "$binf" ]] && [[ ! -f "$binf" ]] && [[ ! -L "$binf" ]]; then
+        install -dm755 "$pkgdir/usr/bin"
+        ln -s /opt/vivaldi/vivaldi "$binf"
+    fi
+
+    # install icons
+    for res in 16 22 24 32 48 64 128 256; do
+        install -Dm644 "$pkgdir/opt/$pkgname/product_logo_${res}.png" \
+            "$pkgdir/usr/share/icons/hicolor/${res}x${res}/apps/$pkgname.png"
+    done
+
+    # license
+    install -dm755 "$pkgdir/usr/share/licenses/$pkgname"
+    w3m -dump "$pkgdir/opt/$pkgname/LICENSE.html" \
+        | head -n 5 \
+        > "$pkgdir/usr/share/licenses/$pkgname/license.txt"
+}
+

--- a/community/vivaldi/eula.txt
+++ b/community/vivaldi/eula.txt
@@ -1,0 +1,96 @@
+Vivaldi End User License Agreement
+
+Read the end user license agreement for Vivaldi Browser and find out how to get
+in touch if you have any questions about regarding our EULA.
+
+Last updated: November 18, 2016
+
+1. This End User License Agreement (“EULA”) governs your use (“You”) of the
+browser software in executable form (“Software”) and any ancillary services
+(“Services”) provided to You by Vivaldi Technology AS (“Vivaldi”) to the
+exclusion of all other terms and conditions. Source code used in the Software,
+under open source license agreements, can be obtained at https://vivaldi.com/
+source.
+
+2. Here at Vivaldi, we try to keep things as simple and easy as possible but
+since this is a legal document, it’s a bit longer than we would like it to be.
+It’s important that you read this carefully and understand the terms of use. By
+clicking through, you agree to the following terms and conditions. If you don’t
+agree to the following terms and conditions, you are not allowed to use Vivaldi
+Software or Services.
+
+3. We may modify this EULA and the Privacy Policy at any time. When we post
+changes to this EULA, we will include the date when this EULA was last updated.
+If there are significant changes to the Vivaldi EULA, we will notify you either
+by prominently posting a notice of such changes or by directly sending you a
+notification.
+
+4. This EULA does not apply to third party software or services that Vivaldi
+may deliver with Software or Services. Vivaldi assumes no responsibility or
+liability for such “Third Party Software or Services”. Your use of such Third
+Party Software or Services is exclusively governed by the applicable end user
+license terms and conditions for such Third Party Software or Services. The
+terms in this EULA do not apply to Third Party Software or Services to the
+extent they are inconsistent with end user license terms and conditions for
+such Third Party Software or Service.
+
+5. Subject to the terms and conditions herein, Vivaldi hereby grants You a
+limited, non-exclusive, non-transferable, non-sublicensable license to install
+and use the Software and Services for its intended purpose.
+
+6. You may use the Software and Services on your personal computer, including
+your laptop, desktop and handheld device. You may only use the Software and
+Services for personal use. By way of example, this means that although You are
+allowed to use our Software and Services at work or within your business or
+organization, You are not allowed to sell, trade or resell the Software or
+Services for any purpose, including without limitation any use in any
+application service provider environment, service bureau, or time-sharing
+arrangements
+
+7. Without limiting the foregoing, you are neither allowed to (a) adapt, alter,
+translate, embed into any other product or otherwise create derivative works
+of, or otherwise modify the Software ; (b) separate the component programs of
+the Software for use on different computers; (c) reverse engineer, decompile,
+disassemble or otherwise attempt to derive the source code for the Software,
+except as permitted by applicable law; or (d) remove, alter or obscure any
+proprietary notices on the Software or the applicable documentation therein.
+
+8. The Software and Services and all intellectual property rights therein are
+the exclusive property of Vivaldi and its suppliers, and all rights in and to
+the Software not expressly granted to You in this EULA are reserved. Vivaldi
+owns all copies of the Software, however made.
+
+9. By accepting this EULA, You also accept our privacy policy (available at 
+https://vivaldi.com/privacy/browser). Here at Vivaldi we take privacy matters
+very seriously and we always strive to be compliant with applicable laws and
+regulations.
+
+10. The Software and Services are provided to you “as is” without any warranty
+of any kind, which hereby is disclaimed. Without limiting the foregoing we do
+not guarantee availability of our Software and Services. You use our Software
+and Services at your own risk, and You agree to be fully responsible for any
+claim, expense, liability and/or losses arising from any infringement of this
+EULA. Even though we do our best to provide You with great Software and
+Services, we cannot be held liable for any kind of damage, direct or indirect
+or consequential, resulting from your use of our Software and Services.
+
+11. This EULA applies from the time you download or activate the Software, and
+continues in perpetuity unless terminated by Vivaldi for no cause with thirty
+(30) days prior written notice, or terminated because of Your breach of this
+EULA. On termination all rights granted in this EULA lapse and You are not
+allowed to use the Software or Services. All provisions herein that by its
+nature are intended to survive termination, including Section 10 and 12, shall
+survive such termination.
+
+12. Vivaldi’s headquarters are based in the beautiful city of Oslo, Norway.
+This EULA is therefore governed by the laws of Norway, except its conflict of
+laws rules and regulations. All disputes, actions or proceedings arising under
+or related to this EULA shall exclusively be referred and resolved by the Oslo
+City Court. Notwithstanding, nothing in this EULA will be deemed as preventing
+Vivaldi from seeking injunctive relief (or any other provisional remedy) from
+any court having jurisdiction over the parties and the subject matter of the
+dispute as is necessary to protect Vivaldi’s proprietary information, trade
+secrets, know-how, or any other intellectual property rights.
+
+Please direct any questions or queries with regard to this EULA to 
+legal@vivaldi.com


### PR DESCRIPTION
The package is in the Arch Linux repos, but it's missing from Arch Linux ARM.
There are only 2 changes to the official PKGBUILD - I had to split the sources and checksums into two different entries because Vivaldi uses unconventional ARM architecture names, and while the official package relies on an rpm package there's only deb available for ARM architecture. Tested and built on Orange Pi 3.