### PR TITLE
extra/qemu: make qemu-base to work on aarch64

### DIFF
--- a/extra/qemu/PKGBUILD
+++ b/extra/qemu/PKGBUILD
@@ -23,15 +23,15 @@ pkgname=(
   qemu-tests
   qemu-tools
   qemu-ui-{curses,dbus,egl-headless,gtk,opengl,sdl,spice-{app,core}}
-  qemu-user{,-static}{,-binfmt}
+  #qemu-user{,-static}{,-binfmt}
   qemu-vhost-user-gpu
   qemu-virtiofsd
   qemu-{base,desktop,emulators-full,full}
 )
 pkgver=7.1.0
-pkgrel=10
+pkgrel=11
 pkgdesc="A generic and open source machine emulator and virtualizer"
-arch=(x86_64)
+arch=(x86_64 aarch64)
 url="https://www.qemu.org/"
 license=(GPL2 LGPL2.1)
 # TODO: consider providing rdma-core
@@ -224,6 +224,8 @@ _qemu_optdepends=(
   'qemu-vhost-user-gpu: for vhost-user-gpu display device'
   'qemu-virtiofsd: for virtio-fs shared filesystem daemon'
   'samba: for SMB/CIFS server support'
+  'edk2-ovmf: for x86/x86_64 UEFI firmware'
+  'edk2-armvirt: for arm/arm64 UEFI firmware'
 )
 
 _pick() {
@@ -254,53 +256,54 @@ prepare() {
 
   # create build dir
   mkdir -vp build
-  mkdir -vp build-static
+  #mkdir -vp build-static
 }
 
 build() {
-  (
-    cd build-static
-    ../$pkgbase-$pkgver/configure \
-      --prefix=/usr \
-      --sysconfdir=/etc \
-      --libexecdir=/usr/lib/qemu \
-      --enable-attr \
-      --enable-linux-user \
-      --enable-tcg \
-      --disable-bpf \
-      --disable-bsd-user \
-      --disable-capstone \
-      --disable-docs \
-      --disable-fdt \
-      --disable-gcrypt \
-      --disable-glusterfs \
-      --disable-gnutls \
-      --disable-gtk \
-      --disable-install-blobs \
-      --disable-kvm \
-      --disable-libiscsi \
-      --disable-libnfs \
-      --disable-libssh \
-      --disable-linux-io-uring \
-      --disable-nettle \
-      --disable-opengl \
-      --disable-qom-cast-debug \
-      --disable-sdl \
-      --disable-system \
-      --disable-tools \
-      --disable-tpm \
-      --disable-vde \
-      --disable-vhost-crypto \
-      --disable-vhost-kernel \
-      --disable-vhost-net \
-      --disable-vhost-user \
-      --disable-vnc \
-      --disable-werror \
-      --disable-xen \
-      --disable-zstd \
-      --static
-    ninja
-  )
+# Disable static build completely, as it fails at linking on aarch64 (native)
+#  (
+#    cd build-static
+#    ../$pkgbase-$pkgver/configure \
+#      --prefix=/usr \
+#      --sysconfdir=/etc \
+#      --libexecdir=/usr/lib/qemu \
+#      --enable-attr \
+#      --enable-linux-user \
+#      --enable-tcg \
+#      --disable-bpf \
+#      --disable-bsd-user \
+#      --disable-capstone \
+#      --disable-docs \
+#      --disable-fdt \
+#      --disable-gcrypt \
+#      --disable-glusterfs \
+#      --disable-gnutls \
+#      --disable-gtk \
+#      --disable-install-blobs \
+#      --disable-kvm \
+#      --disable-libiscsi \
+#      --disable-libnfs \
+#      --disable-libssh \
+#      --disable-linux-io-uring \
+#      --disable-nettle \
+#      --disable-opengl \
+#      --disable-qom-cast-debug \
+#      --disable-sdl \
+#      --disable-system \
+#      --disable-tools \
+#      --disable-tpm \
+#      --disable-vde \
+#      --disable-vhost-crypto \
+#      --disable-vhost-kernel \
+#      --disable-vhost-net \
+#      --disable-vhost-user \
+#      --disable-vnc \
+#      --disable-werror \
+#      --disable-xen \
+#      --disable-zstd \
+#      --static
+#    ninja
+#  )
 
   # Build only minimal debug info to reduce size
   CFLAGS+=' -g1'
@@ -335,18 +338,18 @@ package_qemu-common() {
   install=$pkgname.install
 
   # install static binaries
-  meson install -C build-static --destdir "$pkgdir"
-  install -vdm 755 "$pkgdir/usr/lib/binfmt.d/"
-  $pkgbase-$pkgver/scripts/qemu-binfmt-conf.sh --systemd ALL --exportdir "$pkgdir/usr/lib/binfmt.d/" --qemu-path "/usr/bin"
+  #meson install -C build-static --destdir "$pkgdir"
+  #install -vdm 755 "$pkgdir/usr/lib/binfmt.d/"
+  #$pkgbase-$pkgver/scripts/qemu-binfmt-conf.sh --systemd ALL --exportdir "$pkgdir/usr/lib/binfmt.d/" --qemu-path "/usr/bin"
 
   # rename static binaries to prevent name conflicts
-  for _src in "$pkgdir/usr/bin/qemu-"*; do
-    mv -v "$_src" "$pkgdir/usr/bin/$(basename "$_src")-static"
-  done
+  #for _src in "$pkgdir/usr/bin/qemu-"*; do
+  #  mv -v "$_src" "$pkgdir/usr/bin/$(basename "$_src")-static"
+  #done
   # modify and rename binfmt.d configs to prevent name conflicts
-  for _conf in "$pkgdir/usr/lib/binfmt.d/"*; do
-    cat "$_conf" | tr -d '\n' | sed "s/:$/-static:F/" > "${_conf//.conf/-static.conf}"
-  done
+  #for _conf in "$pkgdir/usr/lib/binfmt.d/"*; do
+  #  cat "$_conf" | tr -d '\n' | sed "s/:$/-static:F/" > "${_conf//.conf/-static.conf}"
+  #done
 
   # install default binaries
   meson install -C build --destdir "$pkgdir"
@@ -538,8 +541,8 @@ package_qemu-common() {
     _pick qemu-ui-spice-app usr/lib/qemu/ui-spice-app.so
     _pick qemu-ui-spice-core usr/lib/qemu/ui-spice-core.so
 
-    _pick qemu-user-static usr/bin/qemu-*-static
-    _pick qemu-user-static-binfmt usr/lib/binfmt.d/*-static.conf
+    #_pick qemu-user-static usr/bin/qemu-*-static
+    #_pick qemu-user-static-binfmt usr/lib/binfmt.d/*-static.conf
 
     _pick qemu-user usr/bin/qemu-{aarch64{,_be},alpha,arm{,eb},cris,hexagon,hppa,i386,loongarch64,m68k,microblaze{,el},mips{,64,64el,el,n32,n32el},nios2,or1k,ppc{,64,64le},riscv{32,64},s390x,sh4{,eb},sparc{,32plus,64},x86_64,xtensa{,eb}}
     _pick qemu-user-binfmt usr/lib/binfmt.d/*.conf
@@ -714,7 +717,9 @@ package_qemu-hw-s390x-virtio-gpu-ccw() {
 
 package_qemu-system-aarch64() {
   pkgdesc="QEMU system emulator for AARCH64"
-  depends=("${_qemu_system_deps[@]}" edk2-armvirt systemd-libs libudev.so)
+  # Remove ekd2-armvirt until we can build it natively.
+  # As a workaround
+  depends=("${_qemu_system_deps[@]}" systemd-libs libudev.so)
   mv -v $pkgname/* "$pkgdir"
 }
 
@@ -877,7 +882,7 @@ package_qemu-system-tricore() {
 
 package_qemu-system-x86() {
   pkgdesc="QEMU system emulator for x86"
-  depends=("${_qemu_system_deps[@]}" edk2-ovmf qemu-system-x86-firmware=$pkgver-$pkgrel seabios systemd-libs libudev.so)
+  depends=("${_qemu_system_deps[@]}" qemu-system-x86-firmware=$pkgver-$pkgrel seabios systemd-libs libudev.so)
   mv -v $pkgname/* "$pkgdir"
 }
 
@@ -1017,20 +1022,20 @@ package_qemu-user-binfmt() {
   mv -v $pkgname/* "$pkgdir"
 }
 
-package_qemu-user-static() {
-  pkgdesc="QEMU static user mode emulation"
-  depends=(glibc)
-  optdepends=('qemu-user-static-binfmt: for binary format rules')
-  mv -v $pkgname/* "$pkgdir"
-}
+#package_qemu-user-static() {
+#  pkgdesc="QEMU static user mode emulation"
+#  depends=(glibc)
+#  optdepends=('qemu-user-static-binfmt: for binary format rules')
+#  mv -v $pkgname/* "$pkgdir"
+#}
 
-package_qemu-user-static-binfmt() {
-  pkgdesc="Binary format rules for QEMU static user mode emulation"
-  depends=(qemu-user-static=$pkgver-$pkgrel)
-  provides=(qemu-user-binfmt-provider)
-  conflicts=(qemu-user-binfmt-provider)
-  mv -v $pkgname/* "$pkgdir"
-}
+#package_qemu-user-static-binfmt() {
+#  pkgdesc="Binary format rules for QEMU static user mode emulation"
+#  depends=(qemu-user-static=$pkgver-$pkgrel)
+#  provides=(qemu-user-binfmt-provider)
+#  conflicts=(qemu-user-binfmt-provider)
+#  mv -v $pkgname/* "$pkgdir"
+#}
 
 package_qemu-vhost-user-gpu() {
   pkgdesc="QEMU vhost-user-gpu display device"
@@ -1057,7 +1062,8 @@ package_qemu-base() {
     qemu-hw-usb-{host,redirect,smartcard}=$pkgver-$pkgrel
     qemu-img=$pkgver-$pkgrel
     qemu-pr-helper=$pkgver-$pkgrel
-    qemu-system-x86=$pkgver-$pkgrel
+    # Aarch64 is our base target, not x86 from upstream Archlinux
+    qemu-system-aarch64=$pkgver-$pkgrel
     qemu-tools=$pkgver-$pkgrel
     qemu-ui-{curses,spice-{app,core}}=$pkgver-$pkgrel
     qemu-virtiofsd=$pkgver-$pkgrel
@@ -1082,7 +1088,7 @@ package_qemu-desktop() {
     qemu-hw-usb-{host,redirect,smartcard}=$pkgver-$pkgrel
     qemu-img=$pkgver-$pkgrel
     qemu-pr-helper=$pkgver-$pkgrel
-    qemu-system-x86=$pkgver-$pkgrel
+    qemu-system-aarch64=$pkgver-$pkgrel
     qemu-tools=$pkgver-$pkgrel
     qemu-ui-{curses,dbus,egl-headless,gtk,opengl,sdl,spice-{app,core}}=$pkgver-$pkgrel
     qemu-vhost-user-gpu=$pkgver-$pkgrel


### PR DESCRIPTION
Since I'm one of the very few users using ArchlinuxARM and running KVM (libvirt) on it, it's really a pity that ArchlinuxARM is unable to easily install qemu.

There are several problems involved in the current situation:

- Bad qemu-base/desktop dependency
  They still depends on x86 target, which is completely wrong on aarch64 systems.

- Hard requirement on firmwares
  This is especially bad for Aarch64, as we can not build edk2-virtarm natively right now.
  (But we can easily install the same package from upstream archlinux edk2-virtarm, as they are just firmwares)

- Bad libbpf dependency
  This looks like the package is not properly linked to the current libbpf

- Link failure for qemu-static
  This happens with latest native toolchain.

Currently I modified the PKGBUILD to handle above problems by:

- Make qemu-base/desktop to depend on qemu-system-aarch64
- Make edk2-* and seabios dependency optional
- Make the PKGBUILD work at least
- Disable user-static builds completely

So far it at least compiles and qemu can at least start up.