### PR TITLE
extra/qemu: to make qemu installable for aarch64

### DIFF
--- a/extra/qemu-user-static/PKGBUILD
+++ b/extra/qemu-user-static/PKGBUILD
@@ -1,0 +1,138 @@
+# Maintainer: David Runge <dvzrv@archlinux.org>
+# Contributor: Tobias Powalowski <tpowa@archlinux.org>
+# Contributor: Sébastien "Seblu" Luttringer <seblu@seblu.net>
+# Contributor: Qu Wenruo <wqu@suse.com>
+
+pkgbase=qemu
+pkgname=(
+	qemu-user-static{,-binfmt}
+)
+pkgver=7.1.0
+pkgrel=99
+pkgdesc="QEMU static user mode emulation"
+arch=(x86_64 aarch64)
+url="https://www.qemu.org/"
+license=(GPL2 LGPL2.1)
+makedepends=(
+	meson
+)
+source=(
+  https://download.qemu.org/qemu-$pkgver.tar.xz{,.sig}
+  $pkgbase-7.1.0-io_uring.patch::https://patchwork.kernel.org/project/qemu-devel/patch/20220924144815.5591-1-faithilikerun@gmail.com/raw/
+  $pkgbase-7.1.0-block1.patch::https://gitlab.com/qemu-project/qemu/-/commit/a7c5f67a78569f8c275ea4ea9962e9c79b9d03cb.diff
+  $pkgbase-7.1.0-block2.patch::https://gitlab.com/qemu-project/qemu/-/commit/25474d90aa50bd32e0de395a33d8de42dd6f2aef.diff
+)
+sha512sums=('c60c5ff8ec99b7552e485768908920658fdd8035ff7a6fa370fb6881957dc8b7e5f18ff1a8f49bd6aa22909ede2a7c084986d8244f12074ccd33ebe40a0c411f'
+	    'SKIP'
+            '306193b1ed6396acaf5d3d3957dd09954fadc7546c757cca113b35e6a0ad06e41efb94adcd9810d814858a7e2d5d3e535398128820e770b0bbdef2e5ab125cb0'
+            '2d1c76e2c1433867a0156bfb067a0df2229083b61215a87a317685c47f7921b0ce815901dccb005508cf0793b8c9dc37f76ef27b302fe78eb740df073710e672'
+            '4ad2aff54b9e7a85fc62c7dceceda5f946e7578dd1b9902a74383ffadce91d8ae7a4219e9ae3184fcba51fccea2f69fc040277c30b7566e79eb29e1604acd594')
+b2sums=('e05f91ce4993c7591a2df08b5fb017f8b8ec2141ab7bfd55d14730ea6b793ac1091de539992058392a5522d4e58beee92a87752707be58e3619b8213ef9f35bf'
+	'SKIP'
+        'd8b392ef1cd629796a9221f13df43a3ea3a4c2d50a574888a65fa5f9ecffcc75134b0a33ec798be65706831043926ceb2d4b1a8751fedcd181271a986318e6ed'
+        '06d1b099ef1acf393f2866925bbb43a6ad93c28b976deb69c4859aca8f3bd4180e3d49ff43a3d75193af4dd890ee38243a661399517dd4bb3fb74493f7ecfe7f'
+        '5171ae60bbaeb7f277459c27d18ece0d7ea890a71c2cdd110ea84e15b77e3dd491b75965583a1daa859459afafa5310544f58846b38997f91e307ce86a70ab45')
+validpgpkeys=('CEACC9E15534EBABB82D3FA03353C9CEF108B584') # Michael Roth <flukshun@gmail.com>
+
+_pick() {
+  local p="$1" f d; shift
+  for f; do
+    d="$srcdir/$p/${f#$pkgdir/}"
+    mkdir -p "$(dirname "$d")"
+    mv "$f" "$d"
+    rmdir -p --ignore-fail-on-non-empty "$(dirname "$f")"
+  done
+}
+
+prepare() {
+  # fix issues with io_uring: https://gitlab.com/qemu-project/qemu/-/issues/1193
+  patch -Np1 -d $pkgbase-$pkgver -i ../$pkgbase-7.1.0-io_uring.patch
+
+  # fix issue with block alignment: https://bugs.archlinux.org/task/76220
+  patch -Np1 -d $pkgbase-$pkgver -i ../$pkgbase-7.1.0-block1.patch
+  patch -Np1 -d $pkgbase-$pkgver -i ../$pkgbase-7.1.0-block2.patch
+
+  # extract licenses for TCG
+  sed -n '1,23p' $pkgbase-$pkgver/tcg/tcg-internal.h > tcg.LICENSE.MIT
+  sed -n '1,23p' $pkgbase-$pkgver/tcg/arm/tcg-target.c.inc > tcg-arm.LICENSE.MIT
+  sed -n '1,23p' $pkgbase-$pkgver/tcg/tci/tcg-target.h > tci.LICENSE.MIT
+
+  # create build dir
+  mkdir -vp build-static
+}
+
+build() {
+  cd build-static
+  ../$pkgbase-$pkgver/configure \
+      --prefix=/usr \
+      --sysconfdir=/etc \
+      --libexecdir=/usr/lib/qemu \
+      --enable-attr \
+      --enable-linux-user \
+      --enable-tcg \
+      --disable-bpf \
+      --disable-bsd-user \
+      --disable-capstone \
+      --disable-docs \
+      --disable-fdt \
+      --disable-gcrypt \
+      --disable-glusterfs \
+      --disable-gnutls \
+      --disable-gtk \
+      --disable-install-blobs \
+      --disable-kvm \
+      --disable-libiscsi \
+      --disable-libnfs \
+      --disable-libssh \
+      --disable-linux-io-uring \
+      --disable-nettle \
+      --disable-opengl \
+      --disable-qom-cast-debug \
+      --disable-sdl \
+      --disable-system \
+      --disable-tools \
+      --disable-tpm \
+      --disable-vde \
+      --disable-vhost-crypto \
+      --disable-vhost-kernel \
+      --disable-vhost-net \
+      --disable-vhost-user \
+      --disable-vnc \
+      --disable-werror \
+      --disable-xen \
+      --disable-zstd \
+      --static
+  ninja
+
+}
+
+package_qemu-user-static() {
+  pkgdesc="QEMU static user mode emulation"
+  depends=(glibc)
+  optdepends=('qemu-user-static-binfmt: for binary format rules')
+
+  meson install -C build-static --destdir "$pkgdir"
+
+  # rename static binaries to prevent name conflicts
+  for _src in "$pkgdir/usr/bin/qemu-"*; do
+    mv -v "$_src" "$pkgdir/usr/bin/$(basename "$_src")-static"
+  done
+  rm -rf $pkgdir/usr/lib $pkgdir/usr/share
+}
+
+package_qemu-user-static-binfmt() {
+  pkgdesc="Binary format rules for QEMU static user mode emulation"
+  depends=(qemu-user-static=$pkgver-$pkgrel)
+  provides=(qemu-user-binfmt-provider)
+  conflicts=(qemu-user-binfmt-provider)
+
+  meson install -C build-static --destdir "$pkgdir"
+  install -vdm 755 "$pkgdir/usr/lib/binfmt.d/"
+  $pkgbase-$pkgver/scripts/qemu-binfmt-conf.sh --systemd ALL --exportdir "$pkgdir/usr/lib/binfmt.d/" --qemu-path "/usr/bin"
+
+  # modify and rename binfmt.d configs to prevent name conflicts
+  for _conf in "$pkgdir/usr/lib/binfmt.d/"*; do
+    cat "$_conf" | tr -d '\n' | sed "s/:$/-static:F/" > "${_conf//.conf/-static.conf}"
+  done
+  rm -rf $pkgdir/usr/bin $pkgdir/usr/share
+}

