### PR TITLE
Update to alarm/rpi-eeprom 20221020-2

### DIFF
--- a/alarm/rpi-eeprom/PKGBUILD
+++ b/alarm/rpi-eeprom/PKGBUILD
@@ -1,9 +1,9 @@
 # Maintainer: graysky <therealgraysky AT protonmail DOT com>
 
 pkgname=rpi-eeprom
-_commit=d0ff0d5d721811d82ddbf0b2043f8a2c87f120d9
+_commit=092f87659594a48cf52a18a6f2dee9ebf4dcaedf
 pkgver=20221020
-pkgrel=1
+pkgrel=2
 pkgdesc="Bootloader and VL805 USB controller EEPROM update tool for RPi4"
 arch=('any')
 url='https://github.com/raspberrypi/rpi-eeprom'
@@ -11,7 +11,7 @@ license=('custom')
 depends=(python pciutils raspberrypi-firmware coreutils binutils)
 backup=("etc/default/$pkgname-update")
 source=("$pkgname-$pkgver-${_commit:0:10}.tar.gz::https://github.com/raspberrypi/rpi-eeprom/archive/$_commit.tar.gz")
-md5sums=('1338d86b144d36cd8e510119ff585dca')
+md5sums=('c68f5aa58c32c6e6630dcdda3ec94709')
 install="$pkgname.install"
 
 package() {


### PR DESCRIPTION
20221020-1 had an incorrect commit to include updated firmware, this PR addresses and updates that.