### PR TITLE
core/linux-* fix patching silently failing when in-tree

### DIFF
--- a/core/linux-aarch64-rc/PKGBUILD
+++ b/core/linux-aarch64-rc/PKGBUILD
@@ -47,8 +47,8 @@ prepare() {
   echo "${pkgbase#linux}" > localversion.20-pkgname
 
   # ALARM patches
-  git apply ../0001-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
-  git apply ../0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch
+  patch -Np1 < ../0001-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
+  patch -Np1 < ../0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch
 
   cat "${srcdir}/config" > ./.config
 }

--- a/core/linux-aarch64/PKGBUILD
+++ b/core/linux-aarch64/PKGBUILD
@@ -46,11 +46,11 @@ prepare() {
   echo "${pkgbase#linux}" > localversion.20-pkgname
 
   # add upstream patch
-  git apply --whitespace=nowarn ../patch-${pkgver}
+  patch -lNp1 < ../patch-${pkgver}
 
   # ALARM patches
-  git apply ../0001-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
-  git apply ../0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch
+  patch -Np1 < ../0001-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
+  patch -Np1 < ../0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch
 
   cat "${srcdir}/config" > ./.config
 }

--- a/core/linux-am33x/PKGBUILD
+++ b/core/linux-am33x/PKGBUILD
@@ -37,13 +37,13 @@ prepare() {
   cd "${srcdir}/${_srcname}"
 
   # add upstream patch
-  git apply --whitespace=nowarn "${srcdir}/patch-${pkgver}"
+  patch -lNp1 < "${srcdir}/patch-${pkgver}"
 
   # RCN patch
-  git apply ../patch-${rcnver%.0}-${rcnrel}.diff
+  patch -Np1 < ../patch-${rcnver%.0}-${rcnrel}.diff
 
   # ALARM patches
-  git apply ../0001-add-lcd-cape-for-chiliboard.patch
+  patch -Np1 < ../0001-add-lcd-cape-for-chiliboard.patch
 
   cat "${srcdir}/config" > ./.config
 

--- a/core/linux-armv7-rc/PKGBUILD
+++ b/core/linux-armv7-rc/PKGBUILD
@@ -54,17 +54,17 @@ prepare() {
   cd "${srcdir}/${_srcname}"
 
   # RCN patch
-  git apply ../patch-${_rcver}-rc${_rcnrc}-${_rcnrel}.diff
+  patch -Np1 < ../patch-${_rcver}-rc${_rcnrc}-${_rcnrel}.diff
   rm -f scripts/bin2c
 
   # ALARM patches
-  git apply ../0001-ARM-atags-add-support-for-Marvell-s-u-boot.patch
-  git apply ../0002-ARM-atags-fdt-retrieve-MAC-addresses-from-Marvell-bo.patch
-  git apply ../0003-fix-mvsdio-eMMC-timing.patch
-  git apply ../0004-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
-  git apply ../0005-set-default-cubietruck-led-triggers.patch
-  git apply ../0006-exynos4412-odroid-set-higher-minimum-buck2-regulator.patch
-  git apply ../0007-USB-Armory-MkII-support.patch
+  patch -Np1 < ../0001-ARM-atags-add-support-for-Marvell-s-u-boot.patch
+  patch -Np1 < ../0002-ARM-atags-fdt-retrieve-MAC-addresses-from-Marvell-bo.patch
+  patch -Np1 < ../0003-fix-mvsdio-eMMC-timing.patch
+  patch -Np1 < ../0004-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
+  patch -Np1 < ../0005-set-default-cubietruck-led-triggers.patch
+  patch -Np1 < ../0006-exynos4412-odroid-set-higher-minimum-buck2-regulator.patch
+  patch -Np1 < ../0007-USB-Armory-MkII-support.patch
 
   cat "${srcdir}/config" > ./.config
 

--- a/core/linux-armv7/PKGBUILD
+++ b/core/linux-armv7/PKGBUILD
@@ -55,19 +55,19 @@ prepare() {
   cd "${srcdir}/${_srcname}"
 
   # add upstream patch
-  git apply --whitespace=nowarn ../patch-${pkgver}
+  patch -lNp1 < ../patch-${pkgver}
 
   # RCN patch
-  git apply ../patch-${rcnver%.0}-${rcnrel}.diff
+  patch -Np1 < ../patch-${rcnver%.0}-${rcnrel}.diff
 
   # ALARM patches
-  git apply ../0001-ARM-atags-add-support-for-Marvell-s-u-boot.patch
-  git apply ../0002-ARM-atags-fdt-retrieve-MAC-addresses-from-Marvell-bo.patch
-  git apply ../0003-fix-mvsdio-eMMC-timing.patch
-  git apply ../0004-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
-  git apply ../0005-set-default-cubietruck-led-triggers.patch
-  git apply ../0006-exynos4412-odroid-set-higher-minimum-buck2-regulator.patch
-  git apply ../0007-USB-Armory-MkII-support.patch
+  patch -Np1 < ../0001-ARM-atags-add-support-for-Marvell-s-u-boot.patch
+  patch -Np1 < ../0002-ARM-atags-fdt-retrieve-MAC-addresses-from-Marvell-bo.patch
+  patch -Np1 < ../0003-fix-mvsdio-eMMC-timing.patch
+  patch -Np1 < ../0004-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
+  patch -Np1 < ../0005-set-default-cubietruck-led-triggers.patch
+  patch -Np1 < ../0006-exynos4412-odroid-set-higher-minimum-buck2-regulator.patch
+  patch -Np1 < ../0007-USB-Armory-MkII-support.patch
 
   cat "${srcdir}/config" > ./.config
 

--- a/core/linux-espressobin/PKGBUILD
+++ b/core/linux-espressobin/PKGBUILD
@@ -33,7 +33,7 @@ prepare() {
   cd ${_srcname}
 
   # add upstream patch
-  git apply --whitespace=nowarn ../patch-${pkgver}
+  patch -lNp1 < ../patch-${pkgver}
 
   cat "${srcdir}/config" > ./.config
 

--- a/core/linux-gru/PKGBUILD
+++ b/core/linux-gru/PKGBUILD
@@ -32,9 +32,9 @@ md5sums=('6b1ce525151f79f72c10de13392cce08'
          '584777ae88bce2c5659960151b64c7d8')
 
 prepare() {
-  git apply 0001-Input-atmel_mxt_ts-Use-KERN_DEBUG-loglevel-for-statu.patch
-  git apply 0002-Revert-CHROMIUM-drm-rockchip-Add-PSR-residency-debug.patch
-  git apply 0003-temporary-hack-to-fix-console-output.patch
+  patch -Np1 < 0001-Input-atmel_mxt_ts-Use-KERN_DEBUG-loglevel-for-statu.patch
+  patch -Np1 < 0002-Revert-CHROMIUM-drm-rockchip-Add-PSR-residency-debug.patch
+  patch -Np1 < 0003-temporary-hack-to-fix-console-output.patch
 
   cp config .config
 

--- a/core/linux-oak/PKGBUILD
+++ b/core/linux-oak/PKGBUILD
@@ -54,19 +54,19 @@ md5sums=('4418c3dbc04b603215dea1e4d114269d'
          'caac3e4ace66a81a3e0a3e7348e99098')
 
 prepare() {
-  git apply 0001-kbuild-move-Wunused-const-variable-to-W-1-warning-le.patch
-  git apply 0002-md-fix-a-build-warning.patch
-  git apply 0003-netfilter-Fix-switch-statement-warnings-with-recent-.patch
-  git apply 0004-netfilter-nfnetlink_cthelper-Remove-const-and-to-avo.patch
-  git apply 0005-netfilter-Add-some-missing-default-cases-to-switch-s.patch
-  git apply 0006-usbtv-remove-unused-variable.patch
-  git apply 0007-add-extra-errata-843419-build-flags.patch
-  git apply 0008-Downgrade-mmc1-speed.patch
-  git apply 0009-disable-new-gcc-7.1.1-warnings-for-now.patch
-  git apply 0010-UPSTREAM-mwifiex-scan-Simplify-code.patch
-  git apply 0011-media-ir-core-fix-gcc-7-warning-on-bool-arithmetic.patch
-  git apply 0012-sched-fix-duplicate-const-error-on-gcc-7.patch
-  git apply 0013-staging-iio-light-isl29018-fix-duplicate-const-error.patch
+  patch -Np1 < 0001-kbuild-move-Wunused-const-variable-to-W-1-warning-le.patch
+  patch -Np1 < 0002-md-fix-a-build-warning.patch
+  patch -Np1 < 0003-netfilter-Fix-switch-statement-warnings-with-recent-.patch
+  patch -Np1 < 0004-netfilter-nfnetlink_cthelper-Remove-const-and-to-avo.patch
+  patch -Np1 < 0005-netfilter-Add-some-missing-default-cases-to-switch-s.patch
+  patch -Np1 < 0006-usbtv-remove-unused-variable.patch
+  patch -Np1 < 0007-add-extra-errata-843419-build-flags.patch
+  patch -Np1 < 0008-Downgrade-mmc1-speed.patch
+  patch -Np1 < 0009-disable-new-gcc-7.1.1-warnings-for-now.patch
+  patch -Np1 < 0010-UPSTREAM-mwifiex-scan-Simplify-code.patch
+  patch -Np1 < 0011-media-ir-core-fix-gcc-7-warning-on-bool-arithmetic.patch
+  patch -Np1 < 0012-sched-fix-duplicate-const-error-on-gcc-7.patch
+  patch -Np1 < 0013-staging-iio-light-isl29018-fix-duplicate-const-error.patch
 
   cp config .config
 

--- a/core/linux-odroid-c1/PKGBUILD
+++ b/core/linux-odroid-c1/PKGBUILD
@@ -43,10 +43,10 @@ prepare() {
   # don't run depmod on 'make install'. We'll do this ourselves in packaging
   sed -i '2iexit 0' scripts/depmod.sh
 
-  git apply ../0001-disable-pie.patch
-  git apply ../0002-ARM-fix-put_user-for-gcc-8.patch
-  git apply ../0003-fix-redundant-YYLOC-for-gcc10.patch
-  git apply ../0004-fix-bad-udelay-for-gcc10.patch
+  patch -Np1 < ../0001-disable-pie.patch
+  patch -Np1 < ../0002-ARM-fix-put_user-for-gcc-8.patch
+  patch -Np1 < ../0003-fix-redundant-YYLOC-for-gcc10.patch
+  patch -Np1 < ../0004-fix-bad-udelay-for-gcc10.patch
 }
 
 build() {

--- a/core/linux-odroid-c2/PKGBUILD
+++ b/core/linux-odroid-c2/PKGBUILD
@@ -65,18 +65,18 @@ prepare() {
   # don't run depmod on 'make install'. We'll do this ourselves in packaging
   sed -i '2iexit 0' scripts/depmod.sh
 
-  git apply ../0001-add-extra-errata-843419-build-flags.patch
-  git apply ../0002-arm64-Add-audit-support.patch
-  git apply ../0003-random-introduce-getrandom-2-system-call.patch
-  git apply ../0004-Revert-arm64-compat-wire-up-memfd_create-syscall-for.patch
-  git apply ../0005-arm64-Add-__NR_-definitions-for-compat-syscalls.patch
-  git apply ../0006-arm64-compat-wire-up-memfd_create-and-getrandom-sysc.patch
-  git apply ../0007-arm64-ptrace-add-PTRACE_SET_SYSCALL.patch
-  git apply ../0008-arm64-ptrace-allow-tracer-to-skip-a-system-call.patch
-  git apply ../0009-asm-generic-add-generic-seccomp.h-for-secure-computi.patch
-  git apply ../0010-arm64-add-seccomp-syscall-for-compat-task.patch
-  git apply ../0011-arm64-add-SIGSYS-siginfo-for-compat-task.patch
-  git apply ../0012-arm64-add-seccomp-support.patch
+  patch -Np1 < ../0001-add-extra-errata-843419-build-flags.patch
+  patch -Np1 < ../0002-arm64-Add-audit-support.patch
+  patch -Np1 < ../0003-random-introduce-getrandom-2-system-call.patch
+  patch -Np1 < ../0004-Revert-arm64-compat-wire-up-memfd_create-syscall-for.patch
+  patch -Np1 < ../0005-arm64-Add-__NR_-definitions-for-compat-syscalls.patch
+  patch -Np1 < ../0006-arm64-compat-wire-up-memfd_create-and-getrandom-sysc.patch
+  patch -Np1 < ../0007-arm64-ptrace-add-PTRACE_SET_SYSCALL.patch
+  patch -Np1 < ../0008-arm64-ptrace-allow-tracer-to-skip-a-system-call.patch
+  patch -Np1 < ../0009-asm-generic-add-generic-seccomp.h-for-secure-computi.patch
+  patch -Np1 < ../0010-arm64-add-seccomp-syscall-for-compat-task.patch
+  patch -Np1 < ../0011-arm64-add-SIGSYS-siginfo-for-compat-task.patch
+  patch -Np1 < ../0012-arm64-add-seccomp-support.patch
 }
 
 build() {

--- a/core/linux-peach/PKGBUILD
+++ b/core/linux-peach/PKGBUILD
@@ -38,9 +38,9 @@ md5sums=('e0d35bb134a2fa5d482eb3045b03ab97'
          'caac3e4ace66a81a3e0a3e7348e99098')
 
 prepare() {
-  git apply 0001-mwifiex-do-not-create-AP-and-P2P-interfaces-upon-dri.patch
-  git apply 0002-use-chromiumos-mwifiex-drivers.patch
-  git apply 0003-exynos-DRM-have-exynos_drm_fbdev_update-set-smem_sta.patch
+  patch -Np1 < 0001-mwifiex-do-not-create-AP-and-P2P-interfaces-upon-dri.patch
+  patch -Np1 < 0002-use-chromiumos-mwifiex-drivers.patch
+  patch -Np1 < 0003-exynos-DRM-have-exynos_drm_fbdev_update-set-smem_sta.patch
 
   cp include/linux/compiler-gcc5.h include/linux/compiler-gcc6.h
 

--- a/core/linux-veyron/PKGBUILD
+++ b/core/linux-veyron/PKGBUILD
@@ -54,14 +54,14 @@ md5sums=('07393e20ea7ea48ba7dab52e57620a04'
          'cd779bcbe50e6562428279ff7e5b0cd9')
 
 prepare() {
-  git apply 0001-use-chromiumos-mwifiex-drivers.patch
-  git apply 0002-mwifiex-do-not-create-AP-and-P2P-interfaces-upon-dri.patch
-  git apply 0003-UPSTREAM-soc-rockchip-add-handler-for-usb-uart-funct.patch
-  git apply 0004-fix-brcmfmac-oops-and-race-condition.patch
-  git apply 0005-random-simplify-loop-in-random_read.patch
-  git apply 0006-random-introduce-getrandom-2-system-call.patch
-  git apply 0007-ARM-wire-up-getrandom-syscall.patch
-  git apply 0008-random-Wake-up-all-getrandom-2-callers-when-pool-is-.patch
+  patch -Np1 < 0001-use-chromiumos-mwifiex-drivers.patch
+  patch -Np1 < 0002-mwifiex-do-not-create-AP-and-P2P-interfaces-upon-dri.patch
+  patch -Np1 < 0003-UPSTREAM-soc-rockchip-add-handler-for-usb-uart-funct.patch
+  patch -Np1 < 0004-fix-brcmfmac-oops-and-race-condition.patch
+  patch -Np1 < 0005-random-simplify-loop-in-random_read.patch
+  patch -Np1 < 0006-random-introduce-getrandom-2-system-call.patch
+  patch -Np1 < 0007-ARM-wire-up-getrandom-syscall.patch
+  patch -Np1 < 0008-random-Wake-up-all-getrandom-2-callers-when-pool-is-.patch
 
   cp config .config
 


### PR DESCRIPTION
Patches were being applied with `git apply` despite the kernel tarball not being a valid git repo. When building in-tree, git would get confused with the repository root directory, and patching wouldn't be done. The resulting package would therefore be incorrect.

This replaces all calls to `git apply` with calls to `patch`.