### PR TITLE
core/grub: Increase heap size

### DIFF
--- a/core/grub/0004-increase-heap-size.patch
+++ b/core/grub/0004-increase-heap-size.patch
@@ -1,0 +1,12 @@
+diff -urN grub/grub-core/kern/efi/mm.c grub/grub-core/kern/efi/mm.c
+--- grub/grub-core/kern/efi/mm.c	2022-08-20 20:17:23.975902981 +0900
++++ grub/grub-core/kern/efi/mm.c	2022-08-20 20:17:16.268139945 +0900
+@@ -39,7 +39,7 @@
+ #define MEMORY_MAP_SIZE	0x3000
+ 
+ /* The default heap size for GRUB itself in bytes.  */
+-#define DEFAULT_HEAP_SIZE	0x100000
++#define DEFAULT_HEAP_SIZE	0x200000
+ 
+ static void *finish_mmap_buf = 0;
+ static grub_efi_uintn_t finish_mmap_size = 0;

--- a/core/grub/PKGBUILD
+++ b/core/grub/PKGBUILD
@@ -32,7 +32,7 @@ _commit='0c6c1aff2a86a69ae74e1207bca2ff95303cbf43'
 _pkgver=2.06.r297.g0c6c1aff2
 _unifont_ver='14.0.04'
 pkgver=${_pkgver/-/}
-pkgrel=1
+pkgrel=2
 url='https://www.gnu.org/software/grub/'
 arch=('x86_64')
 license=('GPL3')
@@ -73,6 +73,7 @@ source=("git+https://git.savannah.gnu.org/git/grub.git#commit=${_commit}"
         '0001-00_header-add-GRUB_COLOR_-variables.patch'
         '0002-10_linux-detect-archlinux-initramfs.patch'
         '0003-10_linux-add-archlinuxarm-s-default-kernel-path.patch'
+        '0004-increase-heap-size.patch'
         'grub.default'
         'sbat.csv')
 
@@ -83,6 +84,7 @@ sha256sums=('SKIP'
             '5dee6628c48eef79812bb9e86ee772068d85e7fcebbd2b2b8d1e19d24eda9dab'
             '8488aec30a93e8fe66c23ef8c23aefda39c38389530e9e73ba3fbcc8315d244d'
             'bfa56cc7cb2e1650fcd19ecfe5b8d2d0aa7bbc4266a0a5fb1e5d4f60e4a7fa56'
+            '7da44c856a5c8295f82fa3c583dab52fc5f369dc12fea95cc9e63f9e18500fdf'
             'c17bf255a41103f6b71a1710afc7e9addaebc578bcf51a48845e227b2f651682'
             '98b23d41e223bdc0a6e20bdcb3aa77e642f29b64081b1fd2f575314172fc89df')
 
@@ -132,6 +134,9 @@ prepare() {
 
 	echo "Patch to detect of Arch Linux ARM kernel images by grub-mkconfig..."
         patch -Np1 -i "${srcdir}/0003-10_linux-add-archlinuxarm-s-default-kernel-path.patch"
+
+	echo "Patch to increase heap size..."
+        patch -Np1 -i "${srcdir}/0004-increase-heap-size.patch"
 
 	echo "Fix DejaVuSans.ttf location so that grub-mkfont can create *.pf2 files for starfield theme..."
 	sed 's|/usr/share/fonts/dejavu|/usr/share/fonts/dejavu /usr/share/fonts/TTF|g' -i "configure.ac"


### PR DESCRIPTION
The latest update started running out of heap when initializing graphics on Apple M1 systems, breaking the boot menu.

It seems the default heap size is 1MB. Bumping it to 2MB fixes the problem.

Upstream bug: https://savannah.gnu.org/bugs/index.php?62925