### PR TITLE
core/grub: fix detect archlinuxarm's kernel image

### DIFF
--- a/core/grub/0003-10_linux-add-archlinuxarm-s-default-kernel-path.patch
+++ b/core/grub/0003-10_linux-add-archlinuxarm-s-default-kernel-path.patch
@@ -1,0 +1,25 @@
+From 02dd94a72c71b855827f9ec00d2acf93e0f8c85b Mon Sep 17 00:00:00 2001
+From: Menci <huanghaorui301@gmail.com>
+Date: Sat, 5 Feb 2022 16:16:50 +0800
+Subject: [PATCH] 10_linux: add archlinuxarm's default kernel path
+
+---
+ util/grub.d/10_linux.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
+index ca068038e..7e08a7faf 100644
+--- a/util/grub.d/10_linux.in
++++ b/util/grub.d/10_linux.in
+@@ -173,7 +173,7 @@ case "x$machine" in
+ 	done ;;
+     *) 
+ 	list=
+-	for i in /boot/vmlinuz-* /boot/vmlinux-* /vmlinuz-* /vmlinux-* /boot/kernel-* ; do
++	for i in /boot/vmlinuz-* /boot/vmlinux-* /vmlinuz-* /vmlinux-* /boot/kernel-* /boot/Image ; do
+                   if grub_file_is_not_garbage "$i" ; then list="$list $i" ; fi
+ 	done ;;
+ esac
+-- 
+2.34.1
+

--- a/core/grub/PKGBUILD
+++ b/core/grub/PKGBUILD
@@ -73,6 +73,7 @@ source=("git+https://git.savannah.gnu.org/git/grub.git#tag=${_tag}?signed"
         "https://ftp.gnu.org/gnu/unifont/unifont-${_unifont_ver}/unifont-${_unifont_ver}.bdf.gz"{,.sig}
         '0001-00_header-add-GRUB_COLOR_-variables.patch'
         '0002-10_linux-detect-archlinux-initramfs.patch'
+        '0003-10_linux-add-archlinuxarm-s-default-kernel-path.patch'
         'grub.default')
 
 sha256sums=('SKIP'
@@ -81,6 +82,7 @@ sha256sums=('SKIP'
             'SKIP'
             '5dee6628c48eef79812bb9e86ee772068d85e7fcebbd2b2b8d1e19d24eda9dab'
             '8488aec30a93e8fe66c23ef8c23aefda39c38389530e9e73ba3fbcc8315d244d'
+            'bfa56cc7cb2e1650fcd19ecfe5b8d2d0aa7bbc4266a0a5fb1e5d4f60e4a7fa56'
             'c17bf255a41103f6b71a1710afc7e9addaebc578bcf51a48845e227b2f651682')
 
 _backports=(
@@ -127,6 +129,9 @@ prepare() {
 
 	echo "Patch to detect of Arch Linux initramfs images by grub-mkconfig..."
         patch -Np1 -i "${srcdir}/0002-10_linux-detect-archlinux-initramfs.patch"
+
+	echo "Patch to detect of Arch Linux ARM kernel images by grub-mkconfig..."
+        patch -Np1 -i "${srcdir}/0003-10_linux-add-archlinuxarm-s-default-kernel-path.patch"
 
 	echo "Fix DejaVuSans.ttf location so that grub-mkfont can create *.pf2 files for starfield theme..."
 	sed 's|/usr/share/fonts/dejavu|/usr/share/fonts/dejavu /usr/share/fonts/TTF|g' -i "configure.ac"


### PR DESCRIPTION
ArchlinuxARM's `linux` package installs kernel image to `/boot/Image`, which will NOT be detected by `grub-mkconfig` by default.

I patched `10_linux` script of `grub` to add the file to being detected kernel image path list.