### PR TITLE
added community/fd

### DIFF
--- a/community/fd/PKGBUILD
+++ b/community/fd/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Sven-Hendrik Haase <svenstaro@archlinux.org>
+# Maintainer: Maxim Baz <$pkgname at maximbaz dot com>
+# Contributor: Daniel M. Capella <polyzen@archlinux.info>
+
+# ALARM:
+# - compile on aarch64 with JEMALLOC_SYS_WITH_LG_PAGE=16 to support
+#   systems with 16k or 64k page size
+
+pkgname=fd
+pkgver=8.4.0
+pkgrel=1.1
+pkgdesc='Simple, fast and user-friendly alternative to find'
+arch=('x86_64')
+url=https://github.com/sharkdp/fd
+license=('MIT' 'APACHE')
+depends=('gcc-libs')
+makedepends=('rust')
+source=("fd-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
+sha512sums=('467d8cb66398d247e0849228cfe7ebf70f8a7758e126a048f7f34dcd45b0d69d3ff4afc903092dc7d17f42c7b9029e92e88acfc1cbe282857a733a355804bc1c')
+
+build() {
+  cd fd-$pkgver
+  [[ $CARCH == "aarch64" ]] && export JEMALLOC_SYS_WITH_LG_PAGE=16
+  export CFLAGS+=" -ffat-lto-objects"
+  cargo build --release --locked
+}
+
+check() {
+  cd fd-$pkgver
+  cargo test --release --locked
+}
+
+package() {
+  cd fd-$pkgver
+  install -Dm755 target/release/fd "$pkgdir"/usr/bin/fd
+  install -Dm644 target/release/build/fd-find-*/out/fd.bash "$pkgdir"/usr/share/bash-completion/completions/fd
+  install -Dm644 target/release/build/fd-find-*/out/fd.fish "$pkgdir"/usr/share/fish/vendor_completions.d/fd.fish
+  install -Dm644 contrib/completion/_fd "$pkgdir"/usr/share/zsh/site-functions/_fd
+  install -Dm644 doc/fd.1 "$pkgdir"/usr/share/man/man1/fd.1
+  install -Dm644 LICENSE-APACHE "$pkgdir"/usr/share/licenses/fd/LICENSE-APACHE
+  install -Dm644 LICENSE-MIT "$pkgdir"/usr/share/licenses/fd/LICENSE-MIT
+}
+
+# vim:set ts=2 sw=2 et:


### PR DESCRIPTION
fd uses jemalloc. jemalloc uses the build system's page size as internal page size and fails if the target's page size is larger (1). Configure the largest possible page size to support every aarch64 system.

1: https://github.com/jemalloc/jemalloc/issues/467

Signed-off-by: Janne Grunau <j@jannau.net>