### PR TITLE
extra/mesa: add rockchip_ebc support

### DIFF
--- a/extra/mesa/PKGBUILD
+++ b/extra/mesa/PKGBUILD
@@ -5,7 +5,7 @@
 # Contributor: Dan Johansen <strit@manjaro.org>
 
 # ALARM: Kevin Mihelich <kevin@archlinuxarm.org>
-#  - Removed DRI and Gallium3D drivers/packages for chipsets that don't exist in our ARM devices (intel, VMware svga).
+#  - Removed Gallium3D drivers/packages for chipsets that don't exist in our ARM devices (intel, VMware svga).
 #  - added broadcom and panfrost vulkan packages
 #  - enable lto for aarch64
 #  - add patch to fix xwayland on panfrost
@@ -15,8 +15,8 @@ highmem=1
 pkgbase=mesa
 pkgname=('vulkan-mesa-layers' 'opencl-mesa' 'vulkan-radeon' 'vulkan-swrast' 'vulkan-broadcom' 'vulkan-panfrost' 'libva-mesa-driver' 'mesa-vdpau' 'mesa')
 pkgdesc="An open-source implementation of the OpenGL specification"
-pkgver=21.3.7
-pkgrel=2
+pkgver=22.0.0
+pkgrel=1.1
 arch=('x86_64')
 makedepends=('python-mako' 'libxml2' 'libx11' 'xorgproto' 'libdrm' 'libxshmfence' 'libxxf86vm'
              'libxdamage' 'libvdpau' 'libva' 'wayland' 'wayland-protocols' 'zstd' 'elfutils' 'llvm'
@@ -26,10 +26,12 @@ url="https://www.mesa3d.org/"
 license=('custom')
 source=(https://mesa.freedesktop.org/archive/mesa-${pkgver}.tar.xz{,.sig}
         https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/15120.patch
+        https://raw.githubusercontent.com/0cc4m/pinenote-misc/main/mesa-archlinux-arm/mesa/rockchip_ebc.patch
         LICENSE)
-sha512sums=('0991543e9435457fa4d077517408b3f197be32ed61a6c7ca34ddb3906eed208791f1a57227f74115f99df18e612efab1d2c6809b7cf426d273633b53d4aefc88'
+sha512sums=('9faef66adbacba24d11dfe8e2d1a753295798883a10a7cc91e6df9d678c64a8286a12e60c0d8576d944a8cc76f00c30d27c3a71d3458bbe3dbcd66c88a454c3b'
             'SKIP'
             '591e63fee09467d5de3e5c882d0ce49785eda7975833f9bd81486b232cd1dc79ad6492f3dac813f509d47cd74eaaf4e8024041840e344a08923128023add6d08'
+            '5ab31c0fafee04b493835fc2908d50d3911d842b5f0156f7559ae04592ca87a7fe95f91ba9fb06881671818e118abed834fc68e2c472cff664f866ec014ebde7'
             'f9f0d0ccf166fe6cb684478b6f1e1ab1f2850431c06aa041738563eb1808a004e52cdec823c103c9e180f03ffc083e95974d291353f0220fe52ae6d4897fecc7')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D'  # Emil Velikov <emil.l.velikov@gmail.com>
               '946D09B5E4C9845E63075FF1D961C596A7203456'  # Andres Gomez <tanty@igalia.com>
@@ -42,6 +44,8 @@ prepare() {
   cd mesa-$pkgver
   # Fix XWayland issues on Panfrost devices
   patch -Np1 -i "${srcdir}/15120.patch"
+  # Add Rockchip EBC support from 0cc4m
+  patch -Np1 -i "${srcdir}/rockchip_ebc.patch"
 }
 
 build() {
@@ -54,7 +58,6 @@ build() {
     -D b_lto=$([[ $CARCH == aarch64 ]] && echo true || echo false) \
     -D b_ndebug=true \
     -D platforms=x11,wayland \
-    -D dri-drivers=r100,r200,nouveau \
     -D gallium-drivers=r300,r600,radeonsi,freedreno,nouveau,swrast,virgl,zink,d3d12${GALLIUM} \
     -D vulkan-drivers=amd,swrast,broadcom,panfrost \
     -D vulkan-layers=device-select,overlay \


### PR DESCRIPTION
Mesa already has a driver for the EBC interface found
in some rockchip devices, like the PineNote.
We just need to tell mesa to build it.
So add a patch from @0cc4m that does this.
Hopefully @0cc4m will upstream it to upstream Mesa.

Signed-off-by: Dan Johansen <strit@manjaro.org>