### PR TITLE
extra/rust: Add fix for Apple M1

### DIFF
--- a/extra/rust/PKGBUILD
+++ b/extra/rust/PKGBUILD
@@ -10,6 +10,8 @@
 #  - build v6/v7 with -j2 - RAM constraints
 #  - set llvm-config in config.toml for ARM architectures
 #  - set debuginfo-level = 0 in config.toml - RAM constraints
+# ALARM: Michael Picht <mipi@fsfe.org>
+#  - set jemalloc page size to 16K
 
 highmem=1
 
@@ -17,7 +19,7 @@ pkgbase=rust
 pkgname=(rust rust-src)
 epoch=1
 pkgver=1.61.0
-pkgrel=1
+pkgrel=1.1
 pkgdesc="Systems programming language focused on safety, speed and concurrency"
 url=https://www.rust-lang.org/
 arch=(x86_64)
@@ -142,6 +144,7 @@ _pick() {
 build() {
   cd rustc-$pkgver-src
 
+  export JEMALLOC_SYS_WITH_LG_PAGE=16
   export RUST_BACKTRACE=1
   export RUST_COMPILER_RT_ROOT="$srcdir/compiler-rt-$_llvm_ver.src"
   [[ -d $RUST_COMPILER_RT_ROOT ]]


### PR DESCRIPTION
On Apple M1, the rust package does not build.

This PR sets the page size for jemalloc to 16K (as originally [suggested](https://github.com/AsahiLinux/alarm-PKGBUILDs/commit/c2459a0ae6fc04b7fe98bb04f10795248eca949b) by @marcan). With that fix, the rust package can be built and used on Apple M1. Apart from Apple M1, I tested the fix for "standard" aarch64 and for armv7h successfully. 