### PR TITLE
extra/mesa: enable LTO

### DIFF
--- a/extra/mesa/PKGBUILD
+++ b/extra/mesa/PKGBUILD
@@ -8,11 +8,12 @@
 #  - Removed DRI and Gallium3D drivers/packages for chipsets that don't exist in our ARM devices (intel, VMware svga).
 #  - added broadcom and panfrost vulkan packages
 
+highmem=1
 pkgbase=mesa
 pkgname=('vulkan-mesa-layers' 'opencl-mesa' 'vulkan-radeon' 'vulkan-swrast' 'vulkan-broadcom' 'vulkan-panfrost' 'libva-mesa-driver' 'mesa-vdpau' 'mesa')
 pkgdesc="An open-source implementation of the OpenGL specification"
 pkgver=21.3.5
-pkgrel=1.2
+pkgrel=1.3
 arch=('x86_64')
 makedepends=('python-mako' 'libxml2' 'libx11' 'xorgproto' 'libdrm' 'libxshmfence' 'libxxf86vm'
              'libxdamage' 'libvdpau' 'libva' 'wayland' 'wayland-protocols' 'zstd' 'elfutils' 'llvm'
@@ -48,7 +49,7 @@ build() {
   esac
 
   arch-meson mesa-$pkgver build \
-    -D b_lto=false \
+    -D b_lto=true \
     -D b_ndebug=true \
     -D platforms=x11,wayland \
     -D dri-drivers=r100,r200,nouveau \


### PR DESCRIPTION
While LTO does increase build times and memory requirements for the builder, it also results in a 20% score increase in glmark2-es2-wayland on a RK3566 Quartz64 using the panfrost driver.

I haven't seen the used memory during the build go above 2.5G so I think we're good on that front as well.