### PR TITLE
Add community/yt-dlp

### DIFF
--- a/community/yt-dlp/PKGBUILD
+++ b/community/yt-dlp/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Antonio Rojas <arojas@archlinux.org>
+# Contributor: Stefan Tatschner <stefan@rumpelsepp.org>
+# Contributor: katt <magunasu.b97@gmail.com>
+
+# ALARM: Rijnder Wever <rien334@gmail.com>
+#  - change make target from 'pypi-files' to 'yt-dlp' to avoid pandoc dependency
+#  - add zip to makedepends since the 'yt-dlp' target requires it
+
+pkgname=yt-dlp
+pkgver=2021.12.25
+pkgrel=1
+pkgdesc='A youtube-dl fork with additional features and fixes'
+arch=(any)
+url='https://github.com/yt-dlp/yt-dlp'
+license=(Unlicense)
+depends=(python-mutagen python-pycryptodomex python-websockets)
+makedepends=(python-setuptools zip)
+optdepends=('ffmpeg: for video post-processing'
+            'rtmpdump: for rtmp streams support'
+            'atomicparsley: for embedding thumbnails into m4a files'
+            'aria2: for using aria2 as external downloader')
+source=($pkgname-$pkgver.tar.gz::https://github.com/yt-dlp/yt-dlp/releases/download/$pkgver/yt-dlp.tar.gz)
+sha256sums=('0a4eecdb2bf5d53f87507b7067563a3800f3babf216b01583a2e109ea8ccd427')
+
+build() {
+  cd $pkgname
+  make yt-dlp
+  python setup.py build
+}
+
+package() {
+  cd $pkgname
+  python setup.py install --root="$pkgdir" --skip-build --optimize=1
+}


### PR DESCRIPTION
Upstream builds `community/yt-dlp` with `pandoc` in makedepends, since `pandoc` is needed to build the docs. However, pandoc is hard to get by on arm(v7) machines, so we avoid it by changing the make target to only build `yt-dlp`, and nothing more, as suggested by the [yt-dlp developers](https://github.com/yt-dlp/yt-dlp#compile).
