### PR TITLE
alarm/amzn-ena-aarch64-dkms to 2.7.4-2

### DIFF
--- a/alarm/amzn-ena-aarch64-dkms/PKGBUILD
+++ b/alarm/amzn-ena-aarch64-dkms/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: iDigitalFlame <idf@idfla.me>
 pkgname="amzn-ena-aarch64-dkms"
 pkgver="2.7.4"
-pkgrel="1"
+pkgrel="2"
 pkgdesc="Linux kernel driver for Amazon's Elastic Network Adapter (ENA)"
 arch=("aarch64")
 url="https://github.com/amzn/amzn-drivers"
@@ -28,7 +28,7 @@ package() {
     printf 'PACKAGE_NAME="ena"\n' > "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"
     printf 'PACKAGE_VERSION='\"${pkgver}\"'\n' >> "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"
     printf 'CLEAN="make -C ena clean"\n' >> "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"
-    printf 'MAKE="make -C ena/ BUILD_KERNEL=$(uname -r)"\n' >> "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"
+    printf 'MAKE="make -C ena/ BUILD_KERNEL=$kernelver"\n' >> "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"
     printf 'BUILT_MODULE_NAME[0]="ena"\n' >> "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"
     printf 'BUILT_MODULE_LOCATION="ena"\n' >> "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"
     printf 'DEST_MODULE_LOCATION[0]="/updates"\n'>> "${pkgdir}/usr/src/amzn-drivers-${pkgver}-${pkgrel}/dkms.conf"


### PR DESCRIPTION
Update to replace the "$(uname -r)" in dkms.conf with "$kernelver" to comply with the DKMS specification and guidelines ([here](https://wiki.archlinux.org/title/DKMS_package_guidelines)).

Explanation of "$kernelver" [here](https://linux.die.net/man/8/dkms)

- Package Build tested
- Tested Build in a Clean Chroot
- Tested in an AWS ArchLinuxARM instance

Package "pkgrel" updated to "2".

Thanks!