### PR TITLE
alarm/rpi-eeprom: include needed rpi-eeprom-digest executable

### DIFF
--- a/alarm/rpi-eeprom/PKGBUILD
+++ b/alarm/rpi-eeprom/PKGBUILD
@@ -5,7 +5,7 @@ buildarch=12
 pkgname=rpi-eeprom
 _commit=3e56160f8b6d24b7fe6b3ae8eb9635f7904ef1c3
 pkgver=20211122
-pkgrel=1
+pkgrel=2
 pkgdesc="Bootloader and VL805 USB controller EEPROM update tool for RPi4"
 arch=('any')
 url='https://github.com/raspberrypi/rpi-eeprom'
@@ -20,6 +20,7 @@ package() {
   cd "$pkgname-$_commit"
   install -pd "$pkgdir/usr/bin"
   install -pm755 rpi-eeprom-config "$pkgdir/usr/bin/rpi-eeprom-config"
+  install -pm755 rpi-eeprom-digest "$pkgdir/usr/bin/rpi-eeprom-digest"
   install -pm755 rpi-eeprom-update "$pkgdir/usr/bin/rpi-eeprom-update"
   install -pDm644 "$pkgname-update-default" "$pkgdir/etc/default/$pkgname-update"
 


### PR DESCRIPTION
The most recent update to `rpi-eeprom` adds another binary/script for generating signatures. This installs it alongside the rest of the package.