### PR TITLE
Add alarm/raspberrypi-overlays for UEFI firmware

### DIFF
--- a/alarm/raspberrypi-overlays/PKGBUILD
+++ b/alarm/raspberrypi-overlays/PKGBUILD
@@ -1,0 +1,19 @@
+buildarch=1 # any
+
+pkgname="raspberrypi-overlays"
+pkgver=20240902
+pkgrel=1
+pkgdesc="/boot/overlays for RaspberryPi"
+url="https://github.com/raspberrypi/firmware"
+arch=("any")
+license=("GPL2")
+conflicts=("linux-rpi" "raspberrypi-devicetree")
+replaces=("raspberrypi4-overlays" "raspberrypi4-dtbs")
+source=("https://github.com/raspberrypi/firmware/archive/refs/tags/1.${pkgver}.tar.gz")
+sha256sums=('bf198aae3bc5d5555f69669dce7d00230fa3138c0a225bfe8ea660d9ac2c66c9')
+
+package(){
+    cd "${srcdir}/firmware-1.${pkgver}"
+    mkdir -p "${pkgdir}/boot"
+    cp -av boot/overlays "${pkgdir}/boot/" 
+}


### PR DESCRIPTION
This is required by uefi-raspberrypi4, it is the /boot/overlays folder of the Raspberry Pi 4.

This should be provided by linux-raspberrypi, but UEFI firmware needs linux-aarch64 for the devicetree, besides, linux-raspberrypi does not enable ACPI and UEFI related config so it is not suitable for uefi-raspberrypi4.