### PR TITLE
Add alarm/edk2-raspberrypi for UEFI firmware

### DIFF
--- a/alarm/edk2-raspberrypi/60-edk2-rpi3.json
+++ b/alarm/edk2-raspberrypi/60-edk2-rpi3.json
@@ -1,0 +1,25 @@
+{
+    "description": "UEFI firmware for raspi3* aarch64",
+    "interface-types": [
+        "uefi"
+    ],
+    "mapping": {
+        "device": "flash",
+        "nvram-template": {
+            "filename": "/usr/share/edk2/aarch64/RPi3_EFI.fd",
+            "format": "raw"
+        }
+    },
+    "targets": [
+        {
+            "architecture": "aarch64",
+            "machines": [
+                "raspi3*"
+            ]
+        }
+    ],
+    "features": [
+        "verbose-static"
+    ],
+    "tags": []
+}

--- a/alarm/edk2-raspberrypi/60-edk2-rpi4.json
+++ b/alarm/edk2-raspberrypi/60-edk2-rpi4.json
@@ -1,0 +1,25 @@
+{
+    "description": "UEFI firmware for raspi4b aarch64",
+    "interface-types": [
+        "uefi"
+    ],
+    "mapping": {
+        "device": "flash",
+        "nvram-template": {
+            "filename": "/usr/share/edk2/aarch64/RPi4_EFI.fd",
+            "format": "raw"
+        }
+    },
+    "targets": [
+        {
+            "architecture": "aarch64",
+            "machines": [
+                "raspi4b"
+            ]
+        }
+    ],
+    "features": [
+        "verbose-static"
+    ],
+    "tags": []
+}

--- a/alarm/edk2-raspberrypi/70-sync-edk2-rpi3.hook
+++ b/alarm/edk2-raspberrypi/70-sync-edk2-rpi3.hook
@@ -1,0 +1,21 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Path
+Target = boot/start.elf
+Target = boot/start_*.elf
+Target = boot/bootcode.bin
+Target = boot/config.txt
+Target = boot/fixup.dat
+Target = boot/fixup_*.dat
+Target = boot/dtbs/broadcom/bcm2710-rpi-3*.dtb
+Target = boot/dtbs/broadcom/bcm2710-rpi-2-b.dtb
+Target = boot/dtbs/broadcom/bcm2710-rpi-cm3.dtb
+Target = usr/share/edk2/aarch64/RPi3_EFI.fd
+
+[Action]
+Description = Syncing required files...
+Depends = coreutils
+When = PostTransaction
+Exec = /usr/share/libalpm/scripts/edk2-rpi3 --install
+NeedsTargets

--- a/alarm/edk2-raspberrypi/70-sync-edk2-rpi4.hook
+++ b/alarm/edk2-raspberrypi/70-sync-edk2-rpi4.hook
@@ -1,0 +1,16 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Path
+Target = boot/start4*.elf
+Target = boot/config.txt
+Target = boot/fixup4*.dat
+Target = boot/dtbs/broadcom/bcm2711-rpi-4*.dtb
+Target = usr/share/edk2/aarch64/RPi4_EFI.fd
+
+[Action]
+Description = Syncing required files...
+Depends = coreutils
+When = PostTransaction
+Exec = /usr/share/libalpm/scripts/edk2-rpi4 --install
+NeedsTargets

--- a/alarm/edk2-raspberrypi/80-remove-edk2-rpi3.hook
+++ b/alarm/edk2-raspberrypi/80-remove-edk2-rpi3.hook
@@ -1,0 +1,20 @@
+[Trigger]
+Operation = Remove
+Type = Path
+Target = boot/start.elf
+Target = boot/start_*.elf
+Target = boot/bootcode.bin
+Target = boot/config.txt
+Target = boot/fixup.dat
+Target = boot/fixup_*.dat
+Target = boot/dtbs/broadcom/bcm2710-rpi-3*.dtb
+Target = boot/dtbs/broadcom/bcm2710-rpi-2-b.dtb
+Target = boot/dtbs/broadcom/bcm2710-rpi-cm3.dtb
+Target = usr/share/edk2/aarch64/RPi3_EFI.fd
+
+[Action]
+Description = Cleaning synced files...
+Depends = coreutils
+When = PreTransaction
+Exec = /usr/share/libalpm/scripts/edk2-rpi3 --uninstall
+NeedsTargets

