### PR TITLE
devtools-alarm: Add ARM chroot helpers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 * **Detailed description.** The body of the PR must contain a detailed description of what changes are being introduced, and most importantly, *why* this PR should be merged.
 * **One package per request.** PRs must be for a single package only.  A PR addressing multiple packages without merit risks having a delayed merge or being closed.
 * **Squash commits.** Your commits must be meaningful. If you make incremental changes or fixes, they must [be squashed](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Squashing-Commits) before the pull request will be merged.
-* **Check that your changes build.** Your submission must build using the [clean chroot](https://wiki.archlinux.org/index.php/DeveloperWiki:Building_in_a_Clean_Chroot) method on *all* supported architectures that the package is to be built for.  No exceptions.
+* **Check that your changes build.** Your submission must build using the [clean chroot](https://wiki.archlinux.org/index.php/DeveloperWiki:Building_in_a_Clean_Chroot) method (e.g. using `extra-*-build` helpers from `devtools-alarm`) on *all* supported architectures that the package is to be built for.  No exceptions.
 * **Work within one PR.** Do not close a PR and open another with new changes.  Amend your commit and force push to your branch to update the changes in the pull request.
 * Ensure your PR addresses three of the most common problems:
   * Correctly update the pkgver or pkgrel of the package (see below).

--- a/alarm/devtools-alarm/0009-Makefile-arm-helpers.patch
+++ b/alarm/devtools-alarm/0009-Makefile-arm-helpers.patch
@@ -1,0 +1,29 @@
+--- a/Makefile
++++ b/Makefile
+@@ -28,6 +28,8 @@ BINPROGS = \
+ 	$(IN_PROGS)
+ 
+ CONFIGFILES = \
++	makepkg-aarch64.conf \
++	makepkg-armv7h.conf \
+ 	makepkg-x86_64.conf \
+ 	makepkg-x86_64_v3.conf \
+ 	pacman-extra.conf \
+@@ -59,10 +61,16 @@ COMMITPKG_LINKS = \
+ 	gnome-unstablepkg
+ 
+ ARCHBUILD_LINKS = \
++	extra-aarch64-build \
++	extra-armv7h-build \
+ 	extra-x86_64-build \
+ 	extra-x86_64_v3-build \
++	testing-aarch64-build \
++	testing-armv7h-build \
+ 	testing-x86_64-build \
+ 	testing-x86_64_v3-build \
++	staging-aarch64-build \
++	staging-armv7h-build \
+ 	staging-x86_64-build \
+ 	staging-x86_64_v3-build \
+ 	multilib-build \
+

--- a/alarm/devtools-alarm/0010-makepkg-aarch64-conf.patch
+++ b/alarm/devtools-alarm/0010-makepkg-aarch64-conf.patch
@@ -1,0 +1,22 @@
+--- a/makepkg-x86_64.conf
++++ b/makepkg-aarch64.conf
+@@ -35,14 +35,14 @@ VCSCLIENTS=('bzr::bzr'
+ # ARCHITECTURE, COMPILE FLAGS
+ #########################################################################
+ #
+-CARCH="x86_64"
+-CHOST="x86_64-pc-linux-gnu"
++CARCH="aarch64"
++CHOST="aarch64-unknown-linux-gnu"
+
+ #-- Compiler and Linker Flags
+ #CPPFLAGS=""
+-CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions \
++CFLAGS="-march=armv8-a -O2 -pipe -fstack-protector-strong -fno-plt -fexceptions \
+         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security \
+-        -fstack-clash-protection -fcf-protection"
++        -fstack-clash-protection"
+ CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS"
+ LDFLAGS="-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now"
+ LTOFLAGS="-flto=auto"
+

--- a/alarm/devtools-alarm/0011-makepkg-armv7h-conf.patch
+++ b/alarm/devtools-alarm/0011-makepkg-armv7h-conf.patch
@@ -1,0 +1,22 @@
+--- a/makepkg-x86_64.conf
++++ b/makepkg-armv7h.conf
+@@ -35,14 +35,14 @@ VCSCLIENTS=('bzr::bzr'
+ # ARCHITECTURE, COMPILE FLAGS
+ #########################################################################
+ #
+-CARCH="x86_64"
+-CHOST="x86_64-pc-linux-gnu"
++CARCH="armv7h"
++CHOST="armv7l-unknown-linux-gnueabihf"
+ 
+ #-- Compiler and Linker Flags
+ #CPPFLAGS=""
+-CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions \
++CFLAGS="-march=armv7-a -mfloat-abi=hard -mfpu=neon -O2 -pipe -fstack-protector-strong -fno-plt -fexceptions \
+         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security \
+-        -fstack-clash-protection -fcf-protection"
++        -fstack-clash-protection"
+ CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS"
+ LDFLAGS="-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now"
+ LTOFLAGS="-flto=auto"
+

--- a/alarm/devtools-alarm/PKGBUILD
+++ b/alarm/devtools-alarm/PKGBUILD
@@ -3,11 +3,13 @@
 
 # ALARM: Kevin Mihelich <kevin@archlinuxarm.org>
 #  - patches to fix issues with how we use the tools
+# ALARM: Maxim Baz <archlinux at maximbaz dot com>
+#  - add ARM-specific helpers to build in clean chroot with recommended flags
 
 pkgname=devtools-alarm
 _pkgname=devtools
 pkgver=20220621
-pkgrel=1
+pkgrel=2
 pkgdesc='Tools for Arch Linux ARM package maintainers'
 arch=('any')
 license=('GPL')
@@ -27,7 +29,10 @@ source=(${url}/uploads/8217baae0afcdb540bde9f5b030f05a9/devtools-${pkgver}.tar.g
         '0005-makechrootpkg-no-default-logging.patch'
         '0006-archbuild-no-setarch.patch'
         '0007-makechrootpkg-don-t-delete-MAKEFLAGS-and-PACKAGER.patch'
-        '0008-makechrootpkg-gotmpdir.patch')
+        '0008-makechrootpkg-gotmpdir.patch'
+        '0009-Makefile-arm-helpers.patch'
+        '0010-makepkg-aarch64-conf.patch' 
+        '0011-makepkg-armv7h-conf.patch')
 validpgpkeys=(
   '4AA4767BBC9C4B1D18AE28B77F2D434B9741E8AC' # Pierre Schmitz <pierre@archlinux.org>
   '86CFFCA918CF3AF47147588051E8B148A9999C34' # Evangelos Foutras <foutrelis@archlinux.org>
@@ -46,7 +51,10 @@ sha256sums=('0938d41b4bc469e62d86d2a287612a090640f6eebde92137b8bd7727b89e95dd'
             '1d6f17cc9c77690bdd007e276da52a6acf54b52dbe081ce6c6767a3fa1b5b113'
             '2f68d22a0c04fe6a47266a9e2b68b90b092be6ab5888686609fd85b19ed8c5b3'
             '3b6d1b20d5145d13c8d8b8fd4a6555034579067dcb768ea574e29bfb7101fb09'
-            '1162044b55ebf6cbec81da94dd1d85e48657311f03e322f3a17dc22e060b54a1')
+            '1162044b55ebf6cbec81da94dd1d85e48657311f03e322f3a17dc22e060b54a1'
+            '5b2fac46c1a0834573f35a6ba3d10246c7fd5778b1cb8ce1f631afbc178e7501'
+            'bdc10f991544b824577199d04c8f9457efd99c1543e6f00134f11cddea198d9b'
+            '8cb082ca41abd01a5c8ede7dff800ae90e3b1f8704e83efa431b8c43711a3cc9')
 b2sums=('007f62b6cb3f06904fcafec4869a43136643bd364a7f0f314c792c08fbdafafaf8a268f8a372f78402deaa1f87bfc3f2fc7099f78742c6776d4ac49fe4884d58'
         'SKIP'
         '1d1a9c5ea3279dc0bae47265f5068b6fae2de63c6f81cba0a713b36b84ddb60f5e982f5e3acc21dd2316fbf9b756036091c51545f1fa1a623628e72bbe2b717d'
@@ -56,7 +64,10 @@ b2sums=('007f62b6cb3f06904fcafec4869a43136643bd364a7f0f314c792c08fbdafafaf8a268f
         '8a672b6debaac19baf2189acbb72b027860bf6d16306feb8d93f48c5ef32f5d073a618a04c65ed645f47d46332b0cead282b63950b2dab0efcab23b38cc61dc8'
         'd796e4c6c8522889d803fe6ee6f52cec548e34db28bb2aeb7a62d7d3cb5e357692d83292d6b51045bc799e3f1ce985583b905b0dd9d2b22cfbdd430e6a60f5c8'
         '9003b89871dcb20f36991a28a3095762191ed9101283504a3a986e38d1b9f207a5db6d7500f047ee40dea6fe17a21a56a94aba5816ad686490d7534cdf77b715'
-        '66b23af5326e0031657f2499ae004cf922b71623798f885d7c777fa1cf44172db2ae05d7128bb932df3f3f2a7c47b418d428687c9f149c2d0b487ec6bd68571e')
+        '66b23af5326e0031657f2499ae004cf922b71623798f885d7c777fa1cf44172db2ae05d7128bb932df3f3f2a7c47b418d428687c9f149c2d0b487ec6bd68571e'
+        'cd540a1e5bc397174c21b1d6308dca0822eafb1cf4c11dd8de1676388f7aa88e8722aa2b91f43ac958c5674dda1f8bf5517373649d40731b3c03bdcefe9208b4'
+        '97b65915cb2e9dc04378a1788d5b19d9aad7afc8632d739265a48935ec676684835cf02e16ee7ace3a31316fc4e49abe956de7cbe804c6afc24bb75c831a7577'
+        '5345ba473a52154cb39e2a6d3f6d1a7ca19bf48884d806168a9c265764ad42ff330d7a32090a888d30029a9ea6682d52f6ccbb490bd015bb1bc28440e62095bf')
 
 prepare() {
   cd "${_pkgname}-${pkgver}"
@@ -68,6 +79,9 @@ prepare() {
   patch -p1 -i ../0006-archbuild-no-setarch.patch
   patch -p1 -i ../0007-makechrootpkg-don-t-delete-MAKEFLAGS-and-PACKAGER.patch
   patch -p1 -i ../0008-makechrootpkg-gotmpdir.patch
+  patch -p1 -i ../0009-Makefile-arm-helpers.patch
+  patch -p1 -i ../0010-makepkg-aarch64-conf.patch -o makepkg-aarch64.conf
+  patch -p1 -i ../0011-makepkg-armv7h-conf.patch -o makepkg-armv7h.conf
 }
 
 build() {


### PR DESCRIPTION
New makepkg-*.conf files contain compiler flags that you use to build packages today.

New extra-*-build symlinks make it simpler to build packages in chroot, taking care of:
  - creating chroot using proper makepkg config
  - updating chroot
  - building package