### PR TITLE
New package: pandoc-citeproc (aarch64)

### DIFF
--- a/community/pandoc-citeproc/PKGBUILD
+++ b/community/pandoc-citeproc/PKGBUILD
@@ -1,0 +1,27 @@
+# ALARM: 
+# Maintainer: codebreaker
+# Contributor: Marek Lach <mareklachbc@tutanota.com>
+#  - update package & its dependencies
+
+buildarch=8
+pkgname=pandoc-citeproc
+pkgver=0.17.0.1
+pkgrel=1
+pkgdesc="Pandoc support for Citation Style Language - tools."
+arch=('aarch64')
+url="https://github.com/jgm/pandoc-citeproc"
+license=('GPL')
+depends=('bibutils' 'glibc' 'gmp' 'icu' 'libffi' 'libyaml' 'pcre' 'zlib' 'cmark-gfm')
+options=('!strip' '!emptydirs')
+source=("http://ftp.de.debian.org/debian/pool/main/h/haskell-pandoc-citeproc/pandoc-citeproc_0.17.0.1-1+b3_arm64.deb")
+sha512sums=('e99fb246f8ad785cedc2e7df4e6bd9c7eb106437234c6308bc0bc698fb2cad4b98bf7632c62ea16d0f1eee1e1354cff6b44ed58b916b5ce2730f38a355e99110')
+
+package(){
+
+	# Extract package data
+	tar xf data.tar.xz -C "${pkgdir}"
+	
+	mkdir -p "${pkgdir}/usr/share/licenses/${pkgname}"
+	install -D -m644 "${pkgdir}/usr/share/doc/${pkgname}/copyright" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+	rm -f "$pkgdir"/usr/share/doc/$pkgname/LICENSE
+}


### PR DESCRIPTION
Builds on aarch64 (armv8).
Crucially needed dependency to build some markdown editors.

Pandoc related packages belong to the community repository in Arch.