--- a/alarm/edk2-raspberrypi/80-remove-edk2-rpi4.hook
+++ b/alarm/edk2-raspberrypi/80-remove-edk2-rpi4.hook
@@ -1,0 +1,15 @@
+[Trigger]
+Operation = Remove
+Type = Path
+Target = boot/start4*.elf
+Target = boot/config.txt
+Target = boot/fixup4*.dat
+Target = boot/dtbs/broadcom/bcm2711-rpi-4*.dtb
+Target = usr/share/edk2/aarch64/RPi4_EFI.fd
+
+[Action]
+Description = Cleaning synced files...
+Depends = coreutils
+When = PreTransaction
+Exec = /usr/share/libalpm/scripts/edk2-rpi4 --uninstall
+NeedsTargets

--- a/alarm/edk2-raspberrypi/PKGBUILD
+++ b/alarm/edk2-raspberrypi/PKGBUILD
@@ -1,0 +1,205 @@
+# Based on edk2 pkgbase in extra repo of vanilla archlinux.
+
+# No tags, use the latest commit when we update the package
+_edk2_non_osi_commit=7ac12d81e02b323bffdf1ef3c188ea33c2185c91
+_edk2_platforms_commit=f37b334aad56fff58bbc1169983657a3167377ce
+
+_secureboot_objects_version=1.6.4
+
+buildarch=8 # aarch64
+
+pkgbase=edk2-raspberrypi
+pkgname=(edk2-rpi4 edk2-bootloader-rpi4 edk2-rpi3 edk2-bootloader-rpi3)
+pkgver=202605
+pkgrel=1
+pkgdesc="Modern, feature-rich firmware development environment for the UEFI specifications"
+arch=(any)
+url="https://github.com/tianocore/edk2-platforms/tree/$_edk2_platforms_commit/Platform/RaspberryPi"
+license=("BSD-2-Clause-Patent")
+makedepends=(acpica git python)
+makedepends_x86_64=(aarch64-linux-gnu-gcc)
+makedepends_riscv64=(aarch64-linux-gnu-gcc)
+makedepends_loong64=(aarch64-linux-gnu-gcc)
+source=("git+https://github.com/tianocore/edk2.git#tag=edk2-stable$pkgver"
+        "git+https://github.com/tianocore/edk2-non-osi.git#commit=$_edk2_non_osi_commit"
+        "git+https://github.com/tianocore/edk2-platforms.git#commit=$_edk2_platforms_commit"
+        "git+https://github.com/openssl/openssl.git"
+        "git+https://github.com/tianocore/edk2-cmocka.git"
+        "git+https://github.com/kkos/oniguruma.git"
+        "git+https://github.com/google/brotli.git"
+        "git+https://github.com/akheron/jansson.git"
+        "git+https://github.com/google/googletest.git"
+        "git+https://github.com/tianocore/edk2-subhook.git"
+        "git+https://github.com/devicetree-org/pylibfdt.git"
+        "git+https://github.com/MIPI-Alliance/public-mipi-sys-t.git"
+        "git+https://github.com/ARMmbed/mbedtls.git"
+        "git+https://github.com/DMTF/libspdm.git"
+        "git+https://github.com/TrustedComputingGroup/TPM.git"
+        "edk2-aarch64-secureboot-binaries-$_secureboot_objects_version.tar.gz::https://github.com/microsoft/secureboot_objects/releases/download/v$_secureboot_objects_version/edk2-aarch64-secureboot-binaries.tar.gz"
+        "edk2-rpi4"
+        "edk2-rpi3"
+        "70-sync-edk2-rpi4.hook"
+        "70-sync-edk2-rpi3.hook"
+        "80-remove-edk2-rpi4.hook"
+        "80-remove-edk2-rpi3.hook"
+        "60-edk2-rpi4.json"
+        "60-edk2-rpi3.json")
+sha256sums=('2199d1a6f3d2afaf8658e69d2e68da3a5e047f9db24bc498b13eecb89eb5956e'
+            '8bd31168159be3b27cc79593856d3ab22a019a139b21a40c9001b35894282b7f'
+            '5fa5a4b9eeca0a36a62233908d3c7643eb6b695a496444ee1a07de954c443988'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            '8df53791b65a5b6b1a0c6c3b588b48a3fab46fb0d4321febdde956618d35f107'
+            'af8fdb018c040add6bdb77bf4994b290e3ee29e6c03ba60fff48c442dcaabdb5'
+            '5837e2327340dd3cfdfe4f26fda7c2242316b10cd7505c8fdb6af71ae417b69a'
+            '58ee39188c5859ab3e6dcc531b25dd432d8d2ceda93287df5a3a50ffe084545a'
+            'c55fdf553f684b21f1eae1316a85c51408465b3c8aa740d9339dba89fca8a77a'
+            '010e704babfddab2009da583fe99a6e0c76dd8b3cf5a4a0e943c20182d9a0227'
+            '0c3986a818c2ae850200f4c112c9df6778ac6fec5c4ad9afc915fc5b01a750a7'
+            '8cb1ffe0c4bff487e27e3d7d561db9877c92416e4971a2a3c492f22ff7470bf4'
+            'c8e59269198bf595ba95a990bae65f30b31211be6023731256d9b8ec94b2222f')
+
+prepare() {
+    local submodule=edk2
+    git -C "$submodule" submodule init
+    git -C "$submodule" config submodule.CryptoPkg/Library/OpensslLib/openssl.url "$srcdir/openssl"
+    git -C "$submodule" config submodule.UnitTestFrameworkPkg/Library/CmockaLib/cmocka.url "$srcdir/edk2-cmocka"
+    git -C "$submodule" config submodule.MdeModulePkg/Universal/RegularExpressionDxe/oniguruma.url "$srcdir/oniguruma"
+    git -C "$submodule" config submodule.MdeModulePkg/Library/BrotliCustomDecompressLib/brotli.url "$srcdir/brotli"
+    git -C "$submodule" config submodule.BaseTools/Source/C/BrotliCompress/brotli.url "$srcdir/brotli"
+    git -C "$submodule" config submodule.RedfishPkg/Library/JsonLib/jansson.url "$srcdir/jansson"
+    git -C "$submodule" config submodule.UnitTestFrameworkPkg/Library/GoogleTestLib/googletest.url "$srcdir/googletest"
+    git -C "$submodule" config submodule.UnitTestFrameworkPkg/Library/SubhookLib/subhook.url "$srcdir/edk2-subhook"
+    git -C "$submodule" config submodule.MdePkg/Library/BaseFdtLib/libfdt.url "$srcdir/pylibfdt"
+    git -C "$submodule" config submodule.MdePkg/Library/MipiSysTLib/mipisyst.url "$srcdir/public-mipi-sys-t"
+    git -C "$submodule" config submodule.CryptoPkg/Library/MbedTlsLib/mbedtls.url "$srcdir/mbedtls"
+    git -C "$submodule" config submodule.SecurityPkg/DeviceSecurity/SpdmLib/libspdm.url "$srcdir/libspdm"
+    git -C "$submodule" config submodule.TcgTpmPkg/Library/TpmLib/TPM.url "$srcdir/TPM"
+    git -C "$submodule" -c protocol.file.allow=always submodule update
+}
+
+build() {
+    local -r secureboot_type=MicrosoftAndThirdParty
+    export WORKSPACE="$PWD"
+    export PACKAGES_PATH="$WORKSPACE/edk2:$WORKSPACE/edk2-platforms:$WORKSPACE/edk2-non-osi"
+    [[ "$(uname -m)" != "aarch64" ]] && export GCC_AARCH64_PREFIX="aarch64-linux-gnu-"
+
+    make -C edk2/BaseTools -j1
+    . edk2/edksetup.sh
+    edk2/BaseTools/BinWrappers/PosixLike/build -a AARCH64 -t GCC -b RELEASE -p edk2-platforms/Platform/RaspberryPi/RPi4/RPi4.dsc \
+        --pcd gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString=L"EDK2 $pkgver-$pkgrel" \
+        --pcd gRaspberryPiTokenSpaceGuid.PcdRamLimitTo3GB="0" \
+        --pcd gRaspberryPiTokenSpaceGuid.PcdSystemTableMode="1" \
+        -D SECURE_BOOT_ENABLE=TRUE \
+        -D INCLUDE_TFTP_COMMAND=TRUE \
+        -D NETWORK_ISCSI_ENABLE=TRUE \
+        -D SMC_PCI_SUPPORT=1 \
+        -D DEFAULT_KEYS=TRUE \
+        -D PK_DEFAULT_FILE=./$secureboot_type/Firmware/PK.bin \
+        -D KEK_DEFAULT_FILE1=./$secureboot_type/Firmware/KEK.bin \
+        -D DB_DEFAULT_FILE1=./$secureboot_type/Firmware/DB.bin \
+        -D DBX_DEFAULT_FILE1=./$secureboot_type/Firmware/DBX.bin
+    edk2/BaseTools/BinWrappers/PosixLike/build -a AARCH64 -t GCC -b RELEASE -p edk2-platforms/Platform/RaspberryPi/RPi3/RPi3.dsc \
+        --pcd gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString=L"EDK2 $pkgver-$pkgrel" \
+        --pcd gRaspberryPiTokenSpaceGuid.PcdSystemTableMode="1" \
+        -D SECURE_BOOT_ENABLE=TRUE \
+        -D INCLUDE_TFTP_COMMAND=TRUE \
+        -D NETWORK_ISCSI_ENABLE=TRUE \
+        -D SMC_PCI_SUPPORT=1 \
+        -D DEFAULT_KEYS=TRUE \
+        -D PK_DEFAULT_FILE=./$secureboot_type/Firmware/PK.bin \
+        -D KEK_DEFAULT_FILE1=./$secureboot_type/Firmware/KEK.bin \
+        -D DB_DEFAULT_FILE1=./$secureboot_type/Firmware/DB.bin \
+        -D DBX_DEFAULT_FILE1=./$secureboot_type/Firmware/DBX.bin
+}
+
+package_edk2-rpi4() {
+    pkgdesc="Firmware for RPi4 (aarch64)"
+    url+="/RPi4"
+
+    install -Dvm644 Build/RPi4/RELEASE_GCC/FV/RPI_EFI.fd "$pkgdir/usr/share/edk2/aarch64/RPi4_EFI.fd"
+    install -Dvm644 -t "$pkgdir/usr/share/qemu/firmware/" -- *"$pkgname"*.json
+    install -Dvm644 edk2/License.txt -t "$pkgdir/usr/share/licenses/$pkgname/"
+    install -Dvm644 edk2-platforms/License.txt "$pkgdir/usr/share/licenses/$pkgname/License.platforms.txt"
+    install -Dvm644 edk2-non-osi/Platform/RaspberryPi/RPi4/TrustedFirmware/License.txt "$pkgdir/usr/share/licenses/$pkgname/License.tf-a.txt"
+}
+
+package_edk2-bootloader-rpi4() {
+    pkgdesc="Bootloader shim to let edk2 image bootable on real machine."
+    url+="/RPi4"
+    depends=("linux-aarch64>=5.8" raspberrypi-bootloader "edk2-rpi4=$pkgver" bash)
+    optdepends=("firmware-raspberrypi: firmware for RaspberryPi"
+                "linux-firmware-broadcom: firmware for RaspberryPi"
+                "virt-firmware: for editing EFI variables")
+    conflicts=(uboot-raspberrypi linux-rpi linux-rpi-16k edk2-raspberrypi)
+    provides=(edk2-raspberrypi)
+    backup=(boot/config.txt)
+
+    conflicts+=(uefi-raspberrypi raspberrypi-overlays)
+    replaces=(uefi-raspberrypi raspberrypi-overlays)
+    provides+=(uefi-raspberrypi raspberrypi-overlays)
+
+    mkdir -p "$pkgdir/boot" "$pkgdir/usr/share/libalpm/hooks" "$pkgdir/usr/share/libalpm/scripts"
+    cat <<EOF > "$pkgdir/boot/config.txt"
+arm_64bit=1
+enable_uart=1
+enable_gic=1
+armstub=RPI_EFI.fd
+disable_commandline_tags=2
+device_tree_address=0x3e0000
+device_tree_end=0x400000
+
+arm_boost=1
+uart_2ndstage=1
+EOF
+    install -Dvm644 -t "$pkgdir/usr/share/libalpm/hooks/" -- *edk2-rpi4*.hook
+    install -Dvm755 -t "$pkgdir/usr/share/libalpm/scripts/" edk2-rpi4
+}
+
+package_edk2-rpi3() {
+    pkgdesc="Firmware for RPi3 (aarch64)"
+    url+="/RPi3"
+
+    install -Dvm644 Build/RPi3/RELEASE_GCC/FV/RPI_EFI.fd "$pkgdir/usr/share/edk2/aarch64/RPi3_EFI.fd"
+    install -Dvm644 -t "$pkgdir/usr/share/qemu/firmware/" -- *"$pkgname"*.json
+    install -Dvm644 edk2/License.txt -t "$pkgdir/usr/share/licenses/$pkgname/"
+    install -Dvm644 edk2-platforms/License.txt "$pkgdir/usr/share/licenses/$pkgname/License.platforms.txt"
+    install -Dvm644 edk2-non-osi/Platform/RaspberryPi/RPi3/TrustedFirmware/License.txt "$pkgdir/usr/share/licenses/$pkgname/License.tf-a.txt"
+}
+
+package_edk2-bootloader-rpi3() {
+    pkgdesc="Bootloader shim to let edk2 image bootable on real machine."
+    url+="/RPi3"
+    depends=(linux-aarch64 raspberrypi-bootloader "edk2-rpi3=$pkgver" bash)
+    optdepends=("firmware-raspberrypi: firmware for RaspberryPi"
+                "linux-firmware-broadcom: firmware for RaspberryPi"
+                "virt-firmware: for editing EFI variables")
+    conflicts=(uboot-raspberrypi linux-rpi linux-rpi-16k edk2-raspberrypi)
+    provides=(edk2-raspberrypi)
+    backup=(boot/config.txt)
+
+    mkdir -p "$pkgdir/boot" "$pkgdir/usr/share/libalpm/hooks" "$pkgdir/usr/share/libalpm/scripts"
+    cat <<EOF > "$pkgdir/boot/config.txt"
+arm_control=0x200
+enable_uart=1
+armstub=RPI_EFI.fd
+disable_commandline_tags=2
+device_tree_address=0x1f0000
+device_tree_end=0x200000
+
+arm_64bit=1
+uart_2ndstage=1
+EOF
+    install -Dvm644 -t "$pkgdir/usr/share/libalpm/hooks/" -- *edk2-rpi3*.hook
+    install -Dvm755 -t "$pkgdir/usr/share/libalpm/scripts/" edk2-rpi3
+}

