### PR TITLE
[openblas] fix broken symlinks on aarch64

### DIFF
--- a/community/openblas/PKGBUILD
+++ b/community/openblas/PKGBUILD
@@ -8,7 +8,7 @@
 pkgname=openblas
 _pkgname=OpenBLAS
 pkgver=0.3.20
-pkgrel=1
+pkgrel=2
 pkgdesc="An optimized BLAS library based on GotoBLAS2 1.13 BSD"
 arch=('x86_64')
 url="https://www.openblas.net/"
@@ -47,8 +47,15 @@ package() {
   install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 
   cd "$pkgdir"/usr/lib/
-  ln -s libopenblasp-r$pkgver.so libblas.so
-  ln -s libopenblasp-r$pkgver.so libblas.so.3
+
+  # Try to get the link target from the library linked during "make install"
+  # fall back to the default if this fails (but the default won't work on aarch64)
+  local link_target=$(readlink "libopenblas.so.3")
+  [[ -e ${link_target} ]] || link_target="libopenblas-r${pkgver}.so"
+
+  ln -s ${link_target} libblas.so
+  ln -s ${link_target} libblas.so.3
+
   sed -i -e "s%$pkgdir%%" "$pkgdir"/usr/lib/cmake/openblas/OpenBLASConfig.cmake
   sed -i -e "s%$pkgdir%%" "$pkgdir"/usr/lib/pkgconfig/openblas.pc
   ln -s openblas.pc "$pkgdir"/usr/lib/pkgconfig/blas.pc


### PR DESCRIPTION
This is a fix for the broken symlinks created when building the package for `aarch64`.

The upstream PKGBUILD links against `libopenblasp-r0.3.20.so`, which doesn't exists in the `aarch64` build.
Instead the library is called `libopenblasp_armv8p-r0.3.20.so` on `aarch64`.

This patch uses the symlink `libopenblas.so.3` that is created by `make install` to determine the correct library to link against.