### PR TITLE
linux-armv7: Fix build in git repo

### DIFF
--- a/core/linux-armv7/PKGBUILD
+++ b/core/linux-armv7/PKGBUILD
@@ -52,6 +52,7 @@ md5sums=('07321a70a48d062cebd0358132f11771'
          '3e2a512f8da5db5fe9f17875405e56a3')
 
 prepare() {
+  export GIT_CEILING_DIRECTORIES="${srcdir}"
   cd "${srcdir}/${_srcname}"
 
   # add upstream patch
@@ -76,6 +77,8 @@ prepare() {
 
   # don't run depmod on 'make install'. We'll do this ourselves in packaging
   sed -i '2iexit 0' scripts/depmod.sh
+
+  unset GIT_CEILING_DIRECTORIES
 }
 
 build() {

--- a/core/linux-armv7/PKGBUILD
+++ b/core/linux-armv7/PKGBUILD
@@ -78,6 +78,12 @@ prepare() {
   # don't run depmod on 'make install'. We'll do this ourselves in packaging
   sed -i '2iexit 0' scripts/depmod.sh
 
+  if [ ! -f "./firmware/regulatory.db" ];
+  then
+    echo "Missing regulatory.db firmware file, looks like the patches failed to apply correctly."
+    exit 101
+  fi
+
   unset GIT_CEILING_DIRECTORIES
 }
 


### PR DESCRIPTION
The `PKGBUILD` uses [`git apply`](https://git-scm.com/docs/git-apply) as a glorified [`GNU patch`](https://man7.org/linux/man-pages/man1/patch.1.html), which works fine if you are not in a git repository since the file-paths in the patch file are interpreted relative to the current working directory. But it breaks horribly and in some cases even silently if you are *somewhere* in a git repo, because the paths in the patch are then interpreted relative to the git repo root.
I am not going to argue about the use of `git apply` here, but will assume there are reasons for it and not touch it. But I am not [the first](https://archlinuxarm.org/forum/viewtopic.php?f=60&t=15933) and probably not the last that runs into this (undocumented?) restriction. And in my eyes it is quiet a reasonable use-case to clone this very git repo, and be able to build packages directly from it.
By setting the [`GIT_CEILING_DIRECTORIES`](https://git-scm.com/docs/git#Documentation/git.txt-codeGITCEILINGDIRECTORIEScode) env var, you can "confine" git to a specific directory so it won't be able to detect any maybe existing git repo further up in the file-tree, and thus make it always work in the simple "GNU patch" mode. It is "only" set to `$srcdir` because you need one directory in between for it to work. It is scoped to the `package` function by unsetting it at the end.
Alternatively you could specify the `--directory` flag on every `git apply` invocation, but the one-stop-shop env var seemed more practical to me.

Just from a quick look there are other packages that suffer from the same `git apply` usage, this solution should work for them too.

## (Optional) Add firmware failsafe check
A simple assertion at the end of the `package` function to exemplary check the existence of one of the firmware files which are added with a patch. If that patch is not applied correctly, that file is missing and the kernel build will later fail. All this really does is catch an obvious error early.
The exit code was arbitrarily chosen just so it is unique.

I left this commit in since I had it and used it to test the solution above, but it is optional and can easily be omitted/removed.