### PR TITLE
Enable ARMv8.5 memory tagging in glibc on aarch64

### DIFF
--- a/core/glibc/PKGBUILD
+++ b/core/glibc/PKGBUILD
@@ -16,7 +16,7 @@ noautobuild=1
 
 pkgname=glibc
 pkgver=2.35
-pkgrel=3
+pkgrel=4
 arch=(x86_64)
 url='https://www.gnu.org/software/libc'
 license=(GPL LGPL)
@@ -80,7 +80,7 @@ build() {
 
   # ALARM: Specify build host types
   [[ $CARCH == "armv7h" ]] && CONFIGFLAG="--host=armv7l-unknown-linux-gnueabihf --build=armv7l-unknown-linux-gnueabihf"
-  [[ $CARCH == "aarch64" ]] && CONFIGFLAG="--host=aarch64-unknown-linux-gnu --build=aarch64-unknown-linux-gnu"
+  [[ $CARCH == "aarch64" ]] && CONFIGFLAG="--host=aarch64-unknown-linux-gnu --build=aarch64-unknown-linux-gnu --enable-memory-tagging"
 
   echo "slibdir=/usr/lib" >> configparms
   echo "rtlddir=/usr/lib" >> configparms


### PR DESCRIPTION
This PR enables MTE support within glibc. On supported SoC's with MTE extensions (some armv8.5 SoC's and armv9 SoC's) glibc will be able to leverage MTE. This has no effect on non-MTE systems. This patch is going to be used internally at GrapheneOS to develop MTE for the hardened_malloc project, and is likely of interest to the wider community. [Debian](https://salsa.debian.org/glibc-team/glibc/-/commit/a120b72a15a6698fd05a72c17db24823602281a7) has deployed MTE support in their glibc builds in Sid for the past 6 months now.
