### PR TITLE
extra/mesa: Enable SVGA gallium driver for aarch64

### DIFF
--- a/extra/mesa/PKGBUILD
+++ b/extra/mesa/PKGBUILD
@@ -44,7 +44,7 @@ prepare() {
 build() {
   case "${CARCH}" in
     armv7h)  GALLIUM=",etnaviv,kmsro,lima,panfrost,tegra,v3d,vc4" ;;
-    aarch64) GALLIUM=",etnaviv,kmsro,lima,panfrost,v3d,vc4" ;;
+    aarch64) GALLIUM=",etnaviv,kmsro,lima,panfrost,svga,v3d,vc4" ;;
   esac
 
   # Build only minimal debug info to reduce size


### PR DESCRIPTION
This driver is also available for the AARCH64 architecture and allows it to run a 3D accelerated Arch Linux ARM with VMware Fusion (currently Public Tech Preview 22H2).