### PR TITLE
community/mgba dependency bug

### DIFF
--- a/community/mgba/PKGBUILD
+++ b/community/mgba/PKGBUILD
@@ -31,7 +31,7 @@ build() {
 
 package_libmgba() {
   pkgdesc='Shared library of mGBA'
-  depends=('zlib' 'libpng' 'libzip' 'libedit' 'ffmpeg' 'sqlite')
+  depends=('zlib' 'libpng' 'libzip' 'libedit' 'ffmpeg' 'sqlite' 'ffmpeg4.4')
 
   cmake -DCOMPONENT=libmgba mgba-$pkgver -DCMAKE_INSTALL_PREFIX="$pkgdir/usr" \
     -P build/cmake_install.cmake


### PR DESCRIPTION
I have come across a simple dependency issue with the libmgba package.
When installed, trying to launch either one of mgba-qt or mgba-sdl results in the following error:
`error while loading shared libraries: libavcodec.so.58: cannot open shared object file: No such file or directory`
​Installing **ffmpeg4.4** solves the issue and the two launch again as expected.
See the following screenshot
![mgbabug](https://user-images.githubusercontent.com/82055622/169297640-9712d9d6-5f33-4fe8-bbdb-21505ca31ec0.png)

I'm using manjaro arm on the pinebook pro and have verified that your package is not ahead of manjaros.
I am yet to confirm if the addition of ffmpeg4.4 makes ffmpeg obsolete, as a few of my other programms depend on it.