### PR TITLE
extra/mesa: Add Asahi driver to aarch64

### DIFF
--- a/extra/mesa/PKGBUILD
+++ b/extra/mesa/PKGBUILD
@@ -15,7 +15,7 @@ pkgbase=mesa
 pkgname=('vulkan-mesa-layers' 'opencl-mesa' 'vulkan-radeon' 'vulkan-swrast' 'vulkan-broadcom' 'vulkan-panfrost' 'libva-mesa-driver' 'mesa-vdpau' 'mesa')
 pkgdesc="An open-source implementation of the OpenGL specification"
 pkgver=22.3.1
-pkgrel=1
+pkgrel=1.1
 arch=('x86_64')
 makedepends=('python-mako' 'libxml2' 'libx11' 'xorgproto' 'libdrm' 'libxshmfence' 'libxxf86vm'
              'libxdamage' 'libvdpau' 'libva' 'wayland' 'wayland-protocols' 'zstd' 'elfutils' 'llvm'
@@ -51,7 +51,7 @@ prepare() {
 build() {
   case "${CARCH}" in
     armv7h)  GALLIUM=",etnaviv,kmsro,lima,panfrost,tegra,v3d,vc4" ;;
-    aarch64) GALLIUM=",etnaviv,kmsro,lima,panfrost,svga,v3d,vc4" ;;
+    aarch64) GALLIUM=",asahi,etnaviv,kmsro,lima,panfrost,svga,v3d,vc4" ;;
   esac
 
   # Build only minimal debug info to reduce size


### PR DESCRIPTION
Mesa has been working on the Asahi driver for about a year and it is still in pretty rapid development.

The Asahi driver is used by Apple based devices with the M1 and M2 Apple Silicon chips.

Add this driver, so it can be used on Apple hardware.

Signed-off-by: Dan Johansen <strit@manjaro.org>