### PR TITLE
core/linux-aarch64-rc: chromebook: do not compress dtb files

### DIFF
--- a/core/linux-aarch64-rc/PKGBUILD
+++ b/core/linux-aarch64-rc/PKGBUILD
@@ -31,7 +31,7 @@ md5sums=('9d41c6fb84bd69b5e477c7cd302b0e4f'
          '21d3e833437461aed3b6ca68b5d8afa0'
          'd679f49645578a193d6e3c220787a40d'
          'b59b761dd60e359f3dd51bc93ffd158f'
-         'e19fbe69f1258b99ee6bed21d7afcbce'
+         '7c97cf141750ad810235b1ad06eb9f75'
          '61c5ff73c136ed07a7aadbf58db3d96a'
          '584777ae88bce2c5659960151b64c7d8'
          '41cb5fef62715ead2dd109dbea8413d6'
@@ -244,11 +244,9 @@ _package-chromebook() {
   )
   chromebook_dtbs=($(for b in ${chromeos_boards[@]}; do find arch/${KARCH}/boot -name "*${b}*.dtb" | LC_COLLATE=C sort; done))
 
-  for to_compress in ${chromebook_dtbs[@]} ${image}; do
-    #lzma -9 -z -f -k ${to_compress} # This is 40% smaller but takes ~1 sec longer to boot
-    lz4 -20 -z -f ${to_compress}
-  done
-  echo ${chromebook_dtbs[@]/%/.lz4} | ../generate_chromebook_its.sh ${image}.lz4 ${KARCH} lz4 > kernel.its
+  #lzma -9 -z -f -k ${image} # This is 40% smaller but takes ~1 sec longer to boot
+  lz4 -20 -z -f ${image}
+  echo ${chromebook_dtbs[@]} | ../generate_chromebook_its.sh ${image}.lz4 ${KARCH} lz4 > kernel.its
 
   mkimage -D "-I dts -O dtb -p 2048" -f kernel.its vmlinux.uimg
   dd if=/dev/zero of=bootloader.bin bs=512 count=1

--- a/core/linux-aarch64-rc/generate_chromebook_its.sh
+++ b/core/linux-aarch64-rc/generate_chromebook_its.sh
@@ -31,7 +31,7 @@ for i in ${!dtb_list[@]}; do
 	            data = /incbin/("${dtb}");
 	            type = "flat_dt";
 	            arch = "${arch}";
-	            compression = "${compression}";
+	            compression = "none";
 	            hash {
 	                algo = "sha1";
 	            };


### PR DESCRIPTION
Samsung Chromebook Plus v1 (gru-kevin) does not boot with compressed dtb files
Resulting vmlinux.kpart is still less than 32MiB