--- a/extra/qemu-user-static/qemu-7.1.0-block1.patch
+++ b/extra/qemu-user-static/qemu-7.1.0-block1.patch
@@ -1,0 +1,76 @@
+diff --git a/block/file-posix.c b/block/file-posix.c
+index 256de1f456a77bb617aa9366f8028081313a5994..989dfc4586c2dbdf5e7b6d4a977b0e2e819195a4 100644
+--- a/block/file-posix.c
++++ b/block/file-posix.c
+@@ -2061,6 +2061,27 @@ static int coroutine_fn raw_thread_pool_submit(BlockDriverState *bs,
+     return thread_pool_submit_co(pool, func, arg);
+ }
+ 
++/*
++ * Check if all memory in this vector is sector aligned.
++ */
++static bool bdrv_qiov_is_aligned(BlockDriverState *bs, QEMUIOVector *qiov)
++{
++    int i;
++    size_t alignment = bdrv_min_mem_align(bs);
++    IO_CODE();
++
++    for (i = 0; i < qiov->niov; i++) {
++        if ((uintptr_t) qiov->iov[i].iov_base % alignment) {
++            return false;
++        }
++        if (qiov->iov[i].iov_len % alignment) {
++            return false;
++        }
++    }
++
++    return true;
++}
++
+ static int coroutine_fn raw_co_prw(BlockDriverState *bs, uint64_t offset,
+                                    uint64_t bytes, QEMUIOVector *qiov, int type)
+ {
+diff --git a/block/io.c b/block/io.c
+index 51d8f943a4b79a2d13c9f139ff666d542b6e7e62..c3200bcdffe2eefe7266f863bd7ac31246f2af5a 100644
+--- a/block/io.c
++++ b/block/io.c
+@@ -3227,27 +3227,6 @@ void *qemu_try_blockalign0(BlockDriverState *bs, size_t size)
+     return mem;
+ }
+ 
+-/*
+- * Check if all memory in this vector is sector aligned.
+- */
+-bool bdrv_qiov_is_aligned(BlockDriverState *bs, QEMUIOVector *qiov)
+-{
+-    int i;
+-    size_t alignment = bdrv_min_mem_align(bs);
+-    IO_CODE();
+-
+-    for (i = 0; i < qiov->niov; i++) {
+-        if ((uintptr_t) qiov->iov[i].iov_base % alignment) {
+-            return false;
+-        }
+-        if (qiov->iov[i].iov_len % alignment) {
+-            return false;
+-        }
+-    }
+-
+-    return true;
+-}
+-
+ void bdrv_io_plug(BlockDriverState *bs)
+ {
+     BdrvChild *child;
+diff --git a/include/block/block-io.h b/include/block/block-io.h
+index fd25ffa9be83c28ed98e20caa470de2c27d28f1a..492f95fc05744dabb170aa2fe76f1d656a8cc124 100644
+--- a/include/block/block-io.h
++++ b/include/block/block-io.h
+@@ -150,7 +150,6 @@ void *qemu_blockalign(BlockDriverState *bs, size_t size);
+ void *qemu_blockalign0(BlockDriverState *bs, size_t size);
+ void *qemu_try_blockalign(BlockDriverState *bs, size_t size);
+ void *qemu_try_blockalign0(BlockDriverState *bs, size_t size);
+-bool bdrv_qiov_is_aligned(BlockDriverState *bs, QEMUIOVector *qiov);
+ 
+ void bdrv_enable_copy_on_read(BlockDriverState *bs);
+ void bdrv_disable_copy_on_read(BlockDriverState *bs);

--- a/extra/qemu-user-static/qemu-7.1.0-block2.patch
+++ b/extra/qemu-user-static/qemu-7.1.0-block2.patch
@@ -1,0 +1,20 @@
+diff --git a/block/file-posix.c b/block/file-posix.c
+index 989dfc4586c2dbdf5e7b6d4a977b0e2e819195a4..66fdb07820c01fc0df29d9eede506af2d6b6a870 100644
+--- a/block/file-posix.c
++++ b/block/file-posix.c
+@@ -2068,13 +2068,14 @@ static bool bdrv_qiov_is_aligned(BlockDriverState *bs, QEMUIOVector *qiov)
+ {
+     int i;
+     size_t alignment = bdrv_min_mem_align(bs);
++    size_t len = bs->bl.request_alignment;
+     IO_CODE();
+ 
+     for (i = 0; i < qiov->niov; i++) {
+         if ((uintptr_t) qiov->iov[i].iov_base % alignment) {
+             return false;
+         }
+-        if (qiov->iov[i].iov_len % alignment) {
++        if (qiov->iov[i].iov_len % len) {
+             return false;
+         }
+     }

--- a/extra/qemu-user-static/qemu-7.1.0-io_uring.patch
+++ b/extra/qemu-user-static/qemu-7.1.0-io_uring.patch
@@ -1,0 +1,51 @@
+diff --git a/block/io_uring.c b/block/io_uring.c
+index a1760152e0..973e15d876 100644
+--- a/block/io_uring.c
++++ b/block/io_uring.c
+@@ -11,7 +11,6 @@
+ #include "qemu/osdep.h"
+ #include <liburing.h>
+ #include "block/aio.h"
+-#include "qemu/error-report.h"
+ #include "qemu/queue.h"
+ #include "block/block.h"
+ #include "block/raw-aio.h"
+@@ -19,7 +18,6 @@
+ #include "qapi/error.h"
+ #include "trace.h"
+ 
+-
+ /* io_uring ring size */
+ #define MAX_ENTRIES 128
+ 
+@@ -432,17 +430,8 @@ LuringState *luring_init(Error **errp)
+     }
+ 
+     ioq_init(&s->io_q);
+-#ifdef CONFIG_LIBURING_REGISTER_RING_FD
+-    if (io_uring_register_ring_fd(&s->ring) < 0) {
+-        /*
+-         * Only warn about this error: we will fallback to the non-optimized
+-         * io_uring operations.
+-         */
+-        warn_report("failed to register linux io_uring ring file descriptor");
+-    }
+-#endif
+-
+     return s;
++
+ }
+ 
+ void luring_cleanup(LuringState *s)
+diff --git a/meson.build b/meson.build
+index 3885fc1076..63cfb844cf 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1793,7 +1793,6 @@ config_host_data.set('CONFIG_LIBNFS', libnfs.found())
+ config_host_data.set('CONFIG_LIBSSH', libssh.found())
+ config_host_data.set('CONFIG_LINUX_AIO', libaio.found())
+ config_host_data.set('CONFIG_LINUX_IO_URING', linux_io_uring.found())
+-config_host_data.set('CONFIG_LIBURING_REGISTER_RING_FD', cc.has_function('io_uring_register_ring_fd', prefix: '#include <liburing.h>', dependencies:linux_io_uring))
+ config_host_data.set('CONFIG_LIBPMEM', libpmem.found())
+ config_host_data.set('CONFIG_NUMA', numa.found())
+ config_host_data.set('CONFIG_OPENGL', opengl.found())

--- a/extra/qemu/PKGBUILD
+++ b/extra/qemu/PKGBUILD
@@ -1,9 +1,12 @@
 # Maintainer: David Runge <dvzrv@archlinux.org>
 # Contributor: Tobias Powalowski <tpowa@archlinux.org>
 # Contributor: Sébastien "Seblu" Luttringer <seblu@seblu.net>
-
+# Contributor: Qu Wenruo <wqu@suse.com>
 # ALARM: Kevin Mihelich <kevin@archlinuxarm.org>
 #  - remove makedepends on numactl and seabios, revert not installing qemu seabios files
+# ALARM: Qu Wenruo <wqu@suse.com>
+#  - split user-static build into its own PKGBUILD, make qemu-base/qemu-desktop
+#    meta packages to use their native system emulator as default dependency
 
 pkgbase=qemu
 pkgname=(
@@ -23,15 +26,15 @@ pkgname=(
   qemu-tests
   qemu-tools
   qemu-ui-{curses,dbus,egl-headless,gtk,opengl,sdl,spice-{app,core}}
-  qemu-user{,-static}{,-binfmt}
+  qemu-user{,-binfmt}
   qemu-vhost-user-gpu
   qemu-virtiofsd
   qemu-{base,desktop,emulators-full,full}
 )
 pkgver=7.1.0
-pkgrel=10
+pkgrel=11
 pkgdesc="A generic and open source machine emulator and virtualizer"
-arch=(x86_64)
+arch=(x86_64 aarch64 arm)
 url="https://www.qemu.org/"
 license=(GPL2 LGPL2.1)
 # TODO: consider providing rdma-core
@@ -81,6 +84,7 @@ makedepends=(
   multipath-tools
   ncurses
   ndctl
+  numactl
   pam
   pcre2
   python
@@ -150,6 +154,7 @@ _qemu_system_deps=(
   liburing liburing.so
   lzo
   ndctl
+  numactl libnuma.so
   pam libpam.so
   pixman libpixman-1.so
   qemu-common=$pkgver-$pkgrel
@@ -254,75 +259,27 @@ prepare() {
 
   # create build dir
   mkdir -vp build
-  mkdir -vp build-static
 }
 
 build() {
-  (
-    cd build-static
-    ../$pkgbase-$pkgver/configure \
-      --prefix=/usr \
-      --sysconfdir=/etc \
-      --libexecdir=/usr/lib/qemu \
-      --enable-attr \
-      --enable-linux-user \
-      --enable-tcg \
-      --disable-bpf \
-      --disable-bsd-user \
-      --disable-capstone \
-      --disable-docs \
-      --disable-fdt \
-      --disable-gcrypt \
-      --disable-glusterfs \
-      --disable-gnutls \
-      --disable-gtk \
-      --disable-install-blobs \
-      --disable-kvm \
-      --disable-libiscsi \
-      --disable-libnfs \
-      --disable-libssh \
-      --disable-linux-io-uring \
-      --disable-nettle \
-      --disable-opengl \
-      --disable-qom-cast-debug \
-      --disable-sdl \
-      --disable-system \
-      --disable-tools \
-      --disable-tpm \
-      --disable-vde \
-      --disable-vhost-crypto \
-      --disable-vhost-kernel \
-      --disable-vhost-net \
-      --disable-vhost-user \
-      --disable-vnc \
-      --disable-werror \
-      --disable-xen \
-      --disable-zstd \
-      --static
-    ninja
-  )
-
   # Build only minimal debug info to reduce size
   CFLAGS+=' -g1'
   CXXFLAGS+=' -g1'
 
-  (
-    cd build
-    ../$pkgbase-$pkgver/configure \
-      --prefix=/usr \
-      --sysconfdir=/etc \
-      --libexecdir=/usr/lib/qemu \
-      --localstatedir=/var \
-      --docdir=/usr/share/doc/qemu \
-      --enable-modules \
-      --enable-sdl \
-      --enable-slirp=system \
-      --enable-tpm \
-      --smbd=/usr/bin/smbd \
-      --with-coroutine=ucontext
+  cd build
+  ../$pkgbase-$pkgver/configure \
+    --prefix=/usr \
+    --sysconfdir=/etc \
+    --libexecdir=/usr/lib/qemu \
+    --localstatedir=/var \
+    --docdir=/usr/share/doc/qemu \
+    --enable-modules \
+    --enable-sdl \
+    --enable-slirp=system \
+    --enable-tpm \
+    --smbd=/usr/bin/smbd \
+    --with-coroutine=ucontext
     ninja
-  )
-
 }
 
 package_qemu-common() {
@@ -333,20 +290,6 @@ package_qemu-common() {
     etc/sasl2/$pkgbase.conf
   )
   install=$pkgname.install
-
-  # install static binaries
-  meson install -C build-static --destdir "$pkgdir"
-  install -vdm 755 "$pkgdir/usr/lib/binfmt.d/"
-  $pkgbase-$pkgver/scripts/qemu-binfmt-conf.sh --systemd ALL --exportdir "$pkgdir/usr/lib/binfmt.d/" --qemu-path "/usr/bin"
-
-  # rename static binaries to prevent name conflicts
-  for _src in "$pkgdir/usr/bin/qemu-"*; do
-    mv -v "$_src" "$pkgdir/usr/bin/$(basename "$_src")-static"
-  done
-  # modify and rename binfmt.d configs to prevent name conflicts
-  for _conf in "$pkgdir/usr/lib/binfmt.d/"*; do
-    cat "$_conf" | tr -d '\n' | sed "s/:$/-static:F/" > "${_conf//.conf/-static.conf}"
-  done
 
   # install default binaries
   meson install -C build --destdir "$pkgdir"
@@ -367,6 +310,9 @@ package_qemu-common() {
 
   # remove unneeded files
   find "$pkgdir" -name .buildinfo -delete
+
+  # remove files provided by seabios
+  rm -fv "$pkgdir/usr/share/$pkgbase/"{bios,vgabios}*
 
   # remove files provided by edk2-{armvirt,ovmf}
   rm -fv "$pkgdir/usr/share/$pkgbase/"edk2-*
@@ -537,9 +483,6 @@ package_qemu-common() {
     _pick qemu-ui-sdl usr/lib/qemu/ui-sdl.so
     _pick qemu-ui-spice-app usr/lib/qemu/ui-spice-app.so
     _pick qemu-ui-spice-core usr/lib/qemu/ui-spice-core.so
-
-    _pick qemu-user-static usr/bin/qemu-*-static
-    _pick qemu-user-static-binfmt usr/lib/binfmt.d/*-static.conf
 
     _pick qemu-user usr/bin/qemu-{aarch64{,_be},alpha,arm{,eb},cris,hexagon,hppa,i386,loongarch64,m68k,microblaze{,el},mips{,64,64el,el,n32,n32el},nios2,or1k,ppc{,64,64le},riscv{32,64},s390x,sh4{,eb},sparc{,32plus,64},x86_64,xtensa{,eb}}
     _pick qemu-user-binfmt usr/lib/binfmt.d/*.conf
@@ -714,7 +657,8 @@ package_qemu-hw-s390x-virtio-gpu-ccw() {
 
 package_qemu-system-aarch64() {
   pkgdesc="QEMU system emulator for AARCH64"
-  depends=("${_qemu_system_deps[@]}" edk2-armvirt systemd-libs libudev.so)
+  depends=("${_qemu_system_deps[@]}" systemd-libs libudev.so)
+  optdepends=(edk2-armvirt)
   mv -v $pkgname/* "$pkgdir"
 }
 
@@ -1017,21 +961,6 @@ package_qemu-user-binfmt() {
   mv -v $pkgname/* "$pkgdir"
 }
 
-package_qemu-user-static() {
-  pkgdesc="QEMU static user mode emulation"
-  depends=(glibc)
-  optdepends=('qemu-user-static-binfmt: for binary format rules')
-  mv -v $pkgname/* "$pkgdir"
-}
-
-package_qemu-user-static-binfmt() {
-  pkgdesc="Binary format rules for QEMU static user mode emulation"
-  depends=(qemu-user-static=$pkgver-$pkgrel)
-  provides=(qemu-user-binfmt-provider)
-  conflicts=(qemu-user-binfmt-provider)
-  mv -v $pkgname/* "$pkgdir"
-}
-
 package_qemu-vhost-user-gpu() {
   pkgdesc="QEMU vhost-user-gpu display device"
   depends=(gcc-libs glib2 libglib-2.0.so libgmodule-2.0.so glibc pixman libpixman-1.so mesa qemu-common=$pkgver-$pkgrel virglrenderer)
@@ -1057,11 +986,18 @@ package_qemu-base() {
     qemu-hw-usb-{host,redirect,smartcard}=$pkgver-$pkgrel
     qemu-img=$pkgver-$pkgrel
     qemu-pr-helper=$pkgver-$pkgrel
-    qemu-system-x86=$pkgver-$pkgrel
     qemu-tools=$pkgver-$pkgrel
     qemu-ui-{curses,spice-{app,core}}=$pkgver-$pkgrel
     qemu-virtiofsd=$pkgver-$pkgrel
   )
+  # Add the native target as the dependency.
+  if [ $CARCH == "x86_64" ]; then
+    depends+=(qemu-system-x86=$pkgver-$pkgrel)
+  elif [ $CARCH == "aarch64" ]; then
+    depends+=(qemu-system-aarch64=$pkgver-$pkgrel)
+  elif [ $CARCH == "arm" ]; then
+    depends+=(qemu-system-arm=$pkgver-$pkgrel)
+  fi
   optdepends=("${_qemu_optdepends[@]}")
   # TODO: remove conflicts/provides/replaces for qemu-headless after 2022-10-01
   conflicts=(qemu qemu-headless)
@@ -1082,12 +1018,19 @@ package_qemu-desktop() {
     qemu-hw-usb-{host,redirect,smartcard}=$pkgver-$pkgrel
     qemu-img=$pkgver-$pkgrel
     qemu-pr-helper=$pkgver-$pkgrel
-    qemu-system-x86=$pkgver-$pkgrel
     qemu-tools=$pkgver-$pkgrel
     qemu-ui-{curses,dbus,egl-headless,gtk,opengl,sdl,spice-{app,core}}=$pkgver-$pkgrel
     qemu-vhost-user-gpu=$pkgver-$pkgrel
     qemu-virtiofsd=$pkgver-$pkgrel
   )
+  # Add the native target as the dependency.
+  if [ $CARCH == "x86_64" ]; then
+    depends+=(qemu-system-x86=$pkgver-$pkgrel)
+  elif [ $CARCH == "aarch64" ]; then
+    depends+=(qemu-system-aarch64=$pkgver-$pkgrel)
+  elif [ $CARCH == "arm" ]; then
+    depends+=(qemu-system-arm=$pkgver-$pkgrel)
+  fi
   optdepends=("${_qemu_optdepends[@]}")
   conflicts=(qemu)
   provides=(qemu=$pkgver)


### PR DESCRIPTION
Currently qemu package group has its problems, making it almost impossible to run libvirt with qemu:

- qemu-user-static build will fail using native tool chain This will prevent the whole package, including qemu-system-* which can compile without any problem.

- qemu-base and qemu-desktop depends on qemu-system-x86 Which makes completely no sense. This is something from the Archlinux PKGBUILD.

- No way to install qemu-system-aarch64 As it has hard dependency on edk2-armvirt, which is not buildable yet natively on aarch64 (missing arm toolchain AFAIK).

This update will solve the problems by:

- Split qemu-user-static into its own PKGBUILD Qemu-user-statis has a completely different use-case compared to system emulators. The most common usage is allowing the host to chroot into rootfs for another arch.

  Thus it is not suitable to contain qemu-user-static into qemu package. There is already a feature request to upstream Archlinux: https://bugs.archlinux.org/task/76556

- Make qemu-base and qemu-desktop to change its default system emulator dependecy Now the PKGBUILD will choose the default system emulator depending on the target arch.

- Make edk2-armvirt as optional dependency In fact we can directly install the same package from upstream Archlinux, as that package is just the edk2 uefi firmware, which is arch independent.

Have tested qemu PKGBUILD natively on both x86_64 and aarch64, and resulted qemu can work with libvirt using KVM.

Signed-off-by: Qu Wenruo <wqu@suse.com>