### PR TITLE
extra/firefox: Fix regression on aarch64 (98.0.1-1.1)

### DIFF
--- a/extra/firefox/PKGBUILD
+++ b/extra/firefox/PKGBUILD
@@ -11,7 +11,7 @@ highmem=1
 
 pkgname=firefox
 pkgver=98.0.1
-pkgrel=1
+pkgrel=1.1
 pkgdesc="Standalone web browser from mozilla.org"
 arch=(x86_64)
 license=(MPL GPL LGPL)
@@ -29,10 +29,14 @@ optdepends=('networkmanager: Location detection via available WiFi networks'
 options=(!emptydirs !makeflags !strip !lto !debug)
 source=(https://archive.mozilla.org/pub/firefox/releases/$pkgver/source/firefox-$pkgver.source.tar.xz{,.asc}
         build-arm-libopus.patch
+        revert-crossbeam-crates-upgrade.patch
+        psutil-remove-version-cap.patch
         $pkgname.desktop identity-icons-brand.svg)
 sha256sums=('f8de2f514d94cad25a2c8a5d219399de5c05a907607d51c5c5235a8bc9bb361c'
             'SKIP'
             '2d4d91f7e35d0860225084e37ec320ca6cae669f6c9c8fe7735cdbd542e3a7c9'
+            '56bd09bfd2fa594c2af7dbe923d72bed9da23b7c001f923bf33784554e323541'
+            '2bb0ac385b54972eb3e665ac70fb13565ed9da77b33349b844b2e0ad4948cff5'
             '298eae9de76ec53182f38d5c549d0379569916eebf62149f9d7f4a7edef36abf'
             'a9b8b4a0a1f4a7b4af77d5fc70c2686d624038909263c795ecc81e0aec7711e9')
 validpgpkeys=('14F26682D0916CDD81E37B6D61B7B526D98F0353') # Mozilla Software Releases <release@mozilla.com>
@@ -122,6 +126,8 @@ END
   export LDFLAGS+=" -Wl,--no-keep-memory"
   export RUSTFLAGS="-Cdebuginfo=0"
   patch -p1 -i ../build-arm-libopus.patch
+  patch -p1 -i ../revert-crossbeam-crates-upgrade.patch
+  patch -p1 -i ../psutil-remove-version-cap.patch
 }
 
 build() {

--- a/extra/firefox/psutil-remove-version-cap.patch
+++ b/extra/firefox/psutil-remove-version-cap.patch
@@ -1,0 +1,9 @@
+--- firefox-98.0.1/build/mach_virtualenv_packages.txt.old	2022-03-15 09:22:23.844188180 -0400
++++ firefox-98.0.1/build/mach_virtualenv_packages.txt	2022-03-15 09:22:31.767183949 -0400
+@@ -133,5 +133,5 @@
+ # Mach gracefully handles the case where `psutil` is unavailable.
+ # We aren't (yet) able to pin packages in automation, so we have to
+ # support down to the oldest locally-installed version (5.4.2).
+-pypi-optional:psutil>=5.4.2,<=5.8.0:telemetry will be missing some data
++pypi-optional:psutil>=5.4.2:telemetry will be missing some data
+ pypi-optional:zstandard>=0.11.1,<=0.17.0:zstd archives will not be possible to extract

--- a/extra/firefox/revert-crossbeam-crates-upgrade.patch
+++ b/extra/firefox/revert-crossbeam-crates-upgrade.patch
@@ -1,0 +1,3300 @@
+Description: Revert the upgrade of crossbeam-* crates that happened in Firefox 98.0,
+  which resulted in a regression on arm64 where the browser wouldn't draw its window.
+  This is a temporary measure until the exact cause of the regression is identified and fixed.
+Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1757571
+Author: Olivier Tilloy <olivier.tilloy@canonical.com>
+
+diff --git a/Cargo.lock b/Cargo.lock
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -482,7 +482,7 @@ version = "0.1.0"
+ dependencies = [
+  "bits_client",
+  "comedy",
+- "crossbeam-utils 0.8.6",
++ "crossbeam-utils 0.8.5",
+  "libc",
+  "log",
+  "moz_task",
+@@ -553,7 +553,7 @@ version = "0.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "b8e3ff9db740167616e528c509b3618046fc05d337f8f3182d300f4aa977d2bb"
+ dependencies = [
+- "crossbeam-utils 0.8.6",
++ "crossbeam-utils 0.8.5",
+  "jobserver",
+  "num_cpus",
+ ]
+@@ -628,7 +628,7 @@ version = "0.0.1"
+ dependencies = [
+  "base64 0.10.1",
+  "byteorder",
+- "crossbeam-utils 0.8.6",
++ "crossbeam-utils 0.8.5",
+  "cstr",
+  "log",
+  "malloc_size_of_derive",
+@@ -975,12 +975,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "crossbeam-channel"
+-version = "0.5.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
++version = "0.5.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+ dependencies = [
+  "cfg-if 1.0.0",
+- "crossbeam-utils 0.8.6",
++ "crossbeam-utils 0.8.5",
+ ]
+ 
+ [[package]]
+@@ -1001,8 +1001,8 @@ source = "registry+https://github.com/ru
+ checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+ dependencies = [
+  "cfg-if 1.0.0",
+- "crossbeam-epoch 0.9.6",
+- "crossbeam-utils 0.8.6",
++ "crossbeam-epoch 0.9.5",
++ "crossbeam-utils 0.8.5",
+ ]
+ 
+ [[package]]
+@@ -1022,12 +1022,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "crossbeam-epoch"
+-version = "0.9.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
++version = "0.9.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+ dependencies = [
+  "cfg-if 1.0.0",
+- "crossbeam-utils 0.8.6",
++ "crossbeam-utils 0.8.5",
+  "lazy_static",
+  "memoffset 0.6.5",
+  "scopeguard",
+@@ -1065,9 +1065,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "crossbeam-utils"
+-version = "0.8.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
++version = "0.8.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+ dependencies = [
+  "cfg-if 1.0.0",
+  "lazy_static",
+@@ -2699,7 +2699,7 @@ name = "kvstore"
+ version = "0.1.0"
+ dependencies = [
+  "atomic_refcell",
+- "crossbeam-utils 0.8.6",
++ "crossbeam-utils 0.8.5",
+  "cstr",
+  "lazy_static",
+  "libc",
+@@ -4164,7 +4164,7 @@ checksum = "d78120e2c850279833f1dd3582f7
+ dependencies = [
+  "crossbeam-channel",
+  "crossbeam-deque 0.8.1",
+- "crossbeam-utils 0.8.6",
++ "crossbeam-utils 0.8.5",
+  "lazy_static",
+  "num_cpus",
+ ]
+@@ -4348,7 +4348,7 @@ dependencies = [
+  "base64 0.13.0",
+  "blake2b_simd",
+  "constant_time_eq",
+- "crossbeam-utils 0.8.6",
++ "crossbeam-utils 0.8.5",
+ ]
+ 
+ [[package]]
+@@ -5963,7 +5963,7 @@ dependencies = [
+ name = "xulstore"
+ version = "0.1.0"
+ dependencies = [
+- "crossbeam-utils 0.8.6",
++ "crossbeam-utils 0.8.5",
+  "cstr",
+  "libc",
+  "log",
+diff --git a/third_party/rust/crossbeam-channel/.cargo-checksum.json b/third_party/rust/crossbeam-channel/.cargo-checksum.json
+--- a/third_party/rust/crossbeam-channel/.cargo-checksum.json
++++ b/third_party/rust/crossbeam-channel/.cargo-checksum.json
+@@ -1,1 +1,1 @@
+-{"files":{"CHANGELOG.md":"e70d1a5fa6697a8b24e193e3934975317df12279c167b90fcb9616291792197c","Cargo.lock":"0f4e59f28bdd52c4781d102fc7d1f16d1ea417aaec0a4846432444a4019b2537","Cargo.toml":"c8334f658b699a1a0e25d997d752a9493a627f9ddcb7aab739c7319ea583882f","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"5734ed989dfca1f625b40281ee9f4530f91b2411ec01cb748223e7eb87e201ab","LICENSE-THIRD-PARTY":"b16db96b93b1d7cf7bea533f572091ec6bca3234fbe0a83038be772ff391a44c","README.md":"415a71d4978cfd338a6ae1f1b41284652eccd277a815542c304647dc437a8274","benches/crossbeam.rs":"96cb1abd23cac3ef8a7174a802e94609926b555bb02c9658c78723d433f1dd92","examples/fibonacci.rs":"4e88fa40048cdc31e9c7bb60347d46f92543d7ddf39cab3b52bfe44affdb6a02","examples/matching.rs":"63c250e164607a7a9f643d46f107bb5da846d49e89cf9069909562d20e530f71","examples/stopwatch.rs":"d02121258f08d56f1eb7997e19bcb9bacb6836cfa0abbba90a9e59d8a50ae5cf","src/channel.rs":"a9baaad2f414c38cd324a60ac9375ca58462ce6662217683648e9b66cec43a8c","src/context.rs":"ff4d39639ddf16aaab582d4a5f3d10ef2c71afe1abbf4e60f3d9d2ddbd72c230","src/counter.rs":"c49a9f44587888850edeb62f7c8ecd1acecb39c836834254ff3ac934c478440a","src/err.rs":"fdbde7279a1e74973e5c7d3e835a97836229a357fe465c0ba1a37f2a012d1bef","src/flavors/array.rs":"853c2ad068f912cfb49877bcd41e241f34b25026b709bf0629523f19952e3adc","src/flavors/at.rs":"65bf870b3ddb14738256706b0276f2656ad1fe9cd8eb91737489868edd088e92","src/flavors/list.rs":"50dbe59616c39b5aa184470023ce0cfb1cb0dbd92e1577375d299446981527c0","src/flavors/mod.rs":"3d9d43bc38b0adb18c96c995c2bd3421d8e33ab6c30b20c3c467d21d48e485dc","src/flavors/never.rs":"0e7921922d00c711552fb063c63c78192fa6ddc0762fb81c1713b847495ec39a","src/flavors/tick.rs":"38a479b9f4a72a5ccb9c407a1e7b44d36b6ad0f4e214e39266b12b9564c803dc","src/flavors/zero.rs":"012a53f56b86df22ce49866da95e5f457fb99a18a098f0f64779c6d1cdd7092f","src/lib.rs":"3a65706d4124844ffc4c8cb1f8cc779631ec94f449f85cbb68364ad3619404f1","src/select.rs":"66eb10a6cbdf8dd0869f2a7cac9992fdaee36c9e2a01d708d39d7c794572935b","src/select_macro.rs":"96bc9acb9a22588a4e733b0ab0761ad2be9a6b3e03744e8fc9c6de9ae433b696","src/utils.rs":"746fe315d6cfc832e3dda35e5055c0fd5c99907f1303b2ea7eacc4e37c8527e1","src/waker.rs":"591ee70bf62ccad5aa2fac7b92d444183b02790a79c024f016c78de2396d08a3","tests/after.rs":"0154a8e152880db17a20514ecdd49dabc361d3629858d119b9746b5e932c780c","tests/array.rs":"e5f25e8991863a9a86d61a66be646d04feae527f35b1697fd215b97af4383736","tests/golang.rs":"dc85669c9c4e902b1bb263d00f5cb6f9ecb6d42b19fe53425b55ce97c887da49","tests/iter.rs":"25dc02135bbae9d47a30f9047661648e66bdc134e40ba78bc2fbacbb8b3819bc","tests/list.rs":"de865ef097f3bcb35c1c814554e6108fed43b3dbb1533c8bbcf8688cceb6b6ab","tests/mpsc.rs":"401aa3c6923815058881ddce98070df68ebab283913c89c007436bb8af7ca0ea","tests/never.rs":"ee40c4fc4dd5af4983fae8de6927f52b81174d222c162f745b26c4a6c7108e4f","tests/ready.rs":"d349702f123925a0781b48d677e6dcf64fc5d1fc788a7bf1e151a3d57e81871c","tests/same_channel.rs":"2bab761443671e841e1b2476bd8082d75533a2f6be7946f5dbcee67cdc82dccb","tests/select.rs":"d20259a45f387cbce80c2c876ae81ea3883f36ea01c5151c159d58c362f6ba07","tests/select_macro.rs":"d3af2dc98e0dd03dc4ffab464b8ccb2f8b7504e8bb830948a04c015b92f0b296","tests/thread_locals.rs":"a1ce59e2aff69161621c0cb215eb6ea238088c06a31a8507a74cf179fd5a4299","tests/tick.rs":"5f697bd14c48505d932e82065b5302ef668e1cc19cac18e8ac22e0c83c221c1d","tests/zero.rs":"afbd838001d4196daddf17133e60ccea31529cc48ee01e245ac0d6366d1e30b9"},"package":"e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"}
+\ No newline at end of file
++{"files":{"CHANGELOG.md":"74ac49b84461217698d4430f81b1cdcba0595bc4e57216ffc52b8296ac44cd41","Cargo.lock":"7956079bcac40cc40c894f0260266365ecdb1c01c48636ae4c4080977603e7b8","Cargo.toml":"6a7acaffaa30dab2b5ea1f5ab86b20bc97370314ed03472288745b3b969786dc","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"5734ed989dfca1f625b40281ee9f4530f91b2411ec01cb748223e7eb87e201ab","LICENSE-THIRD-PARTY":"b16db96b93b1d7cf7bea533f572091ec6bca3234fbe0a83038be772ff391a44c","README.md":"415a71d4978cfd338a6ae1f1b41284652eccd277a815542c304647dc437a8274","benches/crossbeam.rs":"f5720508d3458f2451271b9887f7557823304bd38288c928b0d6aa1f459865e5","examples/fibonacci.rs":"6a26ecd74c7493d2c93f4280c0804afc19adc612b77b3d9fea433119ff472a44","examples/matching.rs":"63c250e164607a7a9f643d46f107bb5da846d49e89cf9069909562d20e530f71","examples/stopwatch.rs":"f9a00477b41823199e4af06bddeb0c6cfd22e272340eec1b98b333fc59ee6a1f","src/channel.rs":"a9baaad2f414c38cd324a60ac9375ca58462ce6662217683648e9b66cec43a8c","src/context.rs":"ad24cabfc50dd5e6ae84aa46a0246da12da1f1a6fa19043244ad25136075c6ca","src/counter.rs":"c49a9f44587888850edeb62f7c8ecd1acecb39c836834254ff3ac934c478440a","src/err.rs":"fdbde7279a1e74973e5c7d3e835a97836229a357fe465c0ba1a37f2a012d1bef","src/flavors/array.rs":"c125146771265058ac320226456b1e21667e93649531a3d20157f71cd715881d","src/flavors/at.rs":"65bf870b3ddb14738256706b0276f2656ad1fe9cd8eb91737489868edd088e92","src/flavors/list.rs":"50dbe59616c39b5aa184470023ce0cfb1cb0dbd92e1577375d299446981527c0","src/flavors/mod.rs":"3d9d43bc38b0adb18c96c995c2bd3421d8e33ab6c30b20c3c467d21d48e485dc","src/flavors/never.rs":"0e7921922d00c711552fb063c63c78192fa6ddc0762fb81c1713b847495ec39a","src/flavors/tick.rs":"38a479b9f4a72a5ccb9c407a1e7b44d36b6ad0f4e214e39266b12b9564c803dc","src/flavors/zero.rs":"1bda0c5483b04d53f36f9f4a6fe6f87b69f698068771e637e224c09400c6ce83","src/lib.rs":"3a65706d4124844ffc4c8cb1f8cc779631ec94f449f85cbb68364ad3619404f1","src/select.rs":"4eb4b1988c5dffff3e3d2138d14a1b86613bf62b78c45a5c70f65aaee92c11bb","src/select_macro.rs":"96bc9acb9a22588a4e733b0ab0761ad2be9a6b3e03744e8fc9c6de9ae433b696","src/utils.rs":"746fe315d6cfc832e3dda35e5055c0fd5c99907f1303b2ea7eacc4e37c8527e1","src/waker.rs":"9058cc441d467539c439ef88f0be1a187bf122d26fc116ce3e3a0265a693761f","tests/after.rs":"324c7d773f72bef62d150171f74ba7b7ac1b06f6030b3d4d2b1a35d211956b21","tests/array.rs":"574bff53aff0b0a8c365bf3f9ad77bb64675df9e6e0714be9c16eeeeac22e4d5","tests/golang.rs":"ec03806945fecd381cfce0634e2d776741423589c92e1bd4d8a431ac20f5d2d0","tests/iter.rs":"7563dc7fdf4c63e31dd74ee3fedecdd3aed490f7ef599b98f6f75f929cf79edb","tests/list.rs":"cc2971e69fd7f6a94b5463c9d4e9079df7955b37552e16dd66f4c6e65db60d96","tests/mpsc.rs":"0c4c6b056f5cec77ca19eca45f99b083632700a4b67133e88071a1d22a61d6fe","tests/never.rs":"665441a9fb004f7cd44047619637ebe6766cf2faf58e68e6481397bbfc682e11","tests/ready.rs":"eae3d7f16e817e63f3a6ceda062fece3de5e11c7a9631b32b02f23396a9d59c1","tests/same_channel.rs":"2bab761443671e841e1b2476bd8082d75533a2f6be7946f5dbcee67cdc82dccb","tests/select.rs":"3603f450b23f5e0d1e4014a167a9b23ab149b5f418c8b89636f1c02c90501569","tests/select_macro.rs":"00dd7963f79b96abf30851fdab29e86c8424b502a8a7d34abf4bc1714f493ecf","tests/thread_locals.rs":"3611db5502e6af0a8d15187d09fd195381819795544208b946e9f99b04579a81","tests/tick.rs":"dc4a7d3c8dd888ce135fe8a8c67f5dc8b5ab0c3fa57a48459f96d51fa0f1e6d5","tests/zero.rs":"0ff0587cc74569bfe389e0c619217799a960a0dfc5e6354603c88e6eea1b79a1"},"package":"06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"}
+\ No newline at end of file
+diff --git a/third_party/rust/crossbeam-channel/CHANGELOG.md b/third_party/rust/crossbeam-channel/CHANGELOG.md
+--- a/third_party/rust/crossbeam-channel/CHANGELOG.md
++++ b/third_party/rust/crossbeam-channel/CHANGELOG.md
+@@ -1,7 +1,3 @@
+-# Version 0.5.2
+-
+-- Fix stacked borrows violations. (#763, #764)
+-
+ # Version 0.5.1
+ 
+ - Fix memory leak in unbounded channel. (#669)
+diff --git a/third_party/rust/crossbeam-channel/Cargo.lock b/third_party/rust/crossbeam-channel/Cargo.lock
+--- a/third_party/rust/crossbeam-channel/Cargo.lock
++++ b/third_party/rust/crossbeam-channel/Cargo.lock
+@@ -3,6 +3,12 @@
+ version = 3
+ 
+ [[package]]
++name = "autocfg"
++version = "1.0.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
++
++[[package]]
+ name = "cfg-if"
+ version = "1.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -10,7 +16,7 @@ checksum = "baf1de4339761588bc0619e3cbc0
+ 
+ [[package]]
+ name = "crossbeam-channel"
+-version = "0.5.2"
++version = "0.5.1"
+ dependencies = [
+  "cfg-if",
+  "crossbeam-utils",
+@@ -21,19 +27,20 @@ dependencies = [
+ 
+ [[package]]
+ name = "crossbeam-utils"
+-version = "0.8.6"
++version = "0.8.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
++checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+ dependencies = [
++ "autocfg",
+  "cfg-if",
+  "lazy_static",
+ ]
+ 
+ [[package]]
+ name = "getrandom"
+-version = "0.2.3"
++version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
++checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+ dependencies = [
+  "cfg-if",
+  "libc",
+@@ -42,9 +49,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "hermit-abi"
+-version = "0.1.19"
++version = "0.1.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
++checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+ dependencies = [
+  "libc",
+ ]
+@@ -57,15 +64,15 @@ checksum = "e2abad23fbc42b3700f2f279844d
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.112"
++version = "0.2.93"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
++checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+ 
+ [[package]]
+ name = "num_cpus"
+-version = "1.13.1"
++version = "1.13.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
++checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+ dependencies = [
+  "hermit-abi",
+  "libc",
+@@ -73,15 +80,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "ppv-lite86"
+-version = "0.2.16"
++version = "0.2.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
++checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+ 
+ [[package]]
+ name = "rand"
+-version = "0.8.4"
++version = "0.8.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
++checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+ dependencies = [
+  "libc",
+  "rand_chacha",
+@@ -91,9 +98,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rand_chacha"
+-version = "0.3.1"
++version = "0.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
++checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+ dependencies = [
+  "ppv-lite86",
+  "rand_core",
+@@ -101,27 +108,27 @@ dependencies = [
+ 
+ [[package]]
+ name = "rand_core"
+-version = "0.6.3"
++version = "0.6.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
++checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+ dependencies = [
+  "getrandom",
+ ]
+ 
+ [[package]]
+ name = "rand_hc"
+-version = "0.3.1"
++version = "0.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
++checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+ dependencies = [
+  "rand_core",
+ ]
+ 
+ [[package]]
+ name = "signal-hook"
+-version = "0.3.13"
++version = "0.3.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
++checksum = "ef33d6d0cd06e0840fba9985aab098c147e67e05cee14d412d3345ed14ff30ac"
+ dependencies = [
+  "libc",
+  "signal-hook-registry",
+@@ -129,9 +136,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "signal-hook-registry"
+-version = "1.4.0"
++version = "1.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
++checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+ dependencies = [
+  "libc",
+ ]
+diff --git a/third_party/rust/crossbeam-channel/Cargo.toml b/third_party/rust/crossbeam-channel/Cargo.toml
+--- a/third_party/rust/crossbeam-channel/Cargo.toml
++++ b/third_party/rust/crossbeam-channel/Cargo.toml
+@@ -3,19 +3,21 @@
+ # When uploading crates to the registry Cargo will automatically
+ # "normalize" Cargo.toml files for maximal compatibility
+ # with all versions of Cargo and also rewrite `path` dependencies
+-# to registry (e.g., crates.io) dependencies.
++# to registry (e.g., crates.io) dependencies
+ #
+-# If you are reading this file be aware that the original Cargo.toml
+-# will likely look very different (and much more reasonable).
+-# See Cargo.toml.orig for the original contents.
++# If you believe there's an error in this file please file an
++# issue against the rust-lang/cargo repository. If you're
++# editing this file be aware that the upstream Cargo.toml
++# will likely look very different (and much more reasonable)
+ 
+ [package]
+ edition = "2018"
+-rust-version = "1.36"
+ name = "crossbeam-channel"
+-version = "0.5.2"
++version = "0.5.1"
++authors = ["The Crossbeam Project Developers"]
+ description = "Multi-producer multi-consumer channels for message passing"
+ homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-channel"
++documentation = "https://docs.rs/crossbeam-channel"
+ keywords = ["channel", "mpmc", "select", "golang", "message"]
+ categories = ["algorithms", "concurrency", "data-structures"]
+ license = "MIT OR Apache-2.0"
+diff --git a/third_party/rust/crossbeam-channel/benches/crossbeam.rs b/third_party/rust/crossbeam-channel/benches/crossbeam.rs
+--- a/third_party/rust/crossbeam-channel/benches/crossbeam.rs
++++ b/third_party/rust/crossbeam-channel/benches/crossbeam.rs
+@@ -13,7 +13,7 @@ mod unbounded {
+ 
+     #[bench]
+     fn create(b: &mut Bencher) {
+-        b.iter(unbounded::<i32>);
++        b.iter(|| unbounded::<i32>());
+     }
+ 
+     #[bench]
+diff --git a/third_party/rust/crossbeam-channel/examples/fibonacci.rs b/third_party/rust/crossbeam-channel/examples/fibonacci.rs
+--- a/third_party/rust/crossbeam-channel/examples/fibonacci.rs
++++ b/third_party/rust/crossbeam-channel/examples/fibonacci.rs
+@@ -10,7 +10,7 @@ fn fibonacci(sender: Sender<u64>) {
+     while sender.send(x).is_ok() {
+         let tmp = x;
+         x = y;
+-        y += tmp;
++        y = tmp + y;
+     }
+ }
+ 
+diff --git a/third_party/rust/crossbeam-channel/examples/stopwatch.rs b/third_party/rust/crossbeam-channel/examples/stopwatch.rs
+--- a/third_party/rust/crossbeam-channel/examples/stopwatch.rs
++++ b/third_party/rust/crossbeam-channel/examples/stopwatch.rs
+@@ -33,7 +33,11 @@ fn main() {
+ 
+     // Prints the elapsed time.
+     fn show(dur: Duration) {
+-        println!("Elapsed: {}.{:03} sec", dur.as_secs(), dur.subsec_millis());
++        println!(
++            "Elapsed: {}.{:03} sec",
++            dur.as_secs(),
++            dur.subsec_nanos() / 1_000_000
++        );
+     }
+ 
+     let start = Instant::now();
+diff --git a/third_party/rust/crossbeam-channel/src/context.rs b/third_party/rust/crossbeam-channel/src/context.rs
+--- a/third_party/rust/crossbeam-channel/src/context.rs
++++ b/third_party/rust/crossbeam-channel/src/context.rs
+@@ -1,8 +1,7 @@
+ //! Thread-local context used in select.
+ 
+ use std::cell::Cell;
+-use std::ptr;
+-use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
++use std::sync::atomic::{AtomicUsize, Ordering};
+ use std::sync::Arc;
+ use std::thread::{self, Thread, ThreadId};
+ use std::time::Instant;
+@@ -12,7 +11,6 @@ use crossbeam_utils::Backoff;
+ use crate::select::Selected;
+ 
+ /// Thread-local context used in select.
+-// This is a private API that is used by the select macro.
+ #[derive(Debug, Clone)]
+ pub struct Context {
+     inner: Arc<Inner>,
+@@ -25,7 +23,7 @@ struct Inner {
+     select: AtomicUsize,
+ 
+     /// A slot into which another thread may store a pointer to its `Packet`.
+-    packet: AtomicPtr<()>,
++    packet: AtomicUsize,
+ 
+     /// Thread handle.
+     thread: Thread,
+@@ -47,7 +45,7 @@ impl Context {
+         }
+ 
+         let mut f = Some(f);
+-        let mut f = |cx: &Context| -> R {
++        let mut f = move |cx: &Context| -> R {
+             let f = f.take().unwrap();
+             f(cx)
+         };
+@@ -71,7 +69,7 @@ impl Context {
+         Context {
+             inner: Arc::new(Inner {
+                 select: AtomicUsize::new(Selected::Waiting.into()),
+-                packet: AtomicPtr::new(ptr::null_mut()),
++                packet: AtomicUsize::new(0),
+                 thread: thread::current(),
+                 thread_id: thread::current().id(),
+             }),
+@@ -84,7 +82,7 @@ impl Context {
+         self.inner
+             .select
+             .store(Selected::Waiting.into(), Ordering::Release);
+-        self.inner.packet.store(ptr::null_mut(), Ordering::Release);
++        self.inner.packet.store(0, Ordering::Release);
+     }
+ 
+     /// Attempts to select an operation.
+@@ -114,19 +112,19 @@ impl Context {
+     ///
+     /// This method must be called after `try_select` succeeds and there is a packet to provide.
+     #[inline]
+-    pub fn store_packet(&self, packet: *mut ()) {
+-        if !packet.is_null() {
++    pub fn store_packet(&self, packet: usize) {
++        if packet != 0 {
+             self.inner.packet.store(packet, Ordering::Release);
+         }
+     }
+ 
+     /// Waits until a packet is provided and returns it.
+     #[inline]
+-    pub fn wait_packet(&self) -> *mut () {
++    pub fn wait_packet(&self) -> usize {
+         let backoff = Backoff::new();
+         loop {
+             let packet = self.inner.packet.load(Ordering::Acquire);
+-            if !packet.is_null() {
++            if packet != 0 {
+                 return packet;
+             }
+             backoff.snooze();
+diff --git a/third_party/rust/crossbeam-channel/src/flavors/array.rs b/third_party/rust/crossbeam-channel/src/flavors/array.rs
+--- a/third_party/rust/crossbeam-channel/src/flavors/array.rs
++++ b/third_party/rust/crossbeam-channel/src/flavors/array.rs
+@@ -10,7 +10,7 @@
+ 
+ use std::cell::UnsafeCell;
+ use std::marker::PhantomData;
+-use std::mem::MaybeUninit;
++use std::mem::{self, MaybeUninit};
+ use std::ptr;
+ use std::sync::atomic::{self, AtomicUsize, Ordering};
+ use std::time::Instant;
+@@ -110,7 +110,7 @@ impl<T> Channel<T> {
+         // Allocate a buffer of `cap` slots initialized
+         // with stamps.
+         let buffer = {
+-            let boxed: Box<[Slot<T>]> = (0..cap)
++            let mut boxed: Box<[Slot<T>]> = (0..cap)
+                 .map(|i| {
+                     // Set the stamp to `{ lap: 0, mark: 0, index: i }`.
+                     Slot {
+@@ -119,7 +119,9 @@ impl<T> Channel<T> {
+                     }
+                 })
+                 .collect();
+-            Box::into_raw(boxed) as *mut Slot<T>
++            let ptr = boxed.as_mut_ptr();
++            mem::forget(boxed);
++            ptr
+         };
+ 
+         Channel {
+diff --git a/third_party/rust/crossbeam-channel/src/flavors/zero.rs b/third_party/rust/crossbeam-channel/src/flavors/zero.rs
+--- a/third_party/rust/crossbeam-channel/src/flavors/zero.rs
++++ b/third_party/rust/crossbeam-channel/src/flavors/zero.rs
+@@ -6,7 +6,6 @@ use std::cell::UnsafeCell;
+ use std::marker::PhantomData;
+ use std::sync::atomic::{AtomicBool, Ordering};
+ use std::time::Instant;
+-use std::{fmt, ptr};
+ 
+ use crossbeam_utils::Backoff;
+ 
+@@ -17,19 +16,7 @@ use crate::utils::Spinlock;
+ use crate::waker::Waker;
+ 
+ /// A pointer to a packet.
+-pub struct ZeroToken(*mut ());
+-
+-impl Default for ZeroToken {
+-    fn default() -> Self {
+-        Self(ptr::null_mut())
+-    }
+-}
+-
+-impl fmt::Debug for ZeroToken {
+-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+-        fmt::Debug::fmt(&(self.0 as usize), f)
+-    }
+-}
++pub(crate) type ZeroToken = usize;
+ 
+ /// A slot for passing one message from a sender to a receiver.
+ struct Packet<T> {
+@@ -130,10 +117,10 @@ impl<T> Channel<T> {
+ 
+         // If there's a waiting receiver, pair up with it.
+         if let Some(operation) = inner.receivers.try_select() {
+-            token.zero.0 = operation.packet;
++            token.zero = operation.packet;
+             true
+         } else if inner.is_disconnected {
+-            token.zero.0 = ptr::null_mut();
++            token.zero = 0;
+             true
+         } else {
+             false
+@@ -143,11 +130,11 @@ impl<T> Channel<T> {
+     /// Writes a message into the packet.
+     pub(crate) unsafe fn write(&self, token: &mut Token, msg: T) -> Result<(), T> {
+         // If there is no packet, the channel is disconnected.
+-        if token.zero.0.is_null() {
++        if token.zero == 0 {
+             return Err(msg);
+         }
+ 
+-        let packet = &*(token.zero.0 as *const Packet<T>);
++        let packet = &*(token.zero as *const Packet<T>);
+         packet.msg.get().write(Some(msg));
+         packet.ready.store(true, Ordering::Release);
+         Ok(())
+@@ -159,10 +146,10 @@ impl<T> Channel<T> {
+ 
+         // If there's a waiting sender, pair up with it.
+         if let Some(operation) = inner.senders.try_select() {
+-            token.zero.0 = operation.packet;
++            token.zero = operation.packet;
+             true
+         } else if inner.is_disconnected {
+-            token.zero.0 = ptr::null_mut();
++            token.zero = 0;
+             true
+         } else {
+             false
+@@ -172,11 +159,11 @@ impl<T> Channel<T> {
+     /// Reads a message from the packet.
+     pub(crate) unsafe fn read(&self, token: &mut Token) -> Result<T, ()> {
+         // If there is no packet, the channel is disconnected.
+-        if token.zero.0.is_null() {
++        if token.zero == 0 {
+             return Err(());
+         }
+ 
+-        let packet = &*(token.zero.0 as *const Packet<T>);
++        let packet = &*(token.zero as *const Packet<T>);
+ 
+         if packet.on_stack {
+             // The message has been in the packet from the beginning, so there is no need to wait
+@@ -190,7 +177,7 @@ impl<T> Channel<T> {
+             // heap-allocated packet.
+             packet.wait_ready();
+             let msg = packet.msg.get().replace(None).unwrap();
+-            drop(Box::from_raw(token.zero.0 as *mut Packet<T>));
++            drop(Box::from_raw(packet as *const Packet<T> as *mut Packet<T>));
+             Ok(msg)
+         }
+     }
+@@ -202,7 +189,7 @@ impl<T> Channel<T> {
+ 
+         // If there's a waiting receiver, pair up with it.
+         if let Some(operation) = inner.receivers.try_select() {
+-            token.zero.0 = operation.packet;
++            token.zero = operation.packet;
+             drop(inner);
+             unsafe {
+                 self.write(token, msg).ok().unwrap();
+@@ -226,7 +213,7 @@ impl<T> Channel<T> {
+ 
+         // If there's a waiting receiver, pair up with it.
+         if let Some(operation) = inner.receivers.try_select() {
+-            token.zero.0 = operation.packet;
++            token.zero = operation.packet;
+             drop(inner);
+             unsafe {
+                 self.write(token, msg).ok().unwrap();
+@@ -241,10 +228,10 @@ impl<T> Channel<T> {
+         Context::with(|cx| {
+             // Prepare for blocking until a receiver wakes us up.
+             let oper = Operation::hook(token);
+-            let mut packet = Packet::<T>::message_on_stack(msg);
++            let packet = Packet::<T>::message_on_stack(msg);
+             inner
+                 .senders
+-                .register_with_packet(oper, &mut packet as *mut Packet<T> as *mut (), cx);
++                .register_with_packet(oper, &packet as *const Packet<T> as usize, cx);
+             inner.receivers.notify();
+             drop(inner);
+ 
+@@ -279,7 +266,7 @@ impl<T> Channel<T> {
+ 
+         // If there's a waiting sender, pair up with it.
+         if let Some(operation) = inner.senders.try_select() {
+-            token.zero.0 = operation.packet;
++            token.zero = operation.packet;
+             drop(inner);
+             unsafe { self.read(token).map_err(|_| TryRecvError::Disconnected) }
+         } else if inner.is_disconnected {
+@@ -296,7 +283,7 @@ impl<T> Channel<T> {
+ 
+         // If there's a waiting sender, pair up with it.
+         if let Some(operation) = inner.senders.try_select() {
+-            token.zero.0 = operation.packet;
++            token.zero = operation.packet;
+             drop(inner);
+             unsafe {
+                 return self.read(token).map_err(|_| RecvTimeoutError::Disconnected);
+@@ -310,12 +297,10 @@ impl<T> Channel<T> {
+         Context::with(|cx| {
+             // Prepare for blocking until a sender wakes us up.
+             let oper = Operation::hook(token);
+-            let mut packet = Packet::<T>::empty_on_stack();
+-            inner.receivers.register_with_packet(
+-                oper,
+-                &mut packet as *mut Packet<T> as *mut (),
+-                cx,
+-            );
++            let packet = Packet::<T>::empty_on_stack();
++            inner
++                .receivers
++                .register_with_packet(oper, &packet as *const Packet<T> as usize, cx);
+             inner.senders.notify();
+             drop(inner);
+ 
+@@ -400,7 +385,7 @@ impl<T> SelectHandle for Receiver<'_, T>
+         let mut inner = self.0.inner.lock();
+         inner
+             .receivers
+-            .register_with_packet(oper, packet as *mut (), cx);
++            .register_with_packet(oper, packet as usize, cx);
+         inner.senders.notify();
+         inner.senders.can_select() || inner.is_disconnected
+     }
+@@ -414,7 +399,7 @@ impl<T> SelectHandle for Receiver<'_, T>
+     }
+ 
+     fn accept(&self, token: &mut Token, cx: &Context) -> bool {
+-        token.zero.0 = cx.wait_packet();
++        token.zero = cx.wait_packet();
+         true
+     }
+ 
+@@ -450,7 +435,7 @@ impl<T> SelectHandle for Sender<'_, T> {
+         let mut inner = self.0.inner.lock();
+         inner
+             .senders
+-            .register_with_packet(oper, packet as *mut (), cx);
++            .register_with_packet(oper, packet as usize, cx);
+         inner.receivers.notify();
+         inner.receivers.can_select() || inner.is_disconnected
+     }
+@@ -464,7 +449,7 @@ impl<T> SelectHandle for Sender<'_, T> {
+     }
+ 
+     fn accept(&self, token: &mut Token, cx: &Context) -> bool {
+-        token.zero.0 = cx.wait_packet();
++        token.zero = cx.wait_packet();
+         true
+     }
+ 
+diff --git a/third_party/rust/crossbeam-channel/src/select.rs b/third_party/rust/crossbeam-channel/src/select.rs
+--- a/third_party/rust/crossbeam-channel/src/select.rs
++++ b/third_party/rust/crossbeam-channel/src/select.rs
+@@ -19,7 +19,6 @@ use crate::utils;
+ /// `read` or `write`.
+ ///
+ /// Each field contains data associated with a specific channel flavor.
+-// This is a private API that is used by the select macro.
+ #[derive(Debug, Default)]
+ pub struct Token {
+     pub at: flavors::at::AtToken,
+@@ -94,7 +93,6 @@ impl Into<usize> for Selected {
+ ///
+ /// This is a handle that assists select in executing an operation, registration, deciding on the
+ /// appropriate deadline for blocking, etc.
+-// This is a private API (exposed inside crossbeam_channel::internal module) that is used by the select macro.
+ pub trait SelectHandle {
+     /// Attempts to select an operation and returns `true` on success.
+     fn try_select(&self, token: &mut Token) -> bool;
+@@ -444,7 +442,6 @@ fn run_ready(
+ }
+ 
+ /// Attempts to select one of the operations without blocking.
+-// This is a private API (exposed inside crossbeam_channel::internal module) that is used by the select macro.
+ #[inline]
+ pub fn try_select<'a>(
+     handles: &mut [(&'a dyn SelectHandle, usize, *const u8)],
+@@ -461,7 +458,6 @@ pub fn try_select<'a>(
+ }
+ 
+ /// Blocks until one of the operations becomes ready and selects it.
+-// This is a private API (exposed inside crossbeam_channel::internal module) that is used by the select macro.
+ #[inline]
+ pub fn select<'a>(
+     handles: &mut [(&'a dyn SelectHandle, usize, *const u8)],
+@@ -480,7 +476,6 @@ pub fn select<'a>(
+ }
+ 
+ /// Blocks for a limited time until one of the operations becomes ready and selects it.
+-// This is a private API (exposed inside crossbeam_channel::internal module) that is used by the select macro.
+ #[inline]
+ pub fn select_timeout<'a>(
+     handles: &mut [(&'a dyn SelectHandle, usize, *const u8)],
+diff --git a/third_party/rust/crossbeam-channel/src/waker.rs b/third_party/rust/crossbeam-channel/src/waker.rs
+--- a/third_party/rust/crossbeam-channel/src/waker.rs
++++ b/third_party/rust/crossbeam-channel/src/waker.rs
+@@ -1,6 +1,5 @@
+ //! Waking mechanism for threads blocked on channel operations.
+ 
+-use std::ptr;
+ use std::sync::atomic::{AtomicBool, Ordering};
+ use std::thread::{self, ThreadId};
+ 
+@@ -14,7 +13,7 @@ pub(crate) struct Entry {
+     pub(crate) oper: Operation,
+ 
+     /// Optional packet.
+-    pub(crate) packet: *mut (),
++    pub(crate) packet: usize,
+ 
+     /// Context associated with the thread owning this operation.
+     pub(crate) cx: Context,
+@@ -45,12 +44,12 @@ impl Waker {
+     /// Registers a select operation.
+     #[inline]
+     pub(crate) fn register(&mut self, oper: Operation, cx: &Context) {
+-        self.register_with_packet(oper, ptr::null_mut(), cx);
++        self.register_with_packet(oper, 0, cx);
+     }
+ 
+     /// Registers a select operation and a packet.
+     #[inline]
+-    pub(crate) fn register_with_packet(&mut self, oper: Operation, packet: *mut (), cx: &Context) {
++    pub(crate) fn register_with_packet(&mut self, oper: Operation, packet: usize, cx: &Context) {
+         self.selectors.push(Entry {
+             oper,
+             packet,
+@@ -77,26 +76,34 @@ impl Waker {
+     /// Attempts to find another thread's entry, select the operation, and wake it up.
+     #[inline]
+     pub(crate) fn try_select(&mut self) -> Option<Entry> {
+-        self.selectors
+-            .iter()
+-            .position(|selector| {
++        let mut entry = None;
++
++        if !self.selectors.is_empty() {
++            let thread_id = current_thread_id();
++
++            for i in 0..self.selectors.len() {
+                 // Does the entry belong to a different thread?
+-                selector.cx.thread_id() != current_thread_id()
+-                    && selector // Try selecting this operation.
+-                        .cx
+-                        .try_select(Selected::Operation(selector.oper))
+-                        .is_ok()
+-                    && {
++                if self.selectors[i].cx.thread_id() != thread_id {
++                    // Try selecting this operation.
++                    let sel = Selected::Operation(self.selectors[i].oper);
++                    let res = self.selectors[i].cx.try_select(sel);
++
++                    if res.is_ok() {
+                         // Provide the packet.
+-                        selector.cx.store_packet(selector.packet);
++                        self.selectors[i].cx.store_packet(self.selectors[i].packet);
+                         // Wake the thread up.
+-                        selector.cx.unpark();
+-                        true
++                        self.selectors[i].cx.unpark();
++
++                        // Remove the entry from the queue to keep it clean and improve
++                        // performance.
++                        entry = Some(self.selectors.remove(i));
++                        break;
+                     }
+-            })
+-            // Remove the entry from the queue to keep it clean and improve
+-            // performance.
+-            .map(|pos| self.selectors.remove(pos))
++                }
++            }
++        }
++
++        entry
+     }
+ 
+     /// Returns `true` if there is an entry which can be selected by the current thread.
+@@ -118,7 +125,7 @@ impl Waker {
+     pub(crate) fn watch(&mut self, oper: Operation, cx: &Context) {
+         self.observers.push(Entry {
+             oper,
+-            packet: ptr::null_mut(),
++            packet: 0,
+             cx: cx.clone(),
+         });
+     }
+@@ -262,7 +269,7 @@ impl SyncWaker {
+ impl Drop for SyncWaker {
+     #[inline]
+     fn drop(&mut self) {
+-        debug_assert!(self.is_empty.load(Ordering::SeqCst));
++        debug_assert_eq!(self.is_empty.load(Ordering::SeqCst), true);
+     }
+ }
+ 
+diff --git a/third_party/rust/crossbeam-channel/tests/after.rs b/third_party/rust/crossbeam-channel/tests/after.rs
+--- a/third_party/rust/crossbeam-channel/tests/after.rs
++++ b/third_party/rust/crossbeam-channel/tests/after.rs
+@@ -1,7 +1,5 @@
+ //! Tests for the after channel flavor.
+ 
+-#![cfg(not(miri))] // TODO: many assertions failed due to Miri is slow
+-
+ use std::sync::atomic::AtomicUsize;
+ use std::sync::atomic::Ordering;
+ use std::thread;
+@@ -58,20 +56,20 @@ fn len_empty_full() {
+     let r = after(ms(50));
+ 
+     assert_eq!(r.len(), 0);
+-    assert!(r.is_empty());
+-    assert!(!r.is_full());
++    assert_eq!(r.is_empty(), true);
++    assert_eq!(r.is_full(), false);
+ 
+     thread::sleep(ms(100));
+ 
+     assert_eq!(r.len(), 1);
+-    assert!(!r.is_empty());
+-    assert!(r.is_full());
++    assert_eq!(r.is_empty(), false);
++    assert_eq!(r.is_full(), true);
+ 
+     r.try_recv().unwrap();
+ 
+     assert_eq!(r.len(), 0);
+-    assert!(r.is_empty());
+-    assert!(!r.is_full());
++    assert_eq!(r.is_empty(), true);
++    assert_eq!(r.is_full(), false);
+ }
+ 
+ #[test]
+@@ -213,7 +211,7 @@ fn select() {
+                             break;
+                         }
+                         i => {
+-                            oper.recv(v[i]).unwrap();
++                            oper.recv(&v[i]).unwrap();
+                             hits.fetch_add(1, Ordering::SeqCst);
+                         }
+                     }
+diff --git a/third_party/rust/crossbeam-channel/tests/array.rs b/third_party/rust/crossbeam-channel/tests/array.rs
+--- a/third_party/rust/crossbeam-channel/tests/array.rs
++++ b/third_party/rust/crossbeam-channel/tests/array.rs
+@@ -1,7 +1,5 @@
+ //! Tests for the array channel flavor.
+ 
+-#![cfg(not(miri))] // TODO: many assertions failed due to Miri is slow
+-
+ use std::any::Any;
+ use std::sync::atomic::AtomicUsize;
+ use std::sync::atomic::Ordering;
+@@ -45,38 +43,38 @@ fn len_empty_full() {
+     let (s, r) = bounded(2);
+ 
+     assert_eq!(s.len(), 0);
+-    assert!(s.is_empty());
+-    assert!(!s.is_full());
++    assert_eq!(s.is_empty(), true);
++    assert_eq!(s.is_full(), false);
+     assert_eq!(r.len(), 0);
+-    assert!(r.is_empty());
+-    assert!(!r.is_full());
++    assert_eq!(r.is_empty(), true);
++    assert_eq!(r.is_full(), false);
+ 
+     s.send(()).unwrap();
+ 
+     assert_eq!(s.len(), 1);
+-    assert!(!s.is_empty());
+-    assert!(!s.is_full());
++    assert_eq!(s.is_empty(), false);
++    assert_eq!(s.is_full(), false);
+     assert_eq!(r.len(), 1);
+-    assert!(!r.is_empty());
+-    assert!(!r.is_full());
++    assert_eq!(r.is_empty(), false);
++    assert_eq!(r.is_full(), false);
+ 
+     s.send(()).unwrap();
+ 
+     assert_eq!(s.len(), 2);
+-    assert!(!s.is_empty());
+-    assert!(s.is_full());
++    assert_eq!(s.is_empty(), false);
++    assert_eq!(s.is_full(), true);
+     assert_eq!(r.len(), 2);
+-    assert!(!r.is_empty());
+-    assert!(r.is_full());
++    assert_eq!(r.is_empty(), false);
++    assert_eq!(r.is_full(), true);
+ 
+     r.recv().unwrap();
+ 
+     assert_eq!(s.len(), 1);
+-    assert!(!s.is_empty());
+-    assert!(!s.is_full());
++    assert_eq!(s.is_empty(), false);
++    assert_eq!(s.is_full(), false);
+     assert_eq!(r.len(), 1);
+-    assert!(!r.is_empty());
+-    assert!(!r.is_full());
++    assert_eq!(r.is_empty(), false);
++    assert_eq!(r.is_full(), false);
+ }
+ 
+ #[test]
+diff --git a/third_party/rust/crossbeam-channel/tests/golang.rs b/third_party/rust/crossbeam-channel/tests/golang.rs
+--- a/third_party/rust/crossbeam-channel/tests/golang.rs
++++ b/third_party/rust/crossbeam-channel/tests/golang.rs
+@@ -9,8 +9,6 @@
+ //!   - https://golang.org/LICENSE
+ //!   - https://golang.org/PATENTS
+ 
+-#![allow(clippy::mutex_atomic, clippy::redundant_clone)]
+-
+ use std::alloc::{GlobalAlloc, Layout, System};
+ use std::any::Any;
+ use std::cell::Cell;
+@@ -178,7 +176,7 @@ unsafe impl GlobalAlloc for Counter {
+         if !ret.is_null() {
+             ALLOCATED.fetch_add(layout.size(), SeqCst);
+         }
+-        ret
++        return ret;
+     }
+ 
+     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+@@ -234,9 +232,6 @@ macro_rules! go {
+ mod doubleselect {
+     use super::*;
+ 
+-    #[cfg(miri)]
+-    const ITERATIONS: i32 = 100;
+-    #[cfg(not(miri))]
+     const ITERATIONS: i32 = 10_000;
+ 
+     fn sender(n: i32, c1: Chan<i32>, c2: Chan<i32>, c3: Chan<i32>, c4: Chan<i32>) {
+@@ -696,11 +691,6 @@ mod select {
+ mod select2 {
+     use super::*;
+ 
+-    #[cfg(miri)]
+-    const N: i32 = 1000;
+-    #[cfg(not(miri))]
+-    const N: i32 = 100000;
+-
+     #[test]
+     fn main() {
+         fn sender(c: &Chan<i32>, n: i32) {
+@@ -712,7 +702,9 @@ mod select2 {
+         fn receiver(c: &Chan<i32>, dummy: &Chan<i32>, n: i32) {
+             for _ in 0..n {
+                 select! {
+-                    recv(c.rx()) -> _ => {}
++                    recv(c.rx()) -> _ => {
++                        ()
++                    }
+                     recv(dummy.rx()) -> _ => {
+                         panic!("dummy");
+                     }
+@@ -725,18 +717,15 @@ mod select2 {
+ 
+         ALLOCATED.store(0, SeqCst);
+ 
+-        go!(c, sender(&c, N));
+-        receiver(&c, &dummy, N);
++        go!(c, sender(&c, 100000));
++        receiver(&c, &dummy, 100000);
+ 
+         let alloc = ALLOCATED.load(SeqCst);
+ 
+-        go!(c, sender(&c, N));
+-        receiver(&c, &dummy, N);
++        go!(c, sender(&c, 100000));
++        receiver(&c, &dummy, 100000);
+ 
+-        assert!(
+-            !(ALLOCATED.load(SeqCst) > alloc
+-                && (ALLOCATED.load(SeqCst) - alloc) > (N as usize + 10000))
+-        )
++        assert!(!(ALLOCATED.load(SeqCst) > alloc && (ALLOCATED.load(SeqCst) - alloc) > 110000))
+     }
+ }
+ 
+@@ -924,9 +913,6 @@ mod chan_test {
+ 
+     #[test]
+     fn test_chan() {
+-        #[cfg(miri)]
+-        const N: i32 = 20;
+-        #[cfg(not(miri))]
+         const N: i32 = 200;
+ 
+         for cap in 0..N {
+@@ -1066,9 +1052,6 @@ mod chan_test {
+ 
+     #[test]
+     fn test_nonblock_recv_race() {
+-        #[cfg(miri)]
+-        const N: usize = 100;
+-        #[cfg(not(miri))]
+         const N: usize = 1000;
+ 
+         for _ in 0..N {
+@@ -1090,9 +1073,6 @@ mod chan_test {
+ 
+     #[test]
+     fn test_nonblock_select_race() {
+-        #[cfg(miri)]
+-        const N: usize = 100;
+-        #[cfg(not(miri))]
+         const N: usize = 1000;
+ 
+         let done = make::<bool>(1);
+@@ -1126,9 +1106,6 @@ mod chan_test {
+ 
+     #[test]
+     fn test_nonblock_select_race2() {
+-        #[cfg(miri)]
+-        const N: usize = 100;
+-        #[cfg(not(miri))]
+         const N: usize = 1000;
+ 
+         let done = make::<bool>(1);
+@@ -1165,11 +1142,6 @@ mod chan_test {
+         // Ensure that send/recv on the same chan in select
+         // does not crash nor deadlock.
+ 
+-        #[cfg(miri)]
+-        const N: usize = 100;
+-        #[cfg(not(miri))]
+-        const N: usize = 1000;
+-
+         for &cap in &[0, 10] {
+             let wg = WaitGroup::new();
+             wg.add(2);
+@@ -1179,7 +1151,7 @@ mod chan_test {
+                 let p = p;
+                 go!(wg, p, c, {
+                     defer! { wg.done() }
+-                    for i in 0..N {
++                    for i in 0..1000 {
+                         if p == 0 || i % 2 == 0 {
+                             select! {
+                                 send(c.tx(), p) -> _ => {}
+@@ -1208,11 +1180,6 @@ mod chan_test {
+ 
+     #[test]
+     fn test_select_stress() {
+-        #[cfg(miri)]
+-        const N: usize = 100;
+-        #[cfg(not(miri))]
+-        const N: usize = 10000;
+-
+         let c = vec![
+             make::<i32>(0),
+             make::<i32>(0),
+@@ -1220,6 +1187,8 @@ mod chan_test {
+             make::<i32>(3),
+         ];
+ 
++        const N: usize = 10000;
++
+         // There are 4 goroutines that send N values on each of the chans,
+         // + 4 goroutines that receive N values on each of the chans,
+         // + 1 goroutine that sends N values on each of the chans in a single select,
+@@ -1317,9 +1286,6 @@ mod chan_test {
+ 
+     #[test]
+     fn test_select_fairness() {
+-        #[cfg(miri)]
+-        const TRIALS: usize = 100;
+-        #[cfg(not(miri))]
+         const TRIALS: usize = 10000;
+ 
+         let c1 = make::<u8>(TRIALS + 1);
+@@ -1403,9 +1369,6 @@ mod chan_test {
+ 
+     #[test]
+     fn test_pseudo_random_send() {
+-        #[cfg(miri)]
+-        const N: usize = 20;
+-        #[cfg(not(miri))]
+         const N: usize = 100;
+ 
+         for cap in 0..N {
+@@ -1449,9 +1412,6 @@ mod chan_test {
+     #[test]
+     fn test_multi_consumer() {
+         const NWORK: usize = 23;
+-        #[cfg(miri)]
+-        const NITER: usize = 100;
+-        #[cfg(not(miri))]
+         const NITER: usize = 271828;
+ 
+         let pn = [2, 3, 7, 11, 13, 17, 19, 23, 27, 31];
+@@ -1550,9 +1510,6 @@ mod chan1 {
+     use super::*;
+ 
+     // sent messages
+-    #[cfg(miri)]
+-    const N: usize = 100;
+-    #[cfg(not(miri))]
+     const N: usize = 1000;
+     // receiving "goroutines"
+     const M: usize = 10;
+diff --git a/third_party/rust/crossbeam-channel/tests/iter.rs b/third_party/rust/crossbeam-channel/tests/iter.rs
+--- a/third_party/rust/crossbeam-channel/tests/iter.rs
++++ b/third_party/rust/crossbeam-channel/tests/iter.rs
+@@ -93,7 +93,7 @@ fn recv_into_iter_owned() {
+ 
+     assert_eq!(iter.next().unwrap(), 1);
+     assert_eq!(iter.next().unwrap(), 2);
+-    assert!(iter.next().is_none());
++    assert_eq!(iter.next().is_none(), true);
+ }
+ 
+ #[test]
+@@ -106,5 +106,5 @@ fn recv_into_iter_borrowed() {
+     let mut iter = (&r).into_iter();
+     assert_eq!(iter.next().unwrap(), 1);
+     assert_eq!(iter.next().unwrap(), 2);
+-    assert!(iter.next().is_none());
++    assert_eq!(iter.next().is_none(), true);
+ }
+diff --git a/third_party/rust/crossbeam-channel/tests/list.rs b/third_party/rust/crossbeam-channel/tests/list.rs
+--- a/third_party/rust/crossbeam-channel/tests/list.rs
++++ b/third_party/rust/crossbeam-channel/tests/list.rs
+@@ -41,29 +41,29 @@ fn len_empty_full() {
+     let (s, r) = unbounded();
+ 
+     assert_eq!(s.len(), 0);
+-    assert!(s.is_empty());
+-    assert!(!s.is_full());
++    assert_eq!(s.is_empty(), true);
++    assert_eq!(s.is_full(), false);
+     assert_eq!(r.len(), 0);
+-    assert!(r.is_empty());
+-    assert!(!r.is_full());
++    assert_eq!(r.is_empty(), true);
++    assert_eq!(r.is_full(), false);
+ 
+     s.send(()).unwrap();
+ 
+     assert_eq!(s.len(), 1);
+-    assert!(!s.is_empty());
+-    assert!(!s.is_full());
++    assert_eq!(s.is_empty(), false);
++    assert_eq!(s.is_full(), false);
+     assert_eq!(r.len(), 1);
+-    assert!(!r.is_empty());
+-    assert!(!r.is_full());
++    assert_eq!(r.is_empty(), false);
++    assert_eq!(r.is_full(), false);
+ 
+     r.recv().unwrap();
+ 
+     assert_eq!(s.len(), 0);
+-    assert!(s.is_empty());
+-    assert!(!s.is_full());
++    assert_eq!(s.is_empty(), true);
++    assert_eq!(s.is_full(), false);
+     assert_eq!(r.len(), 0);
+-    assert!(r.is_empty());
+-    assert!(!r.is_full());
++    assert_eq!(r.is_empty(), true);
++    assert_eq!(r.is_full(), false);
+ }
+ 
+ #[test]
+@@ -239,9 +239,6 @@ fn disconnect_wakes_receiver() {
+ 
+ #[test]
+ fn spsc() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 100_000;
+ 
+     let (s, r) = unbounded();
+@@ -264,9 +261,6 @@ fn spsc() {
+ 
+ #[test]
+ fn mpmc() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 25_000;
+     const THREADS: usize = 4;
+ 
+@@ -301,9 +295,6 @@ fn mpmc() {
+ 
+ #[test]
+ fn stress_oneshot() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     for _ in 0..COUNT {
+@@ -319,9 +310,6 @@ fn stress_oneshot() {
+ 
+ #[test]
+ fn stress_iter() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 100_000;
+ 
+     let (request_s, request_r) = unbounded();
+@@ -383,11 +371,8 @@ fn stress_timeout_two_threads() {
+     .unwrap();
+ }
+ 
+-#[cfg_attr(miri, ignore)] // Miri is too slow
+ #[test]
+ fn drops() {
+-    const RUNS: usize = 100;
+-
+     static DROPS: AtomicUsize = AtomicUsize::new(0);
+ 
+     #[derive(Debug, PartialEq)]
+@@ -401,7 +386,7 @@ fn drops() {
+ 
+     let mut rng = thread_rng();
+ 
+-    for _ in 0..RUNS {
++    for _ in 0..100 {
+         let steps = rng.gen_range(0..10_000);
+         let additional = rng.gen_range(0..1000);
+ 
+@@ -436,9 +421,6 @@ fn drops() {
+ 
+ #[test]
+ fn linearizable() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 25_000;
+     const THREADS: usize = 4;
+ 
+@@ -459,9 +441,6 @@ fn linearizable() {
+ 
+ #[test]
+ fn fairness() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = unbounded::<()>();
+@@ -484,9 +463,6 @@ fn fairness() {
+ 
+ #[test]
+ fn fairness_duplicates() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s, r) = unbounded();
+@@ -520,9 +496,6 @@ fn recv_in_send() {
+ 
+ #[test]
+ fn channel_through_channel() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 1000;
+ 
+     type T = Box<dyn Any + Send>;
+diff --git a/third_party/rust/crossbeam-channel/tests/mpsc.rs b/third_party/rust/crossbeam-channel/tests/mpsc.rs
+--- a/third_party/rust/crossbeam-channel/tests/mpsc.rs
++++ b/third_party/rust/crossbeam-channel/tests/mpsc.rs
+@@ -20,12 +20,6 @@
+ //!   - https://github.com/rust-lang/rust/blob/master/COPYRIGHT
+ //!   - https://www.rust-lang.org/en-US/legal.html
+ 
+-#![allow(
+-    clippy::drop_copy,
+-    clippy::match_single_binding,
+-    clippy::redundant_clone
+-)]
+-
+ use std::sync::mpsc::{RecvError, RecvTimeoutError, TryRecvError};
+ use std::sync::mpsc::{SendError, TrySendError};
+ use std::thread::JoinHandle;
+@@ -182,7 +176,7 @@ macro_rules! select {
+     ) => ({
+         cc::crossbeam_channel_internal! {
+             $(
+-                $meth(($rx).inner) -> res => {
++                recv(($rx).inner) -> res => {
+                     let $name = res.map_err(|_| ::std::sync::mpsc::RecvError);
+                     $code
+                 }
+@@ -320,18 +314,13 @@ mod channel_tests {
+ 
+     #[test]
+     fn stress() {
+-        #[cfg(miri)]
+-        const COUNT: usize = 500;
+-        #[cfg(not(miri))]
+-        const COUNT: usize = 10000;
+-
+         let (tx, rx) = channel::<i32>();
+         let t = thread::spawn(move || {
+-            for _ in 0..COUNT {
++            for _ in 0..10000 {
+                 tx.send(1).unwrap();
+             }
+         });
+-        for _ in 0..COUNT {
++        for _ in 0..10000 {
+             assert_eq!(rx.recv().unwrap(), 1);
+         }
+         t.join().ok().unwrap();
+@@ -339,9 +328,6 @@ mod channel_tests {
+ 
+     #[test]
+     fn stress_shared() {
+-        #[cfg(miri)]
+-        const AMT: u32 = 500;
+-        #[cfg(not(miri))]
+         const AMT: u32 = 10000;
+         const NTHREADS: u32 = 8;
+         let (tx, rx) = channel::<i32>();
+@@ -350,7 +336,10 @@ mod channel_tests {
+             for _ in 0..AMT * NTHREADS {
+                 assert_eq!(rx.recv().unwrap(), 1);
+             }
+-            assert!(rx.try_recv().is_err());
++            match rx.try_recv() {
++                Ok(..) => panic!(),
++                _ => {}
++            }
+         });
+ 
+         let mut ts = Vec::with_capacity(NTHREADS as usize);
+@@ -746,17 +735,12 @@ mod channel_tests {
+ 
+     #[test]
+     fn recv_a_lot() {
+-        #[cfg(miri)]
+-        const N: usize = 100;
+-        #[cfg(not(miri))]
+-        const N: usize = 10000;
+-
+         // Regression test that we don't run out of stack in scheduler context
+         let (tx, rx) = channel();
+-        for _ in 0..N {
++        for _ in 0..10000 {
+             tx.send(()).unwrap();
+         }
+-        for _ in 0..N {
++        for _ in 0..10000 {
+             rx.recv().unwrap();
+         }
+     }
+@@ -896,7 +880,7 @@ mod channel_tests {
+         };
+         assert_eq!(iter.next().unwrap(), 1);
+         assert_eq!(iter.next().unwrap(), 2);
+-        assert!(iter.next().is_none());
++        assert_eq!(iter.next().is_none(), true);
+     }
+ 
+     #[test]
+@@ -908,7 +892,7 @@ mod channel_tests {
+         let mut iter = (&rx).into_iter();
+         assert_eq!(iter.next().unwrap(), 1);
+         assert_eq!(iter.next().unwrap(), 2);
+-        assert!(iter.next().is_none());
++        assert_eq!(iter.next().is_none(), true);
+     }
+ 
+     #[test]
+@@ -1095,18 +1079,13 @@ mod sync_channel_tests {
+ 
+     #[test]
+     fn stress() {
+-        #[cfg(miri)]
+-        const N: usize = 100;
+-        #[cfg(not(miri))]
+-        const N: usize = 10000;
+-
+         let (tx, rx) = sync_channel::<i32>(0);
+         let t = thread::spawn(move || {
+-            for _ in 0..N {
++            for _ in 0..10000 {
+                 tx.send(1).unwrap();
+             }
+         });
+-        for _ in 0..N {
++        for _ in 0..10000 {
+             assert_eq!(rx.recv().unwrap(), 1);
+         }
+         t.join().unwrap();
+@@ -1114,15 +1093,10 @@ mod sync_channel_tests {
+ 
+     #[test]
+     fn stress_recv_timeout_two_threads() {
+-        #[cfg(miri)]
+-        const N: usize = 100;
+-        #[cfg(not(miri))]
+-        const N: usize = 10000;
+-
+         let (tx, rx) = sync_channel::<i32>(0);
+ 
+         let t = thread::spawn(move || {
+-            for _ in 0..N {
++            for _ in 0..10000 {
+                 tx.send(1).unwrap();
+             }
+         });
+@@ -1139,15 +1113,12 @@ mod sync_channel_tests {
+             }
+         }
+ 
+-        assert_eq!(recv_count, N);
++        assert_eq!(recv_count, 10000);
+         t.join().unwrap();
+     }
+ 
+     #[test]
+     fn stress_recv_timeout_shared() {
+-        #[cfg(miri)]
+-        const AMT: u32 = 100;
+-        #[cfg(not(miri))]
+         const AMT: u32 = 1000;
+         const NTHREADS: u32 = 8;
+         let (tx, rx) = sync_channel::<i32>(0);
+@@ -1194,9 +1165,6 @@ mod sync_channel_tests {
+ 
+     #[test]
+     fn stress_shared() {
+-        #[cfg(miri)]
+-        const AMT: u32 = 100;
+-        #[cfg(not(miri))]
+         const AMT: u32 = 1000;
+         const NTHREADS: u32 = 8;
+         let (tx, rx) = sync_channel::<i32>(0);
+@@ -1206,7 +1174,10 @@ mod sync_channel_tests {
+             for _ in 0..AMT * NTHREADS {
+                 assert_eq!(rx.recv().unwrap(), 1);
+             }
+-            assert!(rx.try_recv().is_err());
++            match rx.try_recv() {
++                Ok(..) => panic!(),
++                _ => {}
++            }
+             dtx.send(()).unwrap();
+         });
+ 
+@@ -1478,17 +1449,12 @@ mod sync_channel_tests {
+ 
+     #[test]
+     fn recv_a_lot() {
+-        #[cfg(miri)]
+-        const N: usize = 100;
+-        #[cfg(not(miri))]
+-        const N: usize = 10000;
+-
+         // Regression test that we don't run out of stack in scheduler context
+-        let (tx, rx) = sync_channel(N);
+-        for _ in 0..N {
++        let (tx, rx) = sync_channel(10000);
++        for _ in 0..10000 {
+             tx.send(()).unwrap();
+         }
+-        for _ in 0..N {
++        for _ in 0..10000 {
+             rx.recv().unwrap();
+         }
+     }
+@@ -1826,11 +1792,7 @@ mod select_tests {
+ 
+     #[test]
+     fn stress() {
+-        #[cfg(miri)]
+-        const AMT: i32 = 100;
+-        #[cfg(not(miri))]
+         const AMT: i32 = 10000;
+-
+         let (tx1, rx1) = channel::<i32>();
+         let (tx2, rx2) = channel::<i32>();
+         let (tx3, rx3) = channel::<()>();
+diff --git a/third_party/rust/crossbeam-channel/tests/never.rs b/third_party/rust/crossbeam-channel/tests/never.rs
+--- a/third_party/rust/crossbeam-channel/tests/never.rs
++++ b/third_party/rust/crossbeam-channel/tests/never.rs
+@@ -65,8 +65,8 @@ fn capacity() {
+ fn len_empty_full() {
+     let r = never::<i32>();
+     assert_eq!(r.len(), 0);
+-    assert!(r.is_empty());
+-    assert!(r.is_full());
++    assert_eq!(r.is_empty(), true);
++    assert_eq!(r.is_full(), true);
+ }
+ 
+ #[test]
+diff --git a/third_party/rust/crossbeam-channel/tests/ready.rs b/third_party/rust/crossbeam-channel/tests/ready.rs
+--- a/third_party/rust/crossbeam-channel/tests/ready.rs
++++ b/third_party/rust/crossbeam-channel/tests/ready.rs
+@@ -1,7 +1,5 @@
+ //! Tests for channel readiness using the `Select` struct.
+ 
+-#![allow(clippy::drop_copy)]
+-
+ use std::any::Any;
+ use std::cell::Cell;
+ use std::thread;
+@@ -492,9 +490,6 @@ fn nesting() {
+ 
+ #[test]
+ fn stress_recv() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = unbounded();
+@@ -532,9 +527,6 @@ fn stress_recv() {
+ 
+ #[test]
+ fn stress_send() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = bounded(0);
+@@ -569,9 +561,6 @@ fn stress_send() {
+ 
+ #[test]
+ fn stress_mixed() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = bounded(0);
+@@ -677,9 +666,6 @@ fn send_recv_same_channel() {
+ 
+ #[test]
+ fn channel_through_channel() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 1000;
+ 
+     type T = Box<dyn Any + Send>;
+@@ -736,9 +722,6 @@ fn channel_through_channel() {
+ 
+ #[test]
+ fn fairness1() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = bounded::<()>(COUNT);
+@@ -784,9 +767,6 @@ fn fairness1() {
+ 
+ #[test]
+ fn fairness2() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 100_000;
+ 
+     let (s1, r1) = unbounded::<()>();
+diff --git a/third_party/rust/crossbeam-channel/tests/select.rs b/third_party/rust/crossbeam-channel/tests/select.rs
+--- a/third_party/rust/crossbeam-channel/tests/select.rs
++++ b/third_party/rust/crossbeam-channel/tests/select.rs
+@@ -1,7 +1,5 @@
+ //! Tests for channel selection using the `Select` struct.
+ 
+-#![allow(clippy::drop_copy)]
+-
+ use std::any::Any;
+ use std::cell::Cell;
+ use std::thread;
+@@ -408,7 +406,6 @@ fn both_ready() {
+     .unwrap();
+ }
+ 
+-#[cfg_attr(miri, ignore)] // Miri is too slow
+ #[test]
+ fn loop_try() {
+     const RUNS: usize = 20;
+@@ -693,9 +690,6 @@ fn nesting() {
+ 
+ #[test]
+ fn stress_recv() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = unbounded();
+@@ -734,9 +728,6 @@ fn stress_recv() {
+ 
+ #[test]
+ fn stress_send() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = bounded(0);
+@@ -772,9 +763,6 @@ fn stress_send() {
+ 
+ #[test]
+ fn stress_mixed() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = bounded(0);
+@@ -907,12 +895,12 @@ fn matching() {
+         for i in 0..THREADS {
+             scope.spawn(move |_| {
+                 let mut sel = Select::new();
+-                let oper1 = sel.recv(r);
+-                let oper2 = sel.send(s);
++                let oper1 = sel.recv(&r);
++                let oper2 = sel.send(&s);
+                 let oper = sel.select();
+                 match oper.index() {
+-                    ix if ix == oper1 => assert_ne!(oper.recv(r), Ok(i)),
+-                    ix if ix == oper2 => assert!(oper.send(s, i).is_ok()),
++                    ix if ix == oper1 => assert_ne!(oper.recv(&r), Ok(i)),
++                    ix if ix == oper2 => assert!(oper.send(&s, i).is_ok()),
+                     _ => unreachable!(),
+                 }
+             });
+@@ -933,12 +921,12 @@ fn matching_with_leftover() {
+         for i in 0..THREADS {
+             scope.spawn(move |_| {
+                 let mut sel = Select::new();
+-                let oper1 = sel.recv(r);
+-                let oper2 = sel.send(s);
++                let oper1 = sel.recv(&r);
++                let oper2 = sel.send(&s);
+                 let oper = sel.select();
+                 match oper.index() {
+-                    ix if ix == oper1 => assert_ne!(oper.recv(r), Ok(i)),
+-                    ix if ix == oper2 => assert!(oper.send(s, i).is_ok()),
++                    ix if ix == oper1 => assert_ne!(oper.recv(&r), Ok(i)),
++                    ix if ix == oper2 => assert!(oper.send(&s, i).is_ok()),
+                     _ => unreachable!(),
+                 }
+             });
+@@ -952,9 +940,6 @@ fn matching_with_leftover() {
+ 
+ #[test]
+ fn channel_through_channel() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 1000;
+ 
+     type T = Box<dyn Any + Send>;
+@@ -1013,9 +998,6 @@ fn channel_through_channel() {
+ 
+ #[test]
+ fn linearizable_try() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 100_000;
+ 
+     for step in 0..2 {
+@@ -1068,9 +1050,6 @@ fn linearizable_try() {
+ 
+ #[test]
+ fn linearizable_timeout() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 100_000;
+ 
+     for step in 0..2 {
+@@ -1123,9 +1102,6 @@ fn linearizable_timeout() {
+ 
+ #[test]
+ fn fairness1() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = bounded::<()>(COUNT);
+@@ -1172,9 +1148,6 @@ fn fairness1() {
+ 
+ #[test]
+ fn fairness2() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = unbounded::<()>();
+@@ -1239,8 +1212,8 @@ fn sync_and_clone() {
+     let (s, r) = &bounded::<usize>(0);
+ 
+     let mut sel = Select::new();
+-    let oper1 = sel.recv(r);
+-    let oper2 = sel.send(s);
++    let oper1 = sel.recv(&r);
++    let oper2 = sel.send(&s);
+     let sel = &sel;
+ 
+     scope(|scope| {
+@@ -1249,8 +1222,8 @@ fn sync_and_clone() {
+                 let mut sel = sel.clone();
+                 let oper = sel.select();
+                 match oper.index() {
+-                    ix if ix == oper1 => assert_ne!(oper.recv(r), Ok(i)),
+-                    ix if ix == oper2 => assert!(oper.send(s, i).is_ok()),
++                    ix if ix == oper1 => assert_ne!(oper.recv(&r), Ok(i)),
++                    ix if ix == oper2 => assert!(oper.send(&s, i).is_ok()),
+                     _ => unreachable!(),
+                 }
+             });
+@@ -1268,8 +1241,8 @@ fn send_and_clone() {
+     let (s, r) = &bounded::<usize>(0);
+ 
+     let mut sel = Select::new();
+-    let oper1 = sel.recv(r);
+-    let oper2 = sel.send(s);
++    let oper1 = sel.recv(&r);
++    let oper2 = sel.send(&s);
+ 
+     scope(|scope| {
+         for i in 0..THREADS {
+@@ -1277,8 +1250,8 @@ fn send_and_clone() {
+             scope.spawn(move |_| {
+                 let oper = sel.select();
+                 match oper.index() {
+-                    ix if ix == oper1 => assert_ne!(oper.recv(r), Ok(i)),
+-                    ix if ix == oper2 => assert!(oper.send(s, i).is_ok()),
++                    ix if ix == oper1 => assert_ne!(oper.recv(&r), Ok(i)),
++                    ix if ix == oper2 => assert!(oper.send(&s, i).is_ok()),
+                     _ => unreachable!(),
+                 }
+             });
+@@ -1291,9 +1264,6 @@ fn send_and_clone() {
+ 
+ #[test]
+ fn reuse() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = bounded(0);
+diff --git a/third_party/rust/crossbeam-channel/tests/select_macro.rs b/third_party/rust/crossbeam-channel/tests/select_macro.rs
+--- a/third_party/rust/crossbeam-channel/tests/select_macro.rs
++++ b/third_party/rust/crossbeam-channel/tests/select_macro.rs
+@@ -1,7 +1,6 @@
+ //! Tests for the `select!` macro.
+ 
+ #![forbid(unsafe_code)] // select! is safe.
+-#![allow(clippy::drop_copy, clippy::match_single_binding)]
+ 
+ use std::any::Any;
+ use std::cell::Cell;
+@@ -284,7 +283,6 @@ fn both_ready() {
+     .unwrap();
+ }
+ 
+-#[cfg_attr(miri, ignore)] // Miri is too slow
+ #[test]
+ fn loop_try() {
+     const RUNS: usize = 20;
+@@ -487,9 +485,6 @@ fn panic_receiver() {
+ 
+ #[test]
+ fn stress_recv() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = unbounded();
+@@ -523,9 +518,6 @@ fn stress_recv() {
+ 
+ #[test]
+ fn stress_send() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = bounded(0);
+@@ -556,9 +548,6 @@ fn stress_send() {
+ 
+ #[test]
+ fn stress_mixed() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = bounded(0);
+@@ -692,9 +681,6 @@ fn matching_with_leftover() {
+ 
+ #[test]
+ fn channel_through_channel() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 1000;
+ 
+     type T = Box<dyn Any + Send>;
+@@ -740,9 +726,6 @@ fn channel_through_channel() {
+ 
+ #[test]
+ fn linearizable_default() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 100_000;
+ 
+     for step in 0..2 {
+@@ -787,9 +770,6 @@ fn linearizable_default() {
+ 
+ #[test]
+ fn linearizable_timeout() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 100_000;
+ 
+     for step in 0..2 {
+@@ -834,9 +814,6 @@ fn linearizable_timeout() {
+ 
+ #[test]
+ fn fairness1() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = bounded::<()>(COUNT);
+@@ -861,9 +838,6 @@ fn fairness1() {
+ 
+ #[test]
+ fn fairness2() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = unbounded::<()>();
+@@ -901,9 +875,6 @@ fn fairness2() {
+ 
+ #[test]
+ fn fairness_recv() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = bounded::<()>(COUNT);
+@@ -926,9 +897,6 @@ fn fairness_recv() {
+ 
+ #[test]
+ fn fairness_send() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, _r1) = bounded::<()>(COUNT);
+@@ -944,7 +912,6 @@ fn fairness_send() {
+     assert!(hits.iter().all(|x| *x >= COUNT / 4));
+ }
+ 
+-#[allow(clippy::or_fun_call)] // This is intentional.
+ #[test]
+ fn references() {
+     let (s, r) = unbounded::<i32>();
+@@ -991,7 +958,6 @@ fn case_blocks() {
+     drop(s);
+ }
+ 
+-#[allow(clippy::redundant_closure_call)] // This is intentional.
+ #[test]
+ fn move_handles() {
+     let (s, r) = unbounded::<i32>();
+diff --git a/third_party/rust/crossbeam-channel/tests/thread_locals.rs b/third_party/rust/crossbeam-channel/tests/thread_locals.rs
+--- a/third_party/rust/crossbeam-channel/tests/thread_locals.rs
++++ b/third_party/rust/crossbeam-channel/tests/thread_locals.rs
+@@ -1,7 +1,5 @@
+ //! Tests that make sure accessing thread-locals while exiting the thread doesn't cause panics.
+ 
+-#![cfg(not(miri))] // error: abnormal termination: the evaluated program aborted execution
+-
+ use std::thread;
+ use std::time::Duration;
+ 
+diff --git a/third_party/rust/crossbeam-channel/tests/tick.rs b/third_party/rust/crossbeam-channel/tests/tick.rs
+--- a/third_party/rust/crossbeam-channel/tests/tick.rs
++++ b/third_party/rust/crossbeam-channel/tests/tick.rs
+@@ -1,7 +1,5 @@
+ //! Tests for the tick channel flavor.
+ 
+-#![cfg(not(miri))] // TODO: many assertions failed due to Miri is slow
+-
+ use std::sync::atomic::AtomicUsize;
+ use std::sync::atomic::Ordering;
+ use std::thread;
+@@ -80,20 +78,20 @@ fn len_empty_full() {
+     let r = tick(ms(50));
+ 
+     assert_eq!(r.len(), 0);
+-    assert!(r.is_empty());
+-    assert!(!r.is_full());
++    assert_eq!(r.is_empty(), true);
++    assert_eq!(r.is_full(), false);
+ 
+     thread::sleep(ms(100));
+ 
+     assert_eq!(r.len(), 1);
+-    assert!(!r.is_empty());
+-    assert!(r.is_full());
++    assert_eq!(r.is_empty(), false);
++    assert_eq!(r.is_full(), true);
+ 
+     r.try_recv().unwrap();
+ 
+     assert_eq!(r.len(), 0);
+-    assert!(r.is_empty());
+-    assert!(!r.is_full());
++    assert_eq!(r.is_empty(), true);
++    assert_eq!(r.is_full(), false);
+ }
+ 
+ #[test]
+diff --git a/third_party/rust/crossbeam-channel/tests/zero.rs b/third_party/rust/crossbeam-channel/tests/zero.rs
+--- a/third_party/rust/crossbeam-channel/tests/zero.rs
++++ b/third_party/rust/crossbeam-channel/tests/zero.rs
+@@ -35,11 +35,11 @@ fn len_empty_full() {
+     let (s, r) = bounded(0);
+ 
+     assert_eq!(s.len(), 0);
+-    assert!(s.is_empty());
+-    assert!(s.is_full());
++    assert_eq!(s.is_empty(), true);
++    assert_eq!(s.is_full(), true);
+     assert_eq!(r.len(), 0);
+-    assert!(r.is_empty());
+-    assert!(r.is_full());
++    assert_eq!(r.is_empty(), true);
++    assert_eq!(r.is_full(), true);
+ 
+     scope(|scope| {
+         scope.spawn(|_| s.send(0).unwrap());
+@@ -48,11 +48,11 @@ fn len_empty_full() {
+     .unwrap();
+ 
+     assert_eq!(s.len(), 0);
+-    assert!(s.is_empty());
+-    assert!(s.is_full());
++    assert_eq!(s.is_empty(), true);
++    assert_eq!(s.is_full(), true);
+     assert_eq!(r.len(), 0);
+-    assert!(r.is_empty());
+-    assert!(r.is_full());
++    assert_eq!(r.is_empty(), true);
++    assert_eq!(r.is_full(), true);
+ }
+ 
+ #[test]
+@@ -187,9 +187,6 @@ fn send_timeout() {
+ 
+ #[test]
+ fn len() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 25_000;
+ 
+     let (s, r) = bounded(0);
+@@ -252,9 +249,6 @@ fn disconnect_wakes_receiver() {
+ 
+ #[test]
+ fn spsc() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 100_000;
+ 
+     let (s, r) = bounded(0);
+@@ -277,9 +271,6 @@ fn spsc() {
+ 
+ #[test]
+ fn mpmc() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 25_000;
+     const THREADS: usize = 4;
+ 
+@@ -312,9 +303,6 @@ fn mpmc() {
+ 
+ #[test]
+ fn stress_oneshot() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     for _ in 0..COUNT {
+@@ -328,7 +316,6 @@ fn stress_oneshot() {
+     }
+ }
+ 
+-#[cfg_attr(miri, ignore)] // Miri is too slow
+ #[test]
+ fn stress_iter() {
+     const COUNT: usize = 1000;
+@@ -396,11 +383,8 @@ fn stress_timeout_two_threads() {
+     .unwrap();
+ }
+ 
+-#[cfg_attr(miri, ignore)] // Miri is too slow
+ #[test]
+ fn drops() {
+-    const RUNS: usize = 100;
+-
+     static DROPS: AtomicUsize = AtomicUsize::new(0);
+ 
+     #[derive(Debug, PartialEq)]
+@@ -414,7 +398,7 @@ fn drops() {
+ 
+     let mut rng = thread_rng();
+ 
+-    for _ in 0..RUNS {
++    for _ in 0..100 {
+         let steps = rng.gen_range(0..3_000);
+ 
+         DROPS.store(0, Ordering::SeqCst);
+@@ -444,9 +428,6 @@ fn drops() {
+ 
+ #[test]
+ fn fairness() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s1, r1) = bounded::<()>(0);
+@@ -478,9 +459,6 @@ fn fairness() {
+ 
+ #[test]
+ fn fairness_duplicates() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 10_000;
+ 
+     let (s, r) = bounded::<()>(0);
+@@ -539,9 +517,6 @@ fn recv_in_send() {
+ 
+ #[test]
+ fn channel_through_channel() {
+-    #[cfg(miri)]
+-    const COUNT: usize = 100;
+-    #[cfg(not(miri))]
+     const COUNT: usize = 1000;
+ 
+     type T = Box<dyn Any + Send>;
+diff --git a/third_party/rust/crossbeam-epoch/.cargo-checksum.json b/third_party/rust/crossbeam-epoch/.cargo-checksum.json
+--- a/third_party/rust/crossbeam-epoch/.cargo-checksum.json
++++ b/third_party/rust/crossbeam-epoch/.cargo-checksum.json
+@@ -1,1 +1,1 @@
+-{"files":{"CHANGELOG.md":"7f3c7198f2e33ba93bb8270e1c1e8dc6d70c343987acd9d0706e3632cbb9e0ad","Cargo.lock":"10e3899295e7e8ce93d3f0b597efbec844bdda40f78ae717f5995341d41ee937","Cargo.toml":"d7e7ab87ca4a4e8cc4ae9644e1537eedc46473ff5f89399b4733c4bdf59058db","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"5734ed989dfca1f625b40281ee9f4530f91b2411ec01cb748223e7eb87e201ab","README.md":"f946b25082979595d3851d90c4e76424be921a779e88e982f8455d44d46057ec","benches/defer.rs":"c330b704d96b2ad1aed29f72c37a99da534adef8cb06a3976d5f93bf567abb20","benches/flush.rs":"0389ac6c473632f0e93c962f223404cc360257f6699b4ec90b9b3be16bb6d74f","benches/pin.rs":"2f649a5153745c7930efdb32a52f9dc522f7b8cf548a251c5e2c82ee25dc3fff","build.rs":"58a36da8f9ca3a9206d31a0d6e7548f200fe8746ebca5edca48679b0d29a8043","examples/sanitize.rs":"a39d1635fa61e643e59192d7a63becc97ff81f03c1f4e03d38cedefb1525026a","no_atomic.rs":"3529c0833bcd1e09a352d3bd1696d3666850c9b09fe2111bf1a783ec16a5f467","src/atomic.rs":"63843b5ecd51b3fc98336247abe8efa824d826f142e40a761636e530d06f3b41","src/collector.rs":"e2d9780d8707e49360b3c33f2f829f29f70e6929307e65e23449b8ba6def6358","src/default.rs":"e1449bd6e61d7c19e9cbdf183f81c67c3487775fcc55572947874ca535d3d54f","src/deferred.rs":"ea532517c8ca22010ed9a624b059471c8a57b25e7925f6a5dfb391be7646a1fa","src/epoch.rs":"d31e66d8fe62299928e25867336d96391b26a4fe890a1cae0885dfcf36d6835b","src/guard.rs":"55c56ca1b2fbc067ae21108f0f7de4be91e5b41df2492055b635ed436782dd52","src/internal.rs":"67a6811b8c58e1152fd1dc17e389884025a0d99d79ab03dee26efcd0d6896690","src/lib.rs":"bcaa7c8dc9f9eb1ef6f56b4c0705db348d00b21325b6c0c1544cd7aec0613dc9","src/sync/list.rs":"10aa4c59845ab9ff1d8bcb6f594b70bbe23c320fa7a2b125fdf85df88b9d61e2","src/sync/mod.rs":"cbc6334460d73761c3dea7f99ed2ccbf267d5da3bc76c812e94f85c9f4565c6a","src/sync/queue.rs":"06173b2255677d0d39178ceb49876fda2878f491e907c595eb65643dbb43c9ba","tests/loom.rs":"db772f4478966de6ec98774ca4093171dc942da635822a0d2d3257d31188cb9b"},"package":"97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"}
+\ No newline at end of file
++{"files":{"CHANGELOG.md":"40b65a13f12e97a24c838fe2254a3563a5fe00922053ef7256ed4752876614fa","Cargo.lock":"35b1db42b892c01e72ff1f99fc7767e5e47208d083203866337f6f2f7d0738eb","Cargo.toml":"eab75399db818408fd4f45a91919b08e050e56547014816683a269270e292055","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"5734ed989dfca1f625b40281ee9f4530f91b2411ec01cb748223e7eb87e201ab","README.md":"f946b25082979595d3851d90c4e76424be921a779e88e982f8455d44d46057ec","benches/defer.rs":"c330b704d96b2ad1aed29f72c37a99da534adef8cb06a3976d5f93bf567abb20","benches/flush.rs":"0389ac6c473632f0e93c962f223404cc360257f6699b4ec90b9b3be16bb6d74f","benches/pin.rs":"80f9e65ba04a2ddec7a330172d0b0fbc698e20c221b3d8cdc70cc42e3b9099d1","build.rs":"c8684300062c73e96eae8877d03e145ee95e0cd99d4d933696caa582c08e2416","examples/sanitize.rs":"a39d1635fa61e643e59192d7a63becc97ff81f03c1f4e03d38cedefb1525026a","no_atomic.rs":"a2621c1b029c614fb0ab8e3f5cda2e839df88d90d26133181c1b901965f7eec4","src/atomic.rs":"631d3062e3c30d8e505fda3a7e2c68a88abf7617881035d6131c39cb8fdddce0","src/collector.rs":"7d636f3f96fafd033298d1c2ab126205438a46deb84895d8e28bea9eef67798a","src/default.rs":"e1449bd6e61d7c19e9cbdf183f81c67c3487775fcc55572947874ca535d3d54f","src/deferred.rs":"1ee67bd3200d3891076aac8cfc9767abdddc194602f2084d11455484096005ea","src/epoch.rs":"d31e66d8fe62299928e25867336d96391b26a4fe890a1cae0885dfcf36d6835b","src/guard.rs":"55c56ca1b2fbc067ae21108f0f7de4be91e5b41df2492055b635ed436782dd52","src/internal.rs":"f3f8131819b2a4ec4d1a6d392c734688324f3ae708bac6745e88f2930657eba1","src/lib.rs":"bcaa7c8dc9f9eb1ef6f56b4c0705db348d00b21325b6c0c1544cd7aec0613dc9","src/sync/list.rs":"10aa4c59845ab9ff1d8bcb6f594b70bbe23c320fa7a2b125fdf85df88b9d61e2","src/sync/mod.rs":"cbc6334460d73761c3dea7f99ed2ccbf267d5da3bc76c812e94f85c9f4565c6a","src/sync/queue.rs":"262e0d8f343e97df9e2a738461e4255e339710e81c479e484f9efe517ae47135","tests/loom.rs":"db772f4478966de6ec98774ca4093171dc942da635822a0d2d3257d31188cb9b"},"package":"4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"}
+\ No newline at end of file
+diff --git a/third_party/rust/crossbeam-epoch/CHANGELOG.md b/third_party/rust/crossbeam-epoch/CHANGELOG.md
+--- a/third_party/rust/crossbeam-epoch/CHANGELOG.md
++++ b/third_party/rust/crossbeam-epoch/CHANGELOG.md
+@@ -1,16 +1,12 @@
+-# Version 0.9.6
+-
+-- Add `Atomic::fetch_update`. (#706)
+-
+ # Version 0.9.5
+ 
+-- Fix UB in `Pointable` impl of `[MaybeUninit<T>]`. (#694)
+-- Support targets that do not have atomic CAS on stable Rust. (#698)
+-- Fix breakage with nightly feature due to rust-lang/rust#84510. (#692)
++- Fix UB in `Pointable` impl of `[MaybeUninit<T>]` (#694)
++- Support targets that do not have atomic CAS on stable Rust (#698)
++- Fix breakage with nightly feature due to rust-lang/rust#84510 (#692)
+ 
+ # Version 0.9.4
+ 
+-- Fix UB in `<[MaybeUninit<T>] as Pointable>::init` when global allocator failed allocation. (#690)
++- Fix UB in `<[MaybeUninit<T>] as Pointable>::init` when global allocator failed allocation (#690)
+ - Bump `loom` dependency to version 0.5. (#686)
+ 
+ # Version 0.9.3
+diff --git a/third_party/rust/crossbeam-epoch/Cargo.lock b/third_party/rust/crossbeam-epoch/Cargo.lock
+--- a/third_party/rust/crossbeam-epoch/Cargo.lock
++++ b/third_party/rust/crossbeam-epoch/Cargo.lock
+@@ -3,15 +3,6 @@
+ version = 3
+ 
+ [[package]]
+-name = "ansi_term"
+-version = "0.12.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+-dependencies = [
+- "winapi",
+-]
+-
+-[[package]]
+ name = "autocfg"
+ version = "1.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -19,9 +10,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffe
+ 
+ [[package]]
+ name = "cc"
+-version = "1.0.72"
++version = "1.0.68"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
++checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+ 
+ [[package]]
+ name = "cfg-if"
+@@ -31,13 +22,13 @@ checksum = "baf1de4339761588bc0619e3cbc0
+ 
+ [[package]]
+ name = "const_fn"
+-version = "0.4.9"
++version = "0.4.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
++checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
+ 
+ [[package]]
+ name = "crossbeam-epoch"
+-version = "0.9.6"
++version = "0.9.5"
+ dependencies = [
+  "cfg-if",
+  "const_fn",
+@@ -51,9 +42,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "crossbeam-utils"
+-version = "0.8.6"
++version = "0.8.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
++checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+ dependencies = [
+  "cfg-if",
+  "lazy_static",
+@@ -92,9 +83,9 @@ checksum = "e2abad23fbc42b3700f2f279844d
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.112"
++version = "0.2.95"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
++checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+ 
+ [[package]]
+ name = "log"
+@@ -107,76 +98,35 @@ dependencies = [
+ 
+ [[package]]
+ name = "loom"
+-version = "0.5.4"
++version = "0.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "edc5c7d328e32cc4954e8e01193d7f0ef5ab257b5090b70a964e099a36034309"
++checksum = "7aa5348dc45fa5f2419b6dd4ea20345e6b01b1fcc9d176a322eada1ac3f382ba"
+ dependencies = [
+  "cfg-if",
+  "generator",
+  "scoped-tls",
+- "tracing",
+- "tracing-subscriber",
+-]
+-
+-[[package]]
+-name = "matchers"
+-version = "0.1.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+-dependencies = [
+- "regex-automata",
+ ]
+ 
+ [[package]]
+ name = "memoffset"
+-version = "0.6.5"
++version = "0.6.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
++checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+ dependencies = [
+  "autocfg",
+ ]
+ 
+ [[package]]
+-name = "once_cell"
+-version = "1.9.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+-
+-[[package]]
+-name = "pin-project-lite"
+-version = "0.2.8"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+-
+-[[package]]
+ name = "ppv-lite86"
+-version = "0.2.16"
++version = "0.2.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+-
+-[[package]]
+-name = "proc-macro2"
+-version = "1.0.36"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+-dependencies = [
+- "unicode-xid",
+-]
+-
+-[[package]]
+-name = "quote"
+-version = "1.0.14"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+-dependencies = [
+- "proc-macro2",
+-]
++checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+ 
+ [[package]]
+ name = "rand"
+-version = "0.8.4"
++version = "0.8.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
++checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+ dependencies = [
+  "libc",
+  "rand_chacha",
+@@ -186,9 +136,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rand_chacha"
+-version = "0.3.1"
++version = "0.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
++checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+ dependencies = [
+  "ppv-lite86",
+  "rand_core",
+@@ -196,51 +146,27 @@ dependencies = [
+ 
+ [[package]]
+ name = "rand_core"
+-version = "0.6.3"
++version = "0.6.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
++checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+ dependencies = [
+  "getrandom",
+ ]
+ 
+ [[package]]
+ name = "rand_hc"
+-version = "0.3.1"
++version = "0.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
++checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+ dependencies = [
+  "rand_core",
+ ]
+ 
+ [[package]]
+-name = "regex"
+-version = "1.5.4"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+-dependencies = [
+- "regex-syntax",
+-]
+-
+-[[package]]
+-name = "regex-automata"
+-version = "0.1.10"
++name = "rustversion"
++version = "1.0.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+-dependencies = [
+- "regex-syntax",
+-]
+-
+-[[package]]
+-name = "regex-syntax"
+-version = "0.6.25"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+-
+-[[package]]
+-name = "rustversion"
+-version = "1.0.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
++checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+ 
+ [[package]]
+ name = "scoped-tls"
+@@ -255,108 +181,6 @@ source = "registry+https://github.com/ru
+ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+ 
+ [[package]]
+-name = "sharded-slab"
+-version = "0.1.4"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+-dependencies = [
+- "lazy_static",
+-]
+-
+-[[package]]
+-name = "smallvec"
+-version = "1.7.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+-
+-[[package]]
+-name = "syn"
+-version = "1.0.85"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+-dependencies = [
+- "proc-macro2",
+- "quote",
+- "unicode-xid",
+-]
+-
+-[[package]]
+-name = "thread_local"
+-version = "1.1.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+-dependencies = [
+- "once_cell",
+-]
+-
+-[[package]]
+-name = "tracing"
+-version = "0.1.29"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+-dependencies = [
+- "cfg-if",
+- "pin-project-lite",
+- "tracing-attributes",
+- "tracing-core",
+-]
+-
+-[[package]]
+-name = "tracing-attributes"
+-version = "0.1.18"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+-dependencies = [
+- "proc-macro2",
+- "quote",
+- "syn",
+-]
+-
+-[[package]]
+-name = "tracing-core"
+-version = "0.1.21"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+-dependencies = [
+- "lazy_static",
+-]
+-
+-[[package]]
+-name = "tracing-log"
+-version = "0.1.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+-dependencies = [
+- "lazy_static",
+- "log",
+- "tracing-core",
+-]
+-
+-[[package]]
+-name = "tracing-subscriber"
+-version = "0.3.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5d81bfa81424cc98cb034b837c985b7a290f592e5b4322f353f94a0ab0f9f594"
+-dependencies = [
+- "ansi_term",
+- "lazy_static",
+- "matchers",
+- "regex",
+- "sharded-slab",
+- "smallvec",
+- "thread_local",
+- "tracing",
+- "tracing-core",
+- "tracing-log",
+-]
+-
+-[[package]]
+-name = "unicode-xid"
+-version = "0.2.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+-
+-[[package]]
+ name = "wasi"
+ version = "0.10.2+wasi-snapshot-preview1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+diff --git a/third_party/rust/crossbeam-epoch/Cargo.toml b/third_party/rust/crossbeam-epoch/Cargo.toml
+--- a/third_party/rust/crossbeam-epoch/Cargo.toml
++++ b/third_party/rust/crossbeam-epoch/Cargo.toml
+@@ -3,19 +3,21 @@
+ # When uploading crates to the registry Cargo will automatically
+ # "normalize" Cargo.toml files for maximal compatibility
+ # with all versions of Cargo and also rewrite `path` dependencies
+-# to registry (e.g., crates.io) dependencies.
++# to registry (e.g., crates.io) dependencies
+ #
+-# If you are reading this file be aware that the original Cargo.toml
+-# will likely look very different (and much more reasonable).
+-# See Cargo.toml.orig for the original contents.
++# If you believe there's an error in this file please file an
++# issue against the rust-lang/cargo repository. If you're
++# editing this file be aware that the upstream Cargo.toml
++# will likely look very different (and much more reasonable)
+ 
+ [package]
+ edition = "2018"
+-rust-version = "1.36"
+ name = "crossbeam-epoch"
+-version = "0.9.6"
++version = "0.9.5"
++authors = ["The Crossbeam Project Developers"]
+ description = "Epoch-based garbage collection"
+ homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-epoch"
++documentation = "https://docs.rs/crossbeam-epoch"
+ keywords = ["lock-free", "rcu", "atomic", "garbage"]
+ categories = ["concurrency", "memory-management", "no-std"]
+ license = "MIT OR Apache-2.0"
+diff --git a/third_party/rust/crossbeam-epoch/benches/pin.rs b/third_party/rust/crossbeam-epoch/benches/pin.rs
+--- a/third_party/rust/crossbeam-epoch/benches/pin.rs
++++ b/third_party/rust/crossbeam-epoch/benches/pin.rs
+@@ -8,7 +8,7 @@ use test::Bencher;
+ 
+ #[bench]
+ fn single_pin(b: &mut Bencher) {
+-    b.iter(epoch::pin);
++    b.iter(|| epoch::pin());
+ }
+ 
+ #[bench]
+diff --git a/third_party/rust/crossbeam-epoch/build.rs b/third_party/rust/crossbeam-epoch/build.rs
+--- a/third_party/rust/crossbeam-epoch/build.rs
++++ b/third_party/rust/crossbeam-epoch/build.rs
+@@ -4,19 +4,9 @@ use std::env;
+ 
+ include!("no_atomic.rs");
+ 
+-// The rustc-cfg listed below are considered public API, but it is *unstable*
+-// and outside of the normal semver guarantees:
+-//
+-// - `crossbeam_no_atomic_cas`
+-//      Assume the target does *not* support atomic CAS operations.
+-//      This is usually detected automatically by the build script, but you may
+-//      need to enable it manually when building for custom targets or using
+-//      non-cargo build systems that don't run the build script.
+-//
+-// With the exceptions mentioned above, the rustc-cfg strings below are
+-// *not* public API. Please let us know by opening a GitHub issue if your build
+-// environment requires some way to enable these cfgs other than by executing
+-// our build script.
++// The rustc-cfg strings below are *not* public API. Please let us know by
++// opening a GitHub issue if your build environment requires some way to enable
++// these cfgs other than by executing our build script.
+ fn main() {
+     let target = match env::var("TARGET") {
+         Ok(target) => target,
+diff --git a/third_party/rust/crossbeam-epoch/no_atomic.rs b/third_party/rust/crossbeam-epoch/no_atomic.rs
+--- a/third_party/rust/crossbeam-epoch/no_atomic.rs
++++ b/third_party/rust/crossbeam-epoch/no_atomic.rs
+@@ -3,8 +3,6 @@
+ 
+ const NO_ATOMIC_CAS: &[&str] = &[
+     "avr-unknown-gnu-atmega328",
+-    "bpfeb-unknown-none",
+-    "bpfel-unknown-none",
+     "msp430-none-elf",
+     "riscv32i-unknown-none-elf",
+     "riscv32imc-unknown-none-elf",
+@@ -23,7 +21,6 @@ const NO_ATOMIC_64: &[&str] = &[
+     "armv7r-none-eabi",
+     "armv7r-none-eabihf",
+     "hexagon-unknown-linux-musl",
+-    "m68k-unknown-linux-gnu",
+     "mips-unknown-linux-gnu",
+     "mips-unknown-linux-musl",
+     "mips-unknown-linux-uclibc",
+@@ -33,7 +30,6 @@ const NO_ATOMIC_64: &[&str] = &[
+     "mipsel-unknown-none",
+     "mipsisa32r6-unknown-linux-gnu",
+     "mipsisa32r6el-unknown-linux-gnu",
+-    "powerpc-unknown-freebsd",
+     "powerpc-unknown-linux-gnu",
+     "powerpc-unknown-linux-gnuspe",
+     "powerpc-unknown-linux-musl",
+@@ -44,14 +40,12 @@ const NO_ATOMIC_64: &[&str] = &[
+     "riscv32gc-unknown-linux-gnu",
+     "riscv32gc-unknown-linux-musl",
+     "riscv32imac-unknown-none-elf",
+-    "riscv32imc-esp-espidf",
+     "thumbv7em-none-eabi",
+     "thumbv7em-none-eabihf",
+     "thumbv7m-none-eabi",
+     "thumbv8m.base-none-eabi",
+     "thumbv8m.main-none-eabi",
+     "thumbv8m.main-none-eabihf",
+-    "armv6k-nintendo-3ds",
+     "mipsel-sony-psp",
+     "thumbv4t-none-eabi",
+     "thumbv6m-none-eabi",
+diff --git a/third_party/rust/crossbeam-epoch/src/atomic.rs b/third_party/rust/crossbeam-epoch/src/atomic.rs
+--- a/third_party/rust/crossbeam-epoch/src/atomic.rs
++++ b/third_party/rust/crossbeam-epoch/src/atomic.rs
+@@ -562,65 +562,6 @@ impl<T: ?Sized + Pointable> Atomic<T> {
+             })
+     }
+ 
+-    /// Fetches the pointer, and then applies a function to it that returns a new value.
+-    /// Returns a `Result` of `Ok(previous_value)` if the function returned `Some`, else `Err(_)`.
+-    ///
+-    /// Note that the given function may be called multiple times if the value has been changed by
+-    /// other threads in the meantime, as long as the function returns `Some(_)`, but the function
+-    /// will have been applied only once to the stored value.
+-    ///
+-    /// `fetch_update` takes two [`Ordering`] arguments to describe the memory
+-    /// ordering of this operation. The first describes the required ordering for
+-    /// when the operation finally succeeds while the second describes the
+-    /// required ordering for loads. These correspond to the success and failure
+-    /// orderings of [`Atomic::compare_exchange`] respectively.
+-    ///
+-    /// Using [`Acquire`] as success ordering makes the store part of this
+-    /// operation [`Relaxed`], and using [`Release`] makes the final successful
+-    /// load [`Relaxed`]. The (failed) load ordering can only be [`SeqCst`],
+-    /// [`Acquire`] or [`Relaxed`] and must be equivalent to or weaker than the
+-    /// success ordering.
+-    ///
+-    /// [`Relaxed`]: Ordering::Relaxed
+-    /// [`Acquire`]: Ordering::Acquire
+-    /// [`Release`]: Ordering::Release
+-    /// [`SeqCst`]: Ordering::SeqCst
+-    ///
+-    /// # Examples
+-    ///
+-    /// ```
+-    /// use crossbeam_epoch::{self as epoch, Atomic};
+-    /// use std::sync::atomic::Ordering::SeqCst;
+-    ///
+-    /// let a = Atomic::new(1234);
+-    /// let guard = &epoch::pin();
+-    ///
+-    /// let res1 = a.fetch_update(SeqCst, SeqCst, guard, |x| Some(x.with_tag(1)));
+-    /// assert!(res1.is_ok());
+-    ///
+-    /// let res2 = a.fetch_update(SeqCst, SeqCst, guard, |x| None);
+-    /// assert!(res2.is_err());
+-    /// ```
+-    pub fn fetch_update<'g, F>(
+-        &self,
+-        set_order: Ordering,
+-        fail_order: Ordering,
+-        guard: &'g Guard,
+-        mut func: F,
+-    ) -> Result<Shared<'g, T>, Shared<'g, T>>
+-    where
+-        F: FnMut(Shared<'g, T>) -> Option<Shared<'g, T>>,
+-    {
+-        let mut prev = self.load(fail_order, guard);
+-        while let Some(next) = func(prev) {
+-            match self.compare_exchange_weak(prev, next, set_order, fail_order, guard) {
+-                Ok(shared) => return Ok(shared),
+-                Err(next_prev) => prev = next_prev.current,
+-            }
+-        }
+-        Err(prev)
+-    }
+-
+     /// Stores the pointer `new` (either `Shared` or `Owned`) into the atomic pointer if the current
+     /// value is the same as `current`. The tag is also taken into account, so two pointers to the
+     /// same object, but with different tags, will not be considered equal.
+diff --git a/third_party/rust/crossbeam-epoch/src/collector.rs b/third_party/rust/crossbeam-epoch/src/collector.rs
+--- a/third_party/rust/crossbeam-epoch/src/collector.rs
++++ b/third_party/rust/crossbeam-epoch/src/collector.rs
+@@ -178,18 +178,13 @@ mod tests {
+ 
+     #[test]
+     fn pin_holds_advance() {
+-        #[cfg(miri)]
+-        const N: usize = 500;
+-        #[cfg(not(miri))]
+-        const N: usize = 500_000;
+-
+         let collector = Collector::new();
+ 
+         thread::scope(|scope| {
+             for _ in 0..NUM_THREADS {
+                 scope.spawn(|_| {
+                     let handle = collector.register();
+-                    for _ in 0..N {
++                    for _ in 0..500_000 {
+                         let guard = &handle.pin();
+ 
+                         let before = collector.global.epoch.load(Ordering::Relaxed);
+@@ -207,9 +202,6 @@ mod tests {
+     #[cfg(not(crossbeam_sanitize))] // TODO: assertions failed due to `cfg(crossbeam_sanitize)` reduce `internal::MAX_OBJECTS`
+     #[test]
+     fn incremental() {
+-        #[cfg(miri)]
+-        const COUNT: usize = 500;
+-        #[cfg(not(miri))]
+         const COUNT: usize = 100_000;
+         static DESTROYS: AtomicUsize = AtomicUsize::new(0);
+ 
+@@ -238,16 +230,12 @@ mod tests {
+             let guard = &handle.pin();
+             collector.global.collect(guard);
+         }
+-        assert!(DESTROYS.load(Ordering::Relaxed) == COUNT);
++        assert!(DESTROYS.load(Ordering::Relaxed) == 100_000);
+     }
+ 
+     #[test]
+     fn buffering() {
+         const COUNT: usize = 10;
+-        #[cfg(miri)]
+-        const N: usize = 500;
+-        #[cfg(not(miri))]
+-        const N: usize = 100_000;
+         static DESTROYS: AtomicUsize = AtomicUsize::new(0);
+ 
+         let collector = Collector::new();
+@@ -264,7 +252,7 @@ mod tests {
+             }
+         }
+ 
+-        for _ in 0..N {
++        for _ in 0..100_000 {
+             collector.global.collect(&handle.pin());
+         }
+         assert!(DESTROYS.load(Ordering::Relaxed) < COUNT);
+@@ -280,9 +268,6 @@ mod tests {
+ 
+     #[test]
+     fn count_drops() {
+-        #[cfg(miri)]
+-        const COUNT: usize = 500;
+-        #[cfg(not(miri))]
+         const COUNT: usize = 100_000;
+         static DROPS: AtomicUsize = AtomicUsize::new(0);
+ 
+@@ -316,9 +301,6 @@ mod tests {
+ 
+     #[test]
+     fn count_destroy() {
+-        #[cfg(miri)]
+-        const COUNT: usize = 500;
+-        #[cfg(not(miri))]
+         const COUNT: usize = 100_000;
+         static DESTROYS: AtomicUsize = AtomicUsize::new(0);
+ 
+@@ -385,9 +367,6 @@ mod tests {
+ 
+     #[test]
+     fn destroy_array() {
+-        #[cfg(miri)]
+-        const COUNT: usize = 500;
+-        #[cfg(not(miri))]
+         const COUNT: usize = 100_000;
+         static DESTROYS: AtomicUsize = AtomicUsize::new(0);
+ 
+@@ -423,9 +402,6 @@ mod tests {
+     #[test]
+     fn stress() {
+         const THREADS: usize = 8;
+-        #[cfg(miri)]
+-        const COUNT: usize = 500;
+-        #[cfg(not(miri))]
+         const COUNT: usize = 100_000;
+         static DROPS: AtomicUsize = AtomicUsize::new(0);
+ 
+diff --git a/third_party/rust/crossbeam-epoch/src/deferred.rs b/third_party/rust/crossbeam-epoch/src/deferred.rs
+--- a/third_party/rust/crossbeam-epoch/src/deferred.rs
++++ b/third_party/rust/crossbeam-epoch/src/deferred.rs
+@@ -81,8 +81,6 @@ impl Deferred {
+ 
+ #[cfg(all(test, not(crossbeam_loom)))]
+ mod tests {
+-    #![allow(clippy::drop_copy)]
+-
+     use super::Deferred;
+     use std::cell::Cell;
+ 
+diff --git a/third_party/rust/crossbeam-epoch/src/internal.rs b/third_party/rust/crossbeam-epoch/src/internal.rs
+--- a/third_party/rust/crossbeam-epoch/src/internal.rs
++++ b/third_party/rust/crossbeam-epoch/src/internal.rs
+@@ -101,7 +101,7 @@ impl Bag {
+ 
+     /// Seals the bag with the given epoch.
+     fn seal(self, epoch: Epoch) -> SealedBag {
+-        SealedBag { epoch, _bag: self }
++        SealedBag { epoch, bag: self }
+     }
+ }
+ 
+@@ -216,7 +216,7 @@ fn no_op_func() {}
+ #[derive(Default, Debug)]
+ struct SealedBag {
+     epoch: Epoch,
+-    _bag: Bag,
++    bag: Bag,
+ }
+ 
+ /// It is safe to share `SealedBag` because `is_expired` only inspects the epoch.
+@@ -311,7 +311,7 @@ impl Global {
+         // TODO(stjepang): `Local`s are stored in a linked list because linked lists are fairly
+         // easy to implement in a lock-free manner. However, traversal can be slow due to cache
+         // misses and data dependencies. We should experiment with other data structures as well.
+-        for local in self.locals.iter(guard) {
++        for local in self.locals.iter(&guard) {
+             match local {
+                 Err(IterError::Stalled) => {
+                     // A concurrent thread stalled this iteration. That thread might also try to
+diff --git a/third_party/rust/crossbeam-epoch/src/sync/queue.rs b/third_party/rust/crossbeam-epoch/src/sync/queue.rs
+--- a/third_party/rust/crossbeam-epoch/src/sync/queue.rs
++++ b/third_party/rust/crossbeam-epoch/src/sync/queue.rs
+@@ -259,9 +259,6 @@ mod test {
+         }
+     }
+ 
+-    #[cfg(miri)]
+-    const CONC_COUNT: i64 = 1000;
+-    #[cfg(not(miri))]
+     const CONC_COUNT: i64 = 1000000;
+ 
+     #[test]
+@@ -425,8 +422,8 @@ mod test {
+ 
+                     let mut vl2 = vl.clone();
+                     let mut vr2 = vr.clone();
+-                    vl2.sort_unstable();
+-                    vr2.sort_unstable();
++                    vl2.sort();
++                    vr2.sort();
+ 
+                     assert_eq!(vl, vl2);
+                     assert_eq!(vr, vr2);
+diff --git a/third_party/rust/crossbeam-utils/.cargo-checksum.json b/third_party/rust/crossbeam-utils/.cargo-checksum.json
+--- a/third_party/rust/crossbeam-utils/.cargo-checksum.json
++++ b/third_party/rust/crossbeam-utils/.cargo-checksum.json
+@@ -1,1 +1,1 @@
+-{"files":{"CHANGELOG.md":"097eb3484f4f13471dfe6879ce61450cc60d4453aecb924f38a8f0e4af593cdd","Cargo.toml":"2734493ab832f12a4f849c333d2dd11760c6ce614b88355da21118f77acdcd70","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"5734ed989dfca1f625b40281ee9f4530f91b2411ec01cb748223e7eb87e201ab","README.md":"dfa9fbed47c344c134a63c84b7c0e4651baeac1554b7b3266d0e38643743fc33","benches/atomic_cell.rs":"c927eb3cd1e5ecc4b91adbc3bde98af15ffab4086190792ba64d5cde0e24df3d","build.rs":"39cf39e855e52559c8f68880a02b3e2778ae2d8f089650af1b3e34a85898aed7","no_atomic.rs":"3529c0833bcd1e09a352d3bd1696d3666850c9b09fe2111bf1a783ec16a5f467","src/atomic/atomic_cell.rs":"9d0785073f506b75c110270947f6a8367ead7faaf29c507d4ede37125310cff6","src/atomic/consume.rs":"7a7736fcd64f6473dfea7653559ffc5e1a2a234df43835f8aa8734862145ac15","src/atomic/mod.rs":"7f6afd5bd0da1f7b51765ab04da4e5f683588ac2d23506e61bf7007bb1e61ba2","src/atomic/seq_lock.rs":"27182e6b87a9db73c5f6831759f8625f9fcdec3c2828204c444aef04f427735a","src/atomic/seq_lock_wide.rs":"9888dd03116bb89ca36d4ab8d5a0b5032107a2983a7eb8024454263b09080088","src/backoff.rs":"7cc7754e15f69b52e92a70d4f49d1bc274693455a0933a2d7eb0605806566af3","src/cache_padded.rs":"6a512698115ad0d5a5b163dbd7a83247e1f1c146c4a30f3fc74b952e3b767b59","src/lib.rs":"6f1bcf157abe06ad8458a53e865bf8efab9fad4a9424790147cee8fefb3795d8","src/sync/mod.rs":"59986f559a8f170a4b3247ab2eea2460b09809d87c8110ed88e4e7103d3519dc","src/sync/parker.rs":"3f997f5b41fec286ccedcf3d36f801d741387badb574820b8e3456117ecd9154","src/sync/sharded_lock.rs":"14be659744918d0b27db24c56b41c618b0f0484b6761da46561023d96c4c120f","src/sync/wait_group.rs":"32e946a7581c55f8aa9904527b92b177c538fa0cf7cbcfa1d1f25990582cb6ea","src/thread.rs":"6a7676fd4e50af63aec6f655121a10cd6e8c704f4677125388186ba58dc5842d","tests/atomic_cell.rs":"ba2e34ed1e27f0d0d4f1bb8a5feb4eb8131f756adb27a719de52c26ee7b86b9c","tests/cache_padded.rs":"1bfaff8354c8184e1ee1f902881ca9400b60effb273b0d3f752801a483d2b66d","tests/parker.rs":"6def4721287d9d70b1cfd63ebb34e1c83fbb3376edbad2bc8aac6ef69dd99d20","tests/sharded_lock.rs":"eb6c5b59f007e0d290dd0f58758e8ccb5cacd38af34e3341368ced815f0c41be","tests/thread.rs":"9a7d7d3028c552fd834c68598b04a1cc252a816bc20ab62cec060d6cd09cab10","tests/wait_group.rs":"ad8f0cdfed31f9594a2e0737234d418f8b924d784a4db8d7e469deab8c95f5f8"},"package":"cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"}
+\ No newline at end of file
++{"files":{"CHANGELOG.md":"5242f1740c65509c465c9a36326d344722facff5f5e58dd064f7b77806b83a46","Cargo.toml":"ac35a7b8ccb16f1ab256951576537aa4179a316c068929c2acef89e0adc12319","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"5734ed989dfca1f625b40281ee9f4530f91b2411ec01cb748223e7eb87e201ab","README.md":"dfa9fbed47c344c134a63c84b7c0e4651baeac1554b7b3266d0e38643743fc33","benches/atomic_cell.rs":"c927eb3cd1e5ecc4b91adbc3bde98af15ffab4086190792ba64d5cde0e24df3d","build.rs":"68cfc4be02429834a19411fba29cb1cb52c841f03ac8104d1bae59a8b2184f9c","no_atomic.rs":"a2621c1b029c614fb0ab8e3f5cda2e839df88d90d26133181c1b901965f7eec4","src/atomic/atomic_cell.rs":"1a3a1e073340317b5ce7a94e29c6a87db89ff7e00da6b92cb3c0339364c3b084","src/atomic/consume.rs":"7a7736fcd64f6473dfea7653559ffc5e1a2a234df43835f8aa8734862145ac15","src/atomic/mod.rs":"7f6afd5bd0da1f7b51765ab04da4e5f683588ac2d23506e61bf7007bb1e61ba2","src/atomic/seq_lock.rs":"27182e6b87a9db73c5f6831759f8625f9fcdec3c2828204c444aef04f427735a","src/atomic/seq_lock_wide.rs":"9888dd03116bb89ca36d4ab8d5a0b5032107a2983a7eb8024454263b09080088","src/backoff.rs":"7cc7754e15f69b52e92a70d4f49d1bc274693455a0933a2d7eb0605806566af3","src/cache_padded.rs":"6a512698115ad0d5a5b163dbd7a83247e1f1c146c4a30f3fc74b952e3b767b59","src/lib.rs":"6f1bcf157abe06ad8458a53e865bf8efab9fad4a9424790147cee8fefb3795d8","src/sync/mod.rs":"59986f559a8f170a4b3247ab2eea2460b09809d87c8110ed88e4e7103d3519dc","src/sync/parker.rs":"ba8f75bff31b8be9275808e8f393e71cc682dfc1109ceccb12f69a3700cff5be","src/sync/sharded_lock.rs":"14be659744918d0b27db24c56b41c618b0f0484b6761da46561023d96c4c120f","src/sync/wait_group.rs":"32e946a7581c55f8aa9904527b92b177c538fa0cf7cbcfa1d1f25990582cb6ea","src/thread.rs":"0eb5ec1d3c1b40600d88eb70539d14276e32307f5bed2b679f50f6a20777a01e","tests/atomic_cell.rs":"6c9453384ecbbe76f8b97b62f022d478d3a76b4eae1e960f49790970f5d52158","tests/cache_padded.rs":"1bfaff8354c8184e1ee1f902881ca9400b60effb273b0d3f752801a483d2b66d","tests/parker.rs":"6def4721287d9d70b1cfd63ebb34e1c83fbb3376edbad2bc8aac6ef69dd99d20","tests/sharded_lock.rs":"726025ce6351fb56ed629d5a56bdf6e833b7afc5dedfa08de0b056c726b6c26d","tests/thread.rs":"9a7d7d3028c552fd834c68598b04a1cc252a816bc20ab62cec060d6cd09cab10","tests/wait_group.rs":"ad8f0cdfed31f9594a2e0737234d418f8b924d784a4db8d7e469deab8c95f5f8"},"package":"d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"}
+\ No newline at end of file
+diff --git a/third_party/rust/crossbeam-utils/CHANGELOG.md b/third_party/rust/crossbeam-utils/CHANGELOG.md
+--- a/third_party/rust/crossbeam-utils/CHANGELOG.md
++++ b/third_party/rust/crossbeam-utils/CHANGELOG.md
+@@ -1,12 +1,7 @@
+-# Version 0.8.6
+-
+-- Re-add `AtomicCell<{i,u}64>::{fetch_add,fetch_sub,fetch_and,fetch_or,fetch_xor}` that were accidentally removed in 0.8.0 on targets that do not support `Atomic{I,U}64`. (#767)
+-- Re-add `AtomicCell<{i,u}128>::{fetch_add,fetch_sub,fetch_and,fetch_or,fetch_xor}` that were accidentally removed in 0.8.0. (#767)
+-
+ # Version 0.8.5
+ 
+-- Add `AtomicCell::fetch_update`. (#704)
+-- Support targets that do not have atomic CAS on stable Rust. (#698)
++- Add `AtomicCell::fetch_update` (#704)
++- Support targets that do not have atomic CAS on stable Rust (#698)
+ 
+ # Version 0.8.4
+ 
+diff --git a/third_party/rust/crossbeam-utils/Cargo.toml b/third_party/rust/crossbeam-utils/Cargo.toml
+--- a/third_party/rust/crossbeam-utils/Cargo.toml
++++ b/third_party/rust/crossbeam-utils/Cargo.toml
+@@ -3,19 +3,21 @@
+ # When uploading crates to the registry Cargo will automatically
+ # "normalize" Cargo.toml files for maximal compatibility
+ # with all versions of Cargo and also rewrite `path` dependencies
+-# to registry (e.g., crates.io) dependencies.
++# to registry (e.g., crates.io) dependencies
+ #
+-# If you are reading this file be aware that the original Cargo.toml
+-# will likely look very different (and much more reasonable).
+-# See Cargo.toml.orig for the original contents.
++# If you believe there's an error in this file please file an
++# issue against the rust-lang/cargo repository. If you're
++# editing this file be aware that the upstream Cargo.toml
++# will likely look very different (and much more reasonable)
+ 
+ [package]
+ edition = "2018"
+-rust-version = "1.36"
+ name = "crossbeam-utils"
+-version = "0.8.6"
++version = "0.8.5"
++authors = ["The Crossbeam Project Developers"]
+ description = "Utilities for concurrent programming"
+ homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils"
++documentation = "https://docs.rs/crossbeam-utils"
+ keywords = ["scoped", "thread", "atomic", "cache"]
+ categories = ["algorithms", "concurrency", "data-structures", "no-std"]
+ license = "MIT OR Apache-2.0"
+@@ -29,9 +31,6 @@ optional = true
+ [dev-dependencies.rand]
+ version = "0.8"
+ 
+-[dev-dependencies.rustversion]
+-version = "1"
+-
+ [features]
+ default = ["std"]
+ nightly = []
+diff --git a/third_party/rust/crossbeam-utils/build.rs b/third_party/rust/crossbeam-utils/build.rs
+--- a/third_party/rust/crossbeam-utils/build.rs
++++ b/third_party/rust/crossbeam-utils/build.rs
+@@ -4,31 +4,9 @@ use std::env;
+ 
+ include!("no_atomic.rs");
+ 
+-// The rustc-cfg listed below are considered public API, but it is *unstable*
+-// and outside of the normal semver guarantees:
+-//
+-// - `crossbeam_no_atomic_cas`
+-//      Assume the target does *not* support atomic CAS operations.
+-//      This is usually detected automatically by the build script, but you may
+-//      need to enable it manually when building for custom targets or using
+-//      non-cargo build systems that don't run the build script.
+-//
+-// - `crossbeam_no_atomic`
+-//      Assume the target does *not* support any atomic operations.
+-//      This is usually detected automatically by the build script, but you may
+-//      need to enable it manually when building for custom targets or using
+-//      non-cargo build systems that don't run the build script.
+-//
+-// - `crossbeam_no_atomic_64`
+-//      Assume the target does *not* support AtomicU64/AtomicI64.
+-//      This is usually detected automatically by the build script, but you may
+-//      need to enable it manually when building for custom targets or using
+-//      non-cargo build systems that don't run the build script.
+-//
+-// With the exceptions mentioned above, the rustc-cfg strings below are
+-// *not* public API. Please let us know by opening a GitHub issue if your build
+-// environment requires some way to enable these cfgs other than by executing
+-// our build script.
++// The rustc-cfg strings below are *not* public API. Please let us know by
++// opening a GitHub issue if your build environment requires some way to enable
++// these cfgs other than by executing our build script.
+ fn main() {
+     let target = match env::var("TARGET") {
+         Ok(target) => target,
+diff --git a/third_party/rust/crossbeam-utils/no_atomic.rs b/third_party/rust/crossbeam-utils/no_atomic.rs
+--- a/third_party/rust/crossbeam-utils/no_atomic.rs
++++ b/third_party/rust/crossbeam-utils/no_atomic.rs
+@@ -3,8 +3,6 @@
+ 
+ const NO_ATOMIC_CAS: &[&str] = &[
+     "avr-unknown-gnu-atmega328",
+-    "bpfeb-unknown-none",
+-    "bpfel-unknown-none",
+     "msp430-none-elf",
+     "riscv32i-unknown-none-elf",
+     "riscv32imc-unknown-none-elf",
+@@ -23,7 +21,6 @@ const NO_ATOMIC_64: &[&str] = &[
+     "armv7r-none-eabi",
+     "armv7r-none-eabihf",
+     "hexagon-unknown-linux-musl",
+-    "m68k-unknown-linux-gnu",
+     "mips-unknown-linux-gnu",
+     "mips-unknown-linux-musl",
+     "mips-unknown-linux-uclibc",
+@@ -33,7 +30,6 @@ const NO_ATOMIC_64: &[&str] = &[
+     "mipsel-unknown-none",
+     "mipsisa32r6-unknown-linux-gnu",
+     "mipsisa32r6el-unknown-linux-gnu",
+-    "powerpc-unknown-freebsd",
+     "powerpc-unknown-linux-gnu",
+     "powerpc-unknown-linux-gnuspe",
+     "powerpc-unknown-linux-musl",
+@@ -44,14 +40,12 @@ const NO_ATOMIC_64: &[&str] = &[
+     "riscv32gc-unknown-linux-gnu",
+     "riscv32gc-unknown-linux-musl",
+     "riscv32imac-unknown-none-elf",
+-    "riscv32imc-esp-espidf",
+     "thumbv7em-none-eabi",
+     "thumbv7em-none-eabihf",
+     "thumbv7m-none-eabi",
+     "thumbv8m.base-none-eabi",
+     "thumbv8m.main-none-eabi",
+     "thumbv8m.main-none-eabihf",
+-    "armv6k-nintendo-3ds",
+     "mipsel-sony-psp",
+     "thumbv4t-none-eabi",
+     "thumbv6m-none-eabi",
+diff --git a/third_party/rust/crossbeam-utils/src/atomic/atomic_cell.rs b/third_party/rust/crossbeam-utils/src/atomic/atomic_cell.rs
+--- a/third_party/rust/crossbeam-utils/src/atomic/atomic_cell.rs
++++ b/third_party/rust/crossbeam-utils/src/atomic/atomic_cell.rs
+@@ -295,7 +295,7 @@ impl<T: Copy + Eq> AtomicCell<T> {
+ }
+ 
+ macro_rules! impl_arithmetic {
+-    ($t:ty, fallback, $example:tt) => {
++    ($t:ty, $example:tt) => {
+         impl AtomicCell<$t> {
+             /// Increments the current value by `val` and returns the previous value.
+             ///
+@@ -313,13 +313,10 @@ macro_rules! impl_arithmetic {
+             /// ```
+             #[inline]
+             pub fn fetch_add(&self, val: $t) -> $t {
+-                #[cfg(crossbeam_loom)]
+-                {
+-                    let _ = val;
+-                    unimplemented!("loom does not support non-atomic atomic ops");
+-                }
+-                #[cfg(not(crossbeam_loom))]
+-                {
++                if can_transmute::<$t, atomic::AtomicUsize>() {
++                    let a = unsafe { &*(self.value.get() as *const atomic::AtomicUsize) };
++                    a.fetch_add(val as usize, Ordering::AcqRel) as $t
++                } else {
+                     let _guard = lock(self.value.get() as usize).write();
+                     let value = unsafe { &mut *(self.value.get()) };
+                     let old = *value;
+@@ -344,13 +341,10 @@ macro_rules! impl_arithmetic {
+             /// ```
+             #[inline]
+             pub fn fetch_sub(&self, val: $t) -> $t {
+-                #[cfg(crossbeam_loom)]
+-                {
+-                    let _ = val;
+-                    unimplemented!("loom does not support non-atomic atomic ops");
+-                }
+-                #[cfg(not(crossbeam_loom))]
+-                {
++                if can_transmute::<$t, atomic::AtomicUsize>() {
++                    let a = unsafe { &*(self.value.get() as *const atomic::AtomicUsize) };
++                    a.fetch_sub(val as usize, Ordering::AcqRel) as $t
++                } else {
+                     let _guard = lock(self.value.get() as usize).write();
+                     let value = unsafe { &mut *(self.value.get()) };
+                     let old = *value;
+@@ -373,13 +367,10 @@ macro_rules! impl_arithmetic {
+             /// ```
+             #[inline]
+             pub fn fetch_and(&self, val: $t) -> $t {
+-                #[cfg(crossbeam_loom)]
+-                {
+-                    let _ = val;
+-                    unimplemented!("loom does not support non-atomic atomic ops");
+-                }
+-                #[cfg(not(crossbeam_loom))]
+-                {
++                if can_transmute::<$t, atomic::AtomicUsize>() {
++                    let a = unsafe { &*(self.value.get() as *const atomic::AtomicUsize) };
++                    a.fetch_and(val as usize, Ordering::AcqRel) as $t
++                } else {
+                     let _guard = lock(self.value.get() as usize).write();
+                     let value = unsafe { &mut *(self.value.get()) };
+                     let old = *value;
+@@ -402,13 +393,10 @@ macro_rules! impl_arithmetic {
+             /// ```
+             #[inline]
+             pub fn fetch_or(&self, val: $t) -> $t {
+-                #[cfg(crossbeam_loom)]
+-                {
+-                    let _ = val;
+-                    unimplemented!("loom does not support non-atomic atomic ops");
+-                }
+-                #[cfg(not(crossbeam_loom))]
+-                {
++                if can_transmute::<$t, atomic::AtomicUsize>() {
++                    let a = unsafe { &*(self.value.get() as *const atomic::AtomicUsize) };
++                    a.fetch_or(val as usize, Ordering::AcqRel) as $t
++                } else {
+                     let _guard = lock(self.value.get() as usize).write();
+                     let value = unsafe { &mut *(self.value.get()) };
+                     let old = *value;
+@@ -431,13 +419,10 @@ macro_rules! impl_arithmetic {
+             /// ```
+             #[inline]
+             pub fn fetch_xor(&self, val: $t) -> $t {
+-                #[cfg(crossbeam_loom)]
+-                {
+-                    let _ = val;
+-                    unimplemented!("loom does not support non-atomic atomic ops");
+-                }
+-                #[cfg(not(crossbeam_loom))]
+-                {
++                if can_transmute::<$t, atomic::AtomicUsize>() {
++                    let a = unsafe { &*(self.value.get() as *const atomic::AtomicUsize) };
++                    a.fetch_xor(val as usize, Ordering::AcqRel) as $t
++                } else {
+                     let _guard = lock(self.value.get() as usize).write();
+                     let value = unsafe { &mut *(self.value.get()) };
+                     let old = *value;
+@@ -556,15 +541,9 @@ impl_arithmetic!(i32, atomic::AtomicI32,
+ impl_arithmetic!(u64, atomic::AtomicU64, "let a = AtomicCell::new(7u64);");
+ #[cfg(not(crossbeam_no_atomic_64))]
+ impl_arithmetic!(i64, atomic::AtomicI64, "let a = AtomicCell::new(7i64);");
+-#[cfg(crossbeam_no_atomic_64)]
+-impl_arithmetic!(u64, fallback, "let a = AtomicCell::new(7u64);");
+-#[cfg(crossbeam_no_atomic_64)]
+-impl_arithmetic!(i64, fallback, "let a = AtomicCell::new(7i64);");
+ // TODO: AtomicU128 is unstable
+ // impl_arithmetic!(u128, atomic::AtomicU128, "let a = AtomicCell::new(7u128);");
+ // impl_arithmetic!(i128, atomic::AtomicI128, "let a = AtomicCell::new(7i128);");
+-impl_arithmetic!(u128, fallback, "let a = AtomicCell::new(7u128);");
+-impl_arithmetic!(i128, fallback, "let a = AtomicCell::new(7i128);");
+ 
+ impl_arithmetic!(
+     usize,
+@@ -704,13 +683,105 @@ fn lock(addr: usize) -> &'static SeqLock
+     // stored at addresses that are multiples of 3. It'd be too bad if `LEN` was divisible by 3.
+     // In order to protect from such cases, we simply choose a large prime number for `LEN`.
+     const LEN: usize = 97;
+-    #[allow(clippy::declare_interior_mutable_const)]
+-    const L: SeqLock = SeqLock::new();
++
+     static LOCKS: [SeqLock; LEN] = [
+-        L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L,
+-        L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L,
+-        L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L,
+-        L, L, L, L, L, L, L,
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
++        SeqLock::new(),
+     ];
+ 
+     // If the modulus is a constant number, the compiler will use crazy math to transform this into
+@@ -762,6 +833,7 @@ macro_rules! atomic {
+     ($t:ty, $a:ident, $atomic_op:expr, $fallback_op:expr) => {
+         loop {
+             atomic!(@check, $t, AtomicUnit, $a, $atomic_op);
++            atomic!(@check, $t, atomic::AtomicUsize, $a, $atomic_op);
+ 
+             atomic!(@check, $t, atomic::AtomicU8, $a, $atomic_op);
+             atomic!(@check, $t, atomic::AtomicU16, $a, $atomic_op);
+@@ -783,6 +855,7 @@ macro_rules! atomic {
+ const fn atomic_is_lock_free<T>() -> bool {
+     // HACK(taiki-e): This is equivalent to `atomic! { T, _a, true, false }`, but can be used in const fn even in Rust 1.36.
+     let is_lock_free = can_transmute::<T, AtomicUnit>()
++        | can_transmute::<T, atomic::AtomicUsize>()
+         | can_transmute::<T, atomic::AtomicU8>()
+         | can_transmute::<T, atomic::AtomicU16>()
+         | can_transmute::<T, atomic::AtomicU32>();
+diff --git a/third_party/rust/crossbeam-utils/src/sync/parker.rs b/third_party/rust/crossbeam-utils/src/sync/parker.rs
+--- a/third_party/rust/crossbeam-utils/src/sync/parker.rs
++++ b/third_party/rust/crossbeam-utils/src/sync/parker.rs
+@@ -175,7 +175,6 @@ impl Parker {
+     ///
+     /// let p = Parker::new();
+     /// let raw = Parker::into_raw(p);
+-    /// # let _ = unsafe { Parker::from_raw(raw) };
+     /// ```
+     pub fn into_raw(this: Parker) -> *const () {
+         Unparker::into_raw(this.unparker)
+@@ -259,7 +258,6 @@ impl Unparker {
+     /// let p = Parker::new();
+     /// let u = p.unparker().clone();
+     /// let raw = Unparker::into_raw(u);
+-    /// # let _ = unsafe { Unparker::from_raw(raw) };
+     /// ```
+     pub fn into_raw(this: Unparker) -> *const () {
+         Arc::into_raw(this.inner) as *const ()
+diff --git a/third_party/rust/crossbeam-utils/src/thread.rs b/third_party/rust/crossbeam-utils/src/thread.rs
+--- a/third_party/rust/crossbeam-utils/src/thread.rs
++++ b/third_party/rust/crossbeam-utils/src/thread.rs
+@@ -446,7 +446,7 @@ impl<'scope, 'env> ScopedThreadBuilder<'
+                     unsafe { mem::transmute(closure) };
+ 
+                 // Finally, spawn the closure.
+-                self.builder.spawn(closure)?
++                self.builder.spawn(move || closure())?
+             };
+ 
+             let thread = handle.thread().clone();
+diff --git a/third_party/rust/crossbeam-utils/tests/atomic_cell.rs b/third_party/rust/crossbeam-utils/tests/atomic_cell.rs
+--- a/third_party/rust/crossbeam-utils/tests/atomic_cell.rs
++++ b/third_party/rust/crossbeam-utils/tests/atomic_cell.rs
+@@ -264,22 +264,3 @@ fn const_atomic_cell_new() {
+     CELL.store(1);
+     assert_eq!(CELL.load(), 1);
+ }
+-
+-// https://github.com/crossbeam-rs/crossbeam/issues/748
+-#[cfg_attr(miri, ignore)] // TODO
+-#[rustversion::since(1.37)] // #[repr(align(N))] requires Rust 1.37
+-#[test]
+-fn issue_748() {
+-    #[allow(dead_code)]
+-    #[repr(align(8))]
+-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+-    enum Test {
+-        Field(u32),
+-        FieldLess,
+-    }
+-
+-    assert_eq!(mem::size_of::<Test>(), 8);
+-    assert!(AtomicCell::<Test>::is_lock_free());
+-    let x = AtomicCell::new(Test::FieldLess);
+-    assert_eq!(x.load(), Test::FieldLess);
+-}
+diff --git a/third_party/rust/crossbeam-utils/tests/sharded_lock.rs b/third_party/rust/crossbeam-utils/tests/sharded_lock.rs
+--- a/third_party/rust/crossbeam-utils/tests/sharded_lock.rs
++++ b/third_party/rust/crossbeam-utils/tests/sharded_lock.rs
+@@ -21,9 +21,6 @@ fn smoke() {
+ #[test]
+ fn frob() {
+     const N: u32 = 10;
+-    #[cfg(miri)]
+-    const M: usize = 100;
+-    #[cfg(not(miri))]
+     const M: usize = 1000;
+ 
+     let r = Arc::new(ShardedLock::new(()));


### PR DESCRIPTION
Firefox 98+ fails to draw its window on aarch64.
Upstream: https://bugzilla.mozilla.org/show_bug.cgi?id=1757571

Also add a hack to remove the psutil version cap, since otherwise it
fails to build with the latest python-psutil version (for no reason).