### PR TITLE
Add support gzip compressed kernel images

### DIFF
--- a/core/mkinitcpio/0002-functions-handle-gzip-compressed-kernels-in-kver_gen.patch
+++ b/core/mkinitcpio/0002-functions-handle-gzip-compressed-kernels-in-kver_gen.patch
@@ -1,0 +1,29 @@
+From b4a1a6dcb45e010c6ea00767c1a9ecdabb10a4e1 Mon Sep 17 00:00:00 2001
+From: Janne Grunau <j@jannau.net>
+Date: Sun, 30 Jan 2022 10:01:43 +0000
+Subject: [PATCH 1/1] functions: handle gzip compressed kernels in kver_generic
+
+Signed-off-by: Janne Grunau <j@jannau.net>
+---
+ functions | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/functions b/functions
+index 48cfd7a..e90c743 100644
+--- a/functions
++++ b/functions
+@@ -160,6 +160,11 @@ kver_generic() {
+ 
+     read _ _ kver _ < <(grep -m1 -aoE 'Linux version .(\.[-[:alnum:]]+)+' "$1")
+ 
++    # try if the image is gzip compressed
++    if [[ -z "$kver" ]]; then
++        read _ _ kver _ < <(gzip -c -d "$1" | grep -m1 -aoE 'Linux version .(\.[-[:alnum:]]+)+')
++    fi
++
+     printf '%s' "$kver"
+ }
+ 
+-- 
+2.35.0
+

--- a/core/mkinitcpio/PKGBUILD
+++ b/core/mkinitcpio/PKGBUILD
@@ -8,7 +8,7 @@
 
 pkgname=mkinitcpio
 pkgver=31
-pkgrel=2
+pkgrel=3
 pkgdesc="Modular initramfs image creation utility"
 arch=('any')
 url='https://github.com/archlinux/mkinitcpio'
@@ -24,19 +24,23 @@ optdepends=('xz: Use lzma or xz compression for the initramfs image'
 provides=('initramfs')
 backup=('etc/mkinitcpio.conf')
 source=("https://sources.archlinux.org/other/$pkgname/$pkgname-$pkgver.tar.gz"{,.sig}
-        '0001-use-gzip-for-compression-by-default.patch')
+        '0001-use-gzip-for-compression-by-default.patch'
+        '0002-functions-handle-gzip-compressed-kernels-in-kver_gen.patch')
 install=mkinitcpio.install
 sha512sums=('4ef87c2e4f579b292c38f9c487e78b3b99f6db77909cab322e860e5ca70aca3747fcfc272e2e15c9a3605c924ab178057b8b23151f98debc5d96e65f3c0c49d5'
             'SKIP'
-            '692222c01112b30e2d0a0d48265d481617349074bee968c6dca4926bc4ef6501847a79bd7de403ee10ee2e77a7dcc0422ed49a607fe3e96a4d523e2e569724ad')
+            '692222c01112b30e2d0a0d48265d481617349074bee968c6dca4926bc4ef6501847a79bd7de403ee10ee2e77a7dcc0422ed49a607fe3e96a4d523e2e569724ad'
+            '8832c8dd6db5e812f5ea58c42a992c30b9f79cefb4fa513f408441ddaa03bd078118cf95faa004c11b1faf812023b48ff7bb0ffe1b28473c3f305ae691ad5f73')
 b2sums=('0113e288906e3b5fa485c29c00e7df60d85addd96718c45531031a686f18c739fa18303b6cac374d35b85edb7b663e221c8dc9158dff08c75858a4ed4dd154bf'
         'SKIP'
-        '3373b576de3e6fc9d728637f33d7c813bdff20925dc266cab570aea9978927f2d039aa3f8a509b48dcb1c37fd64c65983a1de23db288befdf1005c08dab0f664')
+        '3373b576de3e6fc9d728637f33d7c813bdff20925dc266cab570aea9978927f2d039aa3f8a509b48dcb1c37fd64c65983a1de23db288befdf1005c08dab0f664'
+        '8c2df3c08379f3133cfa46919438771e32b22928d1028001b87c8a727c2e8d3ef53c06b9c570cc071753ba072be0f1d2ec6637b68f522fdf6b367b77af7b45f7')
 validpgpkeys=('ECCAC84C1BA08A6CC8E63FBBF22FB1D78A77AEAB')    # Giancarlo Razzolini
 
 prepare() {
   cd $pkgname-$pkgver
   patch -p1 -i ../0001-use-gzip-for-compression-by-default.patch
+  patch -p1 -i ../0002-functions-handle-gzip-compressed-kernels-in-kver_gen.patch
 }
 
 check() {


### PR DESCRIPTION
Adding this as patch due to no progress on the upstream merge request for more than 3 weeks.

core/mkinitcpio to 31-3

Adds support for gzip compressed kernel images. u-boot and grub support
compressed images so should mkinitcpio.
See this MR https://github.com/archlinux/mkinitcpio/pull/86