### PR TITLE
alarm/dtc145 Fix yylloc error during compilation

### DIFF
--- a/alarm/dtc145/PKGBUILD
+++ b/alarm/dtc145/PKGBUILD
@@ -22,6 +22,7 @@ prepare() {
   cd dtc-$pkgver
   sed -i 's/-Werror//' Makefile
   sed -i 's/python\b/python2/' tests/run_tests.sh
+  sed -i 's/YYLTYPE yylloc;//g' dtc-lexer.l # fix multiple definitions error
 }
 
 build() {


### PR DESCRIPTION
This should be a noop change to the existing dtc145 .pkg files, but in
case you want to recently compile it from scratch you will get this error:

```
/usr/bin/ld: dtc-parser.tab.o:PKGBUILDs/alarm/dtc145/src/dtc-1.4.5/dtc-parser.tab.c:1086: multiple definition of `yylloc'; dtc-lexer.lex.o:PKGBUILDs/alarm/dtc145/src/dtc-1.4.5/dtc-lexer.l:41: first defined here
```

Seems that the usual fix for this (including in the linux kernel) is to
just remove the extra "YYLTYPE yylloc;" line.

Let's do that with a simple sed in our PKGBUILD