--- a/alarm/edk2-raspberrypi/edk2-rpi3
+++ b/alarm/edk2-raspberrypi/edk2-rpi3
@@ -1,0 +1,107 @@
+#!/usr/bin/bash
+
+# Needs files list from stdin.
+# Should be triggered by pacman hook.
+# Arguments:
+# --install:    Sync files
+# --uninstall:  Remove files
+
+declare target
+for target in efi boot boot/efi
+do
+    if [[ -d "$target/EFI" ]]
+    then
+        break
+    fi
+done
+if [[ -z "$target" ]]
+then
+    echo "Unable to detect EFI mountpoint, using fallback value..."
+    target=boot
+fi
+readonly target
+
+declare file sync_target
+while read -r file
+do
+    case "$file" in
+        usr/share/edk2/aarch64/RPi3_EFI.fd)
+            sync_target="$target/RPI_EFI.fd"
+            if [[ "$1" == "--install" ]]
+            then
+                if [[ ! -f "$sync_target" ]]
+                then
+                    cp "$file" "$sync_target"
+                else
+                    echo "Existing $sync_target is found, saving to pacnew..."
+                    cp "$file" "$sync_target.pacnew"
+                fi
+            elif [[ "$1" == "--uninstall" ]]
+            then
+                if [[ -f "$sync_target" ]]
+                then
+                    echo "Saving $sync_target to pacsave..."
+                    mv "$sync_target" "$sync_target.pacsave"
+                else
+                    echo "$sync_target is not found."
+                fi
+            fi
+            ;;
+        boot/config.txt)
+            if [[ "$target" != "boot" ]]
+            then
+                sync_target="$target/config.txt"
+                if [[ "$1" == "--install" ]]
+                then
+                    if [[ ! -f "$sync_target" ]]
+                    then
+                        cp "$file" "$sync_target"
+                    else
+                        echo "Existing $sync_target is found, skipping..."
+                    fi
+                elif [[ "$1" == "--uninstall" ]]
+                then
+                    if [[ -f "$sync_target" ]]
+                    then
+                        rm "$sync_target"
+                    else
+                        echo "$sync_target is not found."
+                    fi
+                fi
+            fi
+            ;;
+        boot/dtbs/broadcom/bcm2711-rpi-3*.dtb|boot/dtbs/broadcom/bcm2710-rpi-2-b.dtb|boot/dtbs/broadcom/bcm2710-rpi-cm3.dtb)
+            sync_target="$target/$(basename "$file")"
+            if [[ "$1" == "--install" ]]
+            then
+                cp "$file" "$sync_target"
+            elif [[ "$1" == "--uninstall" ]]
+            then
+                if [[ -f "$sync_target" ]]
+                then
+                    rm "$sync_target"
+                else
+                    echo "$sync_target is not found."
+                fi
+            fi
+            ;;
+        boot/*)
+            if [[ "$target" != "boot" ]]
+            then
+                sync_target="$target/$(cut -d / -f 2- <<< "$file")"
+                if [[ "$1" == "--install" ]]
+                then
+                    cp -r "$file" "$sync_target"
+                elif [[ "$1" == "--uninstall" ]]
+                then
+                    if [[ -e "$sync_target" ]]
+                    then
+                        rm -r "$sync_target"
+                    else
+                        echo "$sync_target is not found."
+                    fi
+                fi
+            fi
+            ;;
+    esac
+done

--- a/alarm/edk2-raspberrypi/edk2-rpi4
+++ b/alarm/edk2-raspberrypi/edk2-rpi4
@@ -1,0 +1,107 @@
+#!/usr/bin/bash
+
+# Needs files list from stdin.
+# Should be triggered by pacman hook.
+# Arguments:
+# --install:    Sync files
+# --uninstall:  Remove files
+
+declare target
+for target in efi boot boot/efi
+do
+    if [[ -d "$target/EFI" ]]
+    then
+        break
+    fi
+done
+if [[ -z "$target" ]]
+then
+    echo "Unable to detect EFI mountpoint, using fallback value..."
+    target=boot
+fi
+readonly target
+
+declare file sync_target
+while read -r file
+do
+    case "$file" in
+        usr/share/edk2/aarch64/RPi4_EFI.fd)
+            sync_target="$target/RPI_EFI.fd"
+            if [[ "$1" == "--install" ]]
+            then
+                if [[ ! -f "$sync_target" ]]
+                then
+                    cp "$file" "$sync_target"
+                else
+                    echo "Existing $sync_target is found, saving to pacnew..."
+                    cp "$file" "$sync_target.pacnew"
+                fi
+            elif [[ "$1" == "--uninstall" ]]
+            then
+                if [[ -f "$sync_target" ]]
+                then
+                    echo "Saving $sync_target to pacsave..."
+                    mv "$sync_target" "$sync_target.pacsave"
+                else
+                    echo "$sync_target is not found."
+                fi
+            fi
+            ;;
+        boot/config.txt)
+            if [[ "$target" != "boot" ]]
+            then
+                sync_target="$target/config.txt"
+                if [[ "$1" == "--install" ]]
+                then
+                    if [[ ! -e "$sync_target" ]]
+                    then
+                        cp "$file" "$sync_target"
+                    else
+                        echo "Existing $sync_target is found, skipping..."
+                    fi
+                elif [[ "$1" == "--uninstall" ]]
+                then
+                    if [[ -f "$sync_target" ]]
+                    then
+                        rm "$sync_target"
+                    else
+                        echo "$sync_target is not found."
+                    fi
+                fi
+            fi
+            ;;
+        boot/dtbs/broadcom/bcm2711-rpi-4*.dtb)
+            sync_target="$target/$(basename "$file")"
+            if [[ "$1" == "--install" ]]
+            then
+                cp "$file" "$sync_target"
+            elif [[ "$1" == "--uninstall" ]]
+            then
+                if [[ -f "$sync_target" ]]
+                then
+                    rm "$sync_target"
+                else
+                    echo "$sync_target is not found."
+                fi
+            fi
+            ;;
+        boot/*)
+            if [[ "$target" != "boot" ]]
+            then
+                sync_target="$target/$(cut -d / -f 2- <<< "$file")"
+                if [[ "$1" == "--install" ]]
+                then
+                    cp -r "$file" "$sync_target"
+                elif [[ "$1" == "--uninstall" ]]
+                then
+                    if [[ -e "$sync_target" ]]
+                    then
+                        rm -r "$sync_target"
+                    else
+                        echo "$sync_target is not found."
+                    fi
+                fi
+            fi
+            ;;
+    esac
+done


### PR DESCRIPTION
This is the edk2 uefi firmware for [RPi3](https://github.com/tianocore/edk2-platforms/tree/master/Platform/RaspberryPi/RPi3) and [RPi4](https://github.com/tianocore/edk2-platforms/tree/master/Platform/RaspberryPi/RPi4) platforms.

Depends on `linux-aarch64` only because `linux-rpi` does not enable UEFI related configs.

We introduced several breaking changes compared to the previous uefi-raspberrypi4:
1. The sources are changed. We use sources from edk2 directly instead cloning https://github.com/pftf/RPi4.
2. Added `RPi3` support. There is also a https://github.com/pftf/RPi3, but as we use sources from edk2 directly, there is no need to download it anymore.
3. Removed `raspberrypi-overlays`. We use mainline kernel `linux-aarch64`, it does not support this and we should never mix device trees in those kernels. This is the most critical mistake in previous packages.

Packages in this pkgbase:
- `edk2-rpi3`: The firmware for `RPi3` platform. Added a qemu descriptor file like the upstream's `extra/edk2-aarch64`.
- `edk2-rpi4`: The firmware for `RPi4` platform. Added a qemu descriptor file like the upstream's `extra/edk2-aarch64`.
- `edk2-bootloader-rpi3`: A shim package contains `config.txt` and pacman hooks to copy firmware and devicetree to efi partition for booting `edk2-rpi3` on real machine.
- `edk2-bootloader-rpi4`: A shim package contains `config.txt` and pacman hooks to copy firmware and devicetree to efi partition for booting `edk2-rpi4` on real machine.

Features enabled during building:
- Secure Boot. Uses default certificates from [Microsoft](https://github.com/microsoft/secureboot_objects).
- ACPI+DeviceTree mode. This should let most of the devices available in OS.
- 3GB Limitation disabled. This allows OS using all memory. The `linux-aarch64` is new enough to handle this. It is only available for `RPi4` platform.