### PR TITLE
glibc: avoid SIGBUS due to unaligned access

### DIFF
--- a/core/glibc/PKGBUILD
+++ b/core/glibc/PKGBUILD
@@ -17,7 +17,7 @@ noautobuild=1
 pkgname=glibc
 pkgver=2.36
 _commit=645d94808aaa90fb1b20a25ff70bb50d9eb1d55b
-pkgrel=4
+pkgrel=5
 arch=(x86_64)
 url='https://www.gnu.org/software/libc'
 license=(GPL LGPL)
@@ -74,6 +74,9 @@ build() {
   echo "rtlddir=/usr/lib" >> configparms
   echo "sbindir=/usr/bin" >> configparms
   echo "rootsbindir=/usr/bin" >> configparms
+
+  # Avoid SIGBUS due to unaligned access.
+  [[ $CARCH == "armv7h" ]] && CFLAGS="${CFLAGS} -mno-unaligned-access"
 
   # Credits @allanmcrae
   # https://github.com/allanmcrae/toolchain/blob/f18604d70c5933c31b51a320978711e4e6791cf1/glibc/PKGBUILD


### PR DESCRIPTION
A recent upgrade crashes software that is using `glibc` when calling `vsnprintf()` due to a `SIGBUS` signal. The signal happens on ARMv7-A due to an unaligned load into NEON registers, which the kernel does **not** fix.

The crash happens in `_IO_str_init_static_internal()`, whose instructions follow:

```asm
000767a8 <_IO_str_init_static_internal>:
 767a8:       e92d40f0        push    {r4, r5, r6, r7, lr}
 767ac:       e3a0ca01        mov     ip, #4096       ; 0x1000
 767b0:       e04dc00c        sub     ip, sp, ip
 767b4:       e58c0fd8        str     r0, [ip, #4056] ; 0xfd8
 767b8:       e1a05001        mov     r5, r1
 767bc:       e24dd014        sub     sp, sp, #20
 767c0:       e1a06000        mov     r6, r0
 767c4:       e1a07003        mov     r7, r3
 767c8:       e2521000        subs    r1, r2, #0
 767cc:       1a000018        bne     76834 <_IO_str_init_static_internal+0x8c>
 767d0:       e1a00005        mov     r0, r5
 767d4:       eb008131        bl      96ca0 <__rawmemchr>
 767d8:       e1a04000        mov     r4, r0
 767dc:       e1a01005        mov     r1, r5
 767e0:       e1a02004        mov     r2, r4
 767e4:       e3a03000        mov     r3, #0
 767e8:       e1a00006        mov     r0, r6
 767ec:       ebfff91a        bl      74c5c <_IO_setb>
 767f0:       e3570000        cmp     r7, #0
 767f4:       01a07004        moveq   r7, r4
 767f8:       e88d00a0        stm     sp, {r5, r7}
 767fc:       e58d5008        str     r5, [sp, #8]
 76800:       e2862004        add     r2, r6, #4
 76804:       e58d500c        str     r5, [sp, #12]
 76808:       01a01005        moveq   r1, r5
 7680c:       f46d0adf        vld1.64 {d16-d17}, [sp :64]
 76810:       01a04005        moveq   r4, r5
 76814:       11a01007        movne   r1, r7
 76818:       e3a03000        mov     r3, #0
 7681c:       e5861014        str     r1, [r6, #20]
 76820:       e5864018        str     r4, [r6, #24]
 76824:       f4420a8f        vst1.32 {d16-d17}, [r2]
 76828:       e58630a0        str     r3, [r6, #160]  ; 0xa0
 7682c:       e28dd014        add     sp, sp, #20
 76830:       e8bd80f0        pop     {r4, r5, r6, r7, pc}
 76834:       e0852001        add     r2, r5, r1
 76838:       e1550002        cmp     r5, r2
 7683c:       31a04002        movcc   r4, r2
 76840:       23e04000        mvncs   r4, #0
 76844:       eaffffe4        b       767dc <_IO_str_init_static_internal+0x34>
```

The issue happens because the following instruction performs an unaligned load (which is **not** fixed by the kernel).

```asm
vld1.64 {d16-d17}, [sp :64]
```

The `SP` register happens to contain an address that is only aligned to 4 bytes, but the `vld1.64` instruction requires 8 bytes alignment.

After adding the `-mno-unaligned-access` to the C compiler flags when building for ARMv7, the code generated for `_IO_str_init_static_internal()` is now correct:

```asm
00077384 <_IO_str_init_static_internal>:
   77384:       e92d41f0        push    {r4, r5, r6, r7, r8, lr}
   77388:       e3a0ca01        mov     ip, #4096       ; 0x1000
   7738c:       e04dc00c        sub     ip, sp, ip
   77390:       e58c0fe8        str     r0, [ip, #4072] ; 0xfe8
   77394:       e1a06001        mov     r6, r1
   77398:       e1a05000        mov     r5, r0
   7739c:       e1a07003        mov     r7, r3
   773a0:       e2521000        subs    r1, r2, #0
   773a4:       1a000015        bne     77400 <_IO_str_init_static_internal+0x7c>
   773a8:       e1a00006        mov     r0, r6
   773ac:       eb007a0b        bl      95be0 <__rawmemchr>
   773b0:       e1a04000        mov     r4, r0
   773b4:       e1a02004        mov     r2, r4
   773b8:       e3a03000        mov     r3, #0
   773bc:       e1a01006        mov     r1, r6
   773c0:       e1a00005        mov     r0, r5
   773c4:       ebfff922        bl      75854 <_IO_setb>
   773c8:       e3570000        cmp     r7, #0
   773cc:       01a07004        moveq   r7, r4
   773d0:       01a02006        moveq   r2, r6
   773d4:       01a04006        moveq   r4, r6
   773d8:       11a02007        movne   r2, r7
   773dc:       e3a03000        mov     r3, #0
   773e0:       e5856010        str     r6, [r5, #16]
   773e4:       e585600c        str     r6, [r5, #12]
   773e8:       e5856004        str     r6, [r5, #4]
   773ec:       e5852014        str     r2, [r5, #20]
   773f0:       e5854018        str     r4, [r5, #24]
   773f4:       e5857008        str     r7, [r5, #8]
   773f8:       e58530a0        str     r3, [r5, #160]  ; 0xa0
   773fc:       e8bd81f0        pop     {r4, r5, r6, r7, r8, pc}
   77400:       e0862001        add     r2, r6, r1
   77404:       e1560002        cmp     r6, r2
   77408:       31a04002        movcc   r4, r2
   7740c:       23e04000        mvncs   r4, #0
   77410:       eaffffe7        b       773b4 <_IO_str_init_static_internal+0x30>
```
