### PR TITLE
Compile jemalloc with 16 KiB page size on arm

### DIFF
--- a/extra/jemalloc/PKGBUILD
+++ b/extra/jemalloc/PKGBUILD
@@ -1,0 +1,46 @@
+# Maintainer:  Bartłomiej Piotrowski <bpiotrowski@archlinux.org>
+# Contributor: Massimiliano Torromeo <massimiliano.torromeo@gmail.com>
+# Contributor: Kovivchak Evgen <oneonfire@gmail.com>
+
+# ALARM: Hayden Seay <me@diatr.us>
+#  - build with 64 KiB page sizes on arm.
+
+pkgname=jemalloc
+epoch=1
+pkgver=5.2.1
+pkgrel=6
+pkgdesc='General-purpose scalable concurrent malloc implementation'
+arch=('x86_64')
+license=('BSD')
+url='http://www.canonware.com/jemalloc/'
+depends=('glibc')
+makedepends=('clang')
+options=('!lto')
+provides=('libjemalloc.so')
+optdepends=('perl: for jeprof')
+source=("https://github.com/jemalloc/jemalloc/releases/download/${pkgver}/${pkgname}-${pkgver}.tar.bz2")
+sha256sums=('34330e5ce276099e2e8950d9335db5a875689a4c6a56751ef3b1d8c537f887f6')
+
+build() {
+  cd $pkgname-$pkgver
+
+  # FS#71745: GCC-built jemalloc causes telegram-desktop to crash a lot. The reason is still not clear.
+  export CC=clang
+  export CXX=clang++
+
+  ./configure \
+    --enable-autogen \
+    --prefix=/usr \
+    --with-lg-page=16
+  make
+}
+
+package() {
+  cd $pkgname-$pkgver
+
+  make DESTDIR="$pkgdir" install
+
+  install -Dm644 COPYING "$pkgdir/usr/share/licenses/$pkgname/COPYING"
+  chmod 644 "$pkgdir/usr/lib/libjemalloc_pic.a"
+}
+

--- a/extra/jemalloc/PKGBUILD
+++ b/extra/jemalloc/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: Kovivchak Evgen <oneonfire@gmail.com>
 
 # ALARM: Hayden Seay <me@diatr.us>
-#  - build with 64 KiB page sizes on arm.
+#  - build with 16 KiB page sizes on arm.
 
 pkgname=jemalloc
 epoch=1
@@ -31,7 +31,7 @@ build() {
   ./configure \
     --enable-autogen \
     --prefix=/usr \
-    --with-lg-page=16
+    --with-lg-page=14
   make
 }
 


### PR DESCRIPTION
This is needed for kernels with 16 KiB page sizes (currently the kernel for the Apple M1).
This was tested on a 16 KiB kernel does not cause any functionality regression.

See the following discussion for why page size must be set higher or equal to expected:
https://github.com/jemalloc/jemalloc/issues/467#issuecomment-294383178