### PR TITLE
core/linux-rpi to 5.15.30-2

### DIFF
--- a/core/linux-rpi/0001-Revert-usb-xhci-expand-the-scope-of-XHCI_VLI_SS_BULK.patch
+++ b/core/linux-rpi/0001-Revert-usb-xhci-expand-the-scope-of-XHCI_VLI_SS_BULK.patch
@@ -1,0 +1,58 @@
+From 67305928e52a25b19a98256c78a094925107a799 Mon Sep 17 00:00:00 2001
+From: Paul Mulders <justinkb@gmail.com>
+Date: Tue, 22 Mar 2022 08:34:37 +0100
+Subject: [PATCH] Revert "usb: xhci: expand the scope of
+ XHCI_VLI_SS_BULK_OUT_BUG"
+
+This reverts commit 40686d87f87a46b3abf48a8dcaee5e0a031deafb.
+---
+ drivers/usb/host/xhci.c | 16 +---------------
+ 1 file changed, 1 insertion(+), 15 deletions(-)
+
+diff --git a/drivers/usb/host/xhci.c b/drivers/usb/host/xhci.c
+index dc0651828f97..45dfdcdc9f30 100644
+--- a/drivers/usb/host/xhci.c
++++ b/drivers/usb/host/xhci.c
+@@ -1395,12 +1395,9 @@ static void xhci_unmap_temp_buf(struct usb_hcd *hcd, struct urb *urb)
+ static int xhci_map_urb_for_dma(struct usb_hcd *hcd, struct urb *urb,
+ 				gfp_t mem_flags)
+ {
+-	unsigned int i, maxpacket;
+-	struct scatterlist *sg;
+ 	struct xhci_hcd *xhci;
+ 
+ 	xhci = hcd_to_xhci(hcd);
+-	maxpacket = usb_endpoint_maxp(&urb->ep->desc);
+ 
+ 	if (xhci_urb_suitable_for_idt(urb))
+ 		return 0;
+@@ -1409,16 +1406,6 @@ static int xhci_map_urb_for_dma(struct usb_hcd *hcd, struct urb *urb,
+ 		if (xhci_urb_temp_buffer_required(hcd, urb))
+ 			return xhci_map_temp_buffer(hcd, urb);
+ 	}
+-
+-	if (xhci->quirks & XHCI_VLI_SS_BULK_OUT_BUG &&
+-	    usb_endpoint_is_bulk_out(&urb->ep->desc) &&
+-	    urb->dev->speed >= USB_SPEED_SUPER &&
+-	    urb->transfer_buffer_length != 0) {
+-		for_each_sg(urb->sg, sg, urb->num_sgs, i) {
+-			if (sg->length % maxpacket)
+-				return xhci_map_temp_buffer(hcd, urb);
+-		}
+-	}
+ 	return usb_hcd_map_urb_for_dma(hcd, urb, mem_flags);
+ }
+ 
+@@ -1432,8 +1419,7 @@ static void xhci_unmap_urb_for_dma(struct usb_hcd *hcd, struct urb *urb)
+ 	if (urb->num_sgs && (urb->transfer_flags & URB_DMA_MAP_SINGLE))
+ 		unmap_temp_buf = true;
+ 
+-	if ((xhci->quirks & (XHCI_SG_TRB_CACHE_SIZE_QUIRK | XHCI_VLI_SS_BULK_OUT_BUG))
+-	     && unmap_temp_buf)
++	if ((xhci->quirks & XHCI_SG_TRB_CACHE_SIZE_QUIRK) && unmap_temp_buf)
+ 		xhci_unmap_temp_buf(hcd, urb);
+ 	else
+ 		usb_hcd_unmap_urb_for_dma(hcd, urb);
+-- 
+2.35.1
+

--- a/core/linux-rpi/PKGBUILD
+++ b/core/linux-rpi/PKGBUILD
@@ -9,7 +9,7 @@ _commit=87ed6172fdf2f5502b7c9372d9402ecbb6d78178
 _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 pkgver=5.15.30
-pkgrel=1
+pkgrel=2
 pkgdesc='Linux'
 url="http://www.kernel.org/"
 arch=(armv7h aarch64)
@@ -23,6 +23,7 @@ source_aarch64=('config8' 'config8.txt')
 source=("linux-$pkgver-${_commit:0:10}.tar.gz::https://github.com/raspberrypi/linux/archive/${_commit}.tar.gz"
         cmdline.txt
         0001-Make-proc-cpuinfo-consistent-on-arm64-and-arm.patch
+        0001-Revert-usb-xhci-expand-the-scope-of-XHCI_VLI_SS_BULK.patch
         linux.preset
         60-linux.hook
         90-linux.hook
@@ -30,6 +31,7 @@ source=("linux-$pkgver-${_commit:0:10}.tar.gz::https://github.com/raspberrypi/li
 md5sums=('da2fa0b2f924898311af80b49abcec30'
          '31c02f4518d46deb5f0c2ad1f8b083cd'
          'f66a7ea3feb708d398ef57e4da4815e9'
+         '38ca384b08310045e0cd4910006065e0'
          '86d4a35722b5410e3b29fc92dae15d4b'
          '0a5f16bfec6ad982a2f6782724cca8ba'
          '441ec084c47cddc53e592fb0cbce4edf')
@@ -50,6 +52,8 @@ prepare() {
 
   # consistent behavior of lscpu on arm/arm64
   patch -Np1 -i ../0001-Make-proc-cpuinfo-consistent-on-arm64-and-arm.patch
+  # revert bad usb patch
+  patch -Np1 -i ../0001-Revert-usb-xhci-expand-the-scope-of-XHCI_VLI_SS_BULK.patch
 
   echo "Setting version..."
   scripts/setlocalversion --save-scmversion


### PR DESCRIPTION
Add patch to revert "usb: xhci: expand the scope of XHCI_VLI_SS_BULK_OUT_BUG"