### PR TITLE
[core/linux-armv7*] Obtain firmware to reenable building linux-armv7 / linux-armv7-rc

### DIFF
--- a/core/linux-armv7-rc/PKGBUILD
+++ b/core/linux-armv7-rc/PKGBUILD
@@ -17,10 +17,14 @@ pkgrel=2
 arch=('armv7h')
 url="http://www.kernel.org/"
 license=('GPL2')
-makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'git' 'uboot-tools' 'vboot-utils' 'dtc')
+makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'git' 'uboot-tools' 'vboot-utils' 'dtc' 'wireless-regdb')
 options=('!strip')
 source=("https://git.kernel.org/torvalds/t/${_srcname}.tar.gz"
         "http://rcn-ee.com/deb/sid-armhf/v${_rcver}.0-rc${_rcnrc}-${_rcnrel}/patch-${_rcver}-rc${_rcnrc}-${_rcnrel}.diff.gz"
+        "am335x-bone-scale-data.bin::https://git.ti.com/cgit/processor-firmware/ti-amx3-cm3-pm-firmware/tree/bin/am335x-bone-scale-data.bin?id=6a849767df85ce9399494f53fb5c753665396653"
+        "am335x-evm-scale-data.bin::https://git.ti.com/cgit/processor-firmware/ti-amx3-cm3-pm-firmware/tree/bin/am335x-evm-scale-data.bin?id=6a849767df85ce9399494f53fb5c753665396653"
+        "am335x-pm-firmware.elf::https://git.ti.com/cgit/processor-firmware/ti-amx3-cm3-pm-firmware/tree/bin/am335x-pm-firmware.elf?id=6a849767df85ce9399494f53fb5c753665396653"
+        "am43x-evm-scale-data.bin::https://git.ti.com/cgit/processor-firmware/ti-amx3-cm3-pm-firmware/tree/bin/am43x-evm-scale-data.bin?id=6a849767df85ce9399494f53fb5c753665396653"
         '0001-ARM-atags-add-support-for-Marvell-s-u-boot.patch'
         '0002-ARM-atags-fdt-retrieve-MAC-addresses-from-Marvell-bo.patch'
         '0003-fix-mvsdio-eMMC-timing.patch'
@@ -36,6 +40,10 @@ source=("https://git.kernel.org/torvalds/t/${_srcname}.tar.gz"
         '99-linux.hook')
 md5sums=('a5f857ceb0b3950effaa5294b08ba316'
          '8286c88f42422ac57f9e1dd5021a1075'
+         '23709ef964ecdad75e7c96d8b398d239'
+         '7c064fdf15579c2e049d2c0fc68705c5'
+         'b97efb4b61af36c4d5886dc93213a891'
+         '042cfb751c32ceb08b9492abf9eb3841'
          '874e99c5570d305f43f9925592f08556'
          '10f667fedbe19c86c8f51bf1f4edc527'
          '19e8d3975bdd5171eef7f98ef50613d0'
@@ -73,6 +81,21 @@ prepare() {
 
   # don't run depmod on 'make install'. We'll do this ourselves in packaging
   sed -i '2iexit 0' scripts/depmod.sh
+
+  # add binary firmware blobs
+  mkdir -p firmware
+
+  # Config requires regulatory.db files from wireless-regdb
+  cp /usr/lib/firmware/regulatory.db firmware/.
+  cp /usr/lib/firmware/regulatory.db.p7s firmware/.
+
+  # Config requires TI binaries for BeagleBone.
+  # Latest TI binaries are in branch origin/ti-v4.1.y-next:
+  # https://git.ti.com/cgit/processor-firmware/ti-amx3-cm3-pm-firmware/tree/bin?id=6a849767df85ce9399494f53fb5c753665396653
+  cp ../am335x-bone-scale-data.bin firmware/.
+  cp ../am335x-evm-scale-data.bin firmware/.
+  cp ../am335x-pm-firmware.elf firmware/.
+  cp ../am43x-evm-scale-data.bin firmware/.
 }
 
 build() {

--- a/core/linux-armv7/PKGBUILD
+++ b/core/linux-armv7/PKGBUILD
@@ -14,11 +14,15 @@ rcnrel=armv7-x15
 arch=('armv7h')
 url="http://www.kernel.org/"
 license=('GPL2')
-makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'git' 'uboot-tools' 'vboot-utils' 'dtc')
+makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'git' 'uboot-tools' 'vboot-utils' 'dtc' 'wireless-regdb')
 options=('!strip')
 source=("https://www.kernel.org/pub/linux/kernel/v5.x/${_srcname}.tar.xz"
         "https://www.kernel.org/pub/linux/kernel/v5.x/patch-${pkgver}.xz"
         "https://rcn-ee.com/deb/sid-armhf/v${rcnver}-${rcnrel}/patch-${rcnver%.0}-${rcnrel}.diff.gz"
+        "am335x-bone-scale-data.bin::https://git.ti.com/cgit/processor-firmware/ti-amx3-cm3-pm-firmware/tree/bin/am335x-bone-scale-data.bin?id=6a849767df85ce9399494f53fb5c753665396653"
+        "am335x-evm-scale-data.bin::https://git.ti.com/cgit/processor-firmware/ti-amx3-cm3-pm-firmware/tree/bin/am335x-evm-scale-data.bin?id=6a849767df85ce9399494f53fb5c753665396653"
+        "am335x-pm-firmware.elf::https://git.ti.com/cgit/processor-firmware/ti-amx3-cm3-pm-firmware/tree/bin/am335x-pm-firmware.elf?id=6a849767df85ce9399494f53fb5c753665396653"
+        "am43x-evm-scale-data.bin::https://git.ti.com/cgit/processor-firmware/ti-amx3-cm3-pm-firmware/tree/bin/am43x-evm-scale-data.bin?id=6a849767df85ce9399494f53fb5c753665396653"
         '0001-ARM-atags-add-support-for-Marvell-s-u-boot.patch'
         '0002-ARM-atags-fdt-retrieve-MAC-addresses-from-Marvell-bo.patch'
         '0003-SMILE-Plug-device-tree-file.patch'
@@ -38,6 +42,10 @@ source=("https://www.kernel.org/pub/linux/kernel/v5.x/${_srcname}.tar.xz"
 md5sums=('e6680ce7c989a3efe58b51e3f3f0bf93'
          '55647f2eddc0e936b59151a42507382a'
          'b39a2de9fb6f3fac06ffbec3097f1222'
+         '23709ef964ecdad75e7c96d8b398d239'
+         '7c064fdf15579c2e049d2c0fc68705c5'
+         'b97efb4b61af36c4d5886dc93213a891'
+         '042cfb751c32ceb08b9492abf9eb3841'
          'b81c2379a8d11aa94c7362cc2e4dc025'
          '9924e5e533a18f45b5f404e97e24758f'
          '85fe4d7b5ff10099367b784fb25cd180'
@@ -82,6 +90,21 @@ prepare() {
 
   # don't run depmod on 'make install'. We'll do this ourselves in packaging
   sed -i '2iexit 0' scripts/depmod.sh
+
+  # add binary firmware blobs
+  mkdir -p firmware
+
+  # Config requires regulatory.db files from wireless-regdb
+  cp /usr/lib/firmware/regulatory.db firmware/.
+  cp /usr/lib/firmware/regulatory.db.p7s firmware/.
+
+  # Config requires TI binaries for BeagleBone.
+  # Latest TI binaries are in branch origin/ti-v4.1.y-next:
+  # https://git.ti.com/cgit/processor-firmware/ti-amx3-cm3-pm-firmware/tree/bin?id=6a849767df85ce9399494f53fb5c753665396653
+  cp ../am335x-bone-scale-data.bin firmware/.
+  cp ../am335x-evm-scale-data.bin firmware/.
+  cp ../am335x-pm-firmware.elf firmware/.
+  cp ../am43x-evm-scale-data.bin firmware/.
 }
 
 build() {


### PR DESCRIPTION
As described in [the ArchlinuxARM forum](https://archlinuxarm.org/forum/viewtopic.php?f=60&t=15933), the PKGBUILDs of `core/linux-armv7` and `core/linux-armv7-rc` are missing to obtain firmware that is stated in their current ArchlinuxARM armv7 kernel `config`:
`CONFIG_EXTRA_FIRMWARE="regulatory.db regulatory.db.p7s am335x-pm-firmware.elf am335x-bone-scale-data.bin am335x-evm-scale-data.bin am43x-evm-scale-data.bin"`
This means, that both kernels can not be build by a clean download of the ArchlinuxARM PKGBUILDs repository.

The first two firmware files can be retrieved by an installed `wireless-regdb` package, while all latter need to be fetched from TIs repository directly. The code fetches the latest binaries directly, as TIs git repository is slow and big.