### PR TITLE
added community/earlyoom

### DIFF
--- a/community/earlyoom/PKGBUILD
+++ b/community/earlyoom/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Massimiliano Torromeo <massimiliano.torromeo@gmail.com>
+# Maintainer: Maxim Baz <$pkgname at maximbaz dot com>
+
+# ALARM: Maxim Baz <$pkgname at maximbaz dot com>
+#  - remove makedepend on pandoc
+
+pkgname=earlyoom
+pkgver=1.7
+pkgrel=1
+pkgdesc="Early OOM Daemon for Linux"
+arch=('x86_64')
+url="https://github.com/rfjakob/earlyoom"
+license=('MIT')
+depends=('glibc')
+optdepends=('systembus-notify: desktop notifications')
+backup=("etc/default/earlyoom")
+source=("https://github.com/rfjakob/$pkgname/archive/v$pkgver/$pkgname-$pkgver.tar.gz")
+sha256sums=('ebda1279a813d9b0f7860ce5029ccf5ea9f8868be070f2eaf40f90f2e64b6414')
+
+prepare() {
+    cd "$pkgname-$pkgver"
+    sed "/systemctl|chcon/d" -ri Makefile
+    sed '/^DynamicUser=/a SupplementaryGroups=proc' -i earlyoom.service.in
+    sed 's;^EARLYOOM_ARGS="(.*)";EARLYOOM_ARGS="\1 -n --avoid '\''(^|/)(init|systemd|Xorg|sshd)$'\''";' -ri earlyoom.default
+}
+
+build() {
+    cd "$pkgname-$pkgver"
+    make PREFIX=/usr SYSTEMDUNITDIR=/usr/lib/systemd/system VERSION=$pkgver earlyoom
+}
+
+package() {
+    cd "$pkgname-$pkgver"
+    make install DESTDIR="$pkgdir" PREFIX=/usr SYSTEMDUNITDIR=/usr/lib/systemd/system
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}


### PR DESCRIPTION
Hello, I'm going through the packages I maintain to make sure as many of them can also be built for ARM.

This one optionally depends on `pandoc`, thus the only change.

I also made some changes directly in Arch [community] to `wldash` and `kubernetes` (`kube-apiserver` `kube-controller-manager` `kube-proxy` `kube-scheduler` `kubeadm` `kubectl` `kubelet` `kubernetes-control-plane-common`) that let them compile successfully on ARM (those changes are trivial, don't hurt to have in main repos, and release some maintenance burden from you), would those be automatically picked up and compiled for ALARM?