### PR TITLE
added core/zstd

### DIFF
--- a/core/zstd/PKGBUILD
+++ b/core/zstd/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Levente Polyak <anthraxx[at]archlinux[dot]org>
+# Contributor: Bartłomiej Piotrowski <bpiotrowski@archlinux.org>
+# Contributor: Andrzej Giniewicz <gginiu@gmail.com>
+# Contributor: Johan Förberg <johan@forberg.se>
+
+pkgname=zstd
+pkgver=1.5.1
+pkgrel=2
+pkgdesc='Zstandard - Fast real-time compression algorithm'
+url='https://facebook.github.io/zstd/'
+arch=(x86_64)
+license=(BSD GPL2)
+depends=(glibc gcc-libs zlib xz lz4)
+makedepends=(gtest)
+provides=(libzstd.so)
+source=(https://github.com/facebook/zstd/releases/download/v${pkgver}/zstd-${pkgver}.tar.zst{,.sig}
+        'noexecstack.patch::https://github.com/facebook/zstd/commit/9a9d1ec6f4536ffeb745f360ef010cefd125bfd0.patch')
+sha256sums=('444f68cf74d2ee6e1d3e53aa99463570bcabf37734f26f86b8aa3fec99446f96'
+            'SKIP'
+            '5b5030698cf2b18f164ce97a20c55d00fb2250fe5a6dc7b05bce892e8faffd8a')
+b2sums=('2ab2764ee7b4104916c77bc80dc2ac05e52fdf4909cd730e2f0aa4e2a2c55de098d2527910e2ed9109d514bfc5a3b7cf1237c72e9178d55f9781ec4cd2987876'
+        'SKIP'
+        'e87bdcbf88502bcbf381f5763114d1e56ed898259193b4553e7b32a4fab0130378defc97cde9f28c20884ec694edaea9d16a499e677e8c325f8d670cceb0e99b')
+validpgpkeys=(4EF4AC63455FC9F4545D9B7DEF8FE99528B52FFD)
+
+prepare() {
+  cd ${pkgname}-${pkgver}
+  patch -Np1 < ../noexecstack.patch
+}
+
+build() {
+  cd ${pkgname}-${pkgver}
+  make
+  make -C contrib/pzstd
+}
+
+check() {
+  cd ${pkgname}-${pkgver}
+  make check
+  make -C contrib/pzstd test
+}
+
+package() {
+  cd ${pkgname}-${pkgver}
+  make PREFIX=/usr DESTDIR="${pkgdir}" install
+  ln -sf /usr/bin/zstd "${pkgdir}/usr/bin/zstdmt"
+  install -Dm 755 contrib/pzstd/pzstd -t "${pkgdir}/usr/bin"
+  install -Dm 644 LICENSE -t "${pkgdir}/usr/share/licenses/${pkgname}"
+}
+
+# vim: ts=2 sw=2 et:


### PR DESCRIPTION
This issue is breaking boot on non-x86_64 systems: https://bugzilla.redhat.com/show_bug.cgi?id=2035802

This PR adds a core/zstd PKGBUILD that uses a commit from a pending pull request to the zstd GitHub repository to fix it. The patched package works on my machine (passes `check()` and allows the system to boot). I assume this can't be merged exactly like this, but I'm not familiar with Arch Linux ARM protocols, so just tell me what it needs and I'll fix it up (or edit the branch yourselves if you like).