### PR TITLE
added alarm/amzn-ena-aarch64-dkms

### DIFF
--- a/alarm/amzn-ena-aarch64-dkms/PKGBUILD
+++ b/alarm/amzn-ena-aarch64-dkms/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer: iDigitalFlame <idf@idfla.me>
+pkgname="amzn-ena-aarch64-dkms"
+pkgver="2.7.4"
+pkgrel="1"
+pkgdesc="Linux kernel driver for Amazon's Elastic Network Adapter (ENA)"
+arch=("aarch64")
+url="https://github.com/amzn/amzn-drivers"
+license=("GPL")
+depends=("git" "dkms" "curl" "linux-aarch64-headers")
+install="amzn-drivers.install"
+source=("git+https://github.com/amzn/amzn-drivers.git"
+        "https://github.com/amzn/amzn-drivers/files/9392177/0001-fix-bpf_warn_invalid_xdp_action-compilation-error.patch.txt")
+sha256sums=("SKIP"
+            "SKIP")
+buildarch=8
+
+build() {
+    cd "$srcdir/amzn-drivers"
+    # Have to do this so the "am" command completes
+    git config --local user.email "you@example.com"
+    git config --local user.name "Your Name"
+    git am "$srcdir/0001-fix-bpf_warn_invalid_xdp_action-compilation-error.patch.txt"
+}
+
+package() {
+    mkdir -p "${pkgdir}/usr/src" 2> /dev/null
+    cp -R "${srcdir}/amzn-drivers/kernel/linux" "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}"
+    printf 'PACKAGE_NAME="ena"\n' > "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"
+    printf 'PACKAGE_VERSION='\"${pkgver}\"'\n' >> "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"
+    printf 'CLEAN="make -C ena clean"\n' >> "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"
+    printf 'MAKE="make -C ena/ BUILD_KERNEL=$(uname -r)"\n' >> "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"
+    printf 'BUILT_MODULE_NAME[0]="ena"\n' >> "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"
+    printf 'BUILT_MODULE_LOCATION="ena"\n' >> "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"
+    printf 'DEST_MODULE_LOCATION[0]="/updates"\n'>> "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"
+    printf 'DEST_MODULE_NAME[0]="ena"\n' >> "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"
+    printf 'AUTOINSTALL="yes"\n' >> "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"
+}

--- a/alarm/amzn-ena-aarch64-dkms/amzn-drivers.install
+++ b/alarm/amzn-ena-aarch64-dkms/amzn-drivers.install
@@ -1,0 +1,17 @@
+post_install() {
+    dkms add -m amzn-drivers -v $1
+    dkms build -m amzn-drivers -v $1
+    dkms install -m amzn-drivers -v $1
+    depmod
+    printf 'Make sure to add "ena" to the "mkinitcpio.conf" "MODULES" section'
+    printf ' and rebuild the intramfs with "mkinitcpio -P"\n'
+}
+
+post_upgrade() {
+    dkms uninstall -m amzn-drivers -v $2
+    dkms remove -m amzn-drivers -v $2
+    dkms add -m amzn-drivers -v $1
+    dkms build -m amzn-drivers -v $1
+    dkms install -m amzn-drivers -v $1
+    depmod
+}


### PR DESCRIPTION
This pull request adds the amzn-ena-aarch64-dkms PKGBUILD.

This package allows for adding and building the Amazon ENA (Elastic Network Adapter) driver for Gravaton ARM64 instances. Without this driver, ArchLinux ARM instances on AWS do NOT have network connectivity. This package adds the DKMS module to add the driver (since no mainline Arch kernels have support for it).
This package would allow users to build AWS ArchLinuxARM instances without having to manually fetch and build the driver themselves.

Amazon driver source is [here: github.com/amzn/amzn-drivers](https://github.com/amzn/amzn-drivers)

- Package Build tested
- Tested Build in a Clean Chroot
- Tested in an AWS ArchLinuxARM instance

Added this into the "alarm" directory as it is aarch64 specific and is not in any core/extra repos (buildarch is 8).

Thanks!