### PR TITLE
Re-enable gcc-ada 

### DIFF
--- a/core/gcc/PKGBUILD
+++ b/core/gcc/PKGBUILD
@@ -8,8 +8,6 @@
 # NOTE: libtool requires rebuilt with each new gcc version
 
 # ALARM: Kevin Mihelich <kevin@archlinuxarm.org>
-#  - removed ada packages
-#  - removed gnat (ada stuff) from gcc packaging
 #  - disabled make check, too much stress, kills plugs :(
 #  - specifid build host, disabled distcc
 #  - replaced bugurl with our GitHub issue page
@@ -17,7 +15,7 @@
 
 noautobuild=1
 
-pkgname=(gcc gcc-libs gcc-fortran gcc-objc gcc-go gcc-d lto-dump libgccjit)
+pkgname=(gcc gcc-libs gcc-fortran gcc-objc gcc-ada gcc-go gcc-d lto-dump libgccjit)
 pkgver=12.2.0
 _majorver=${pkgver%%.*}
 _commit=2ee5e4300186a92ad73f1a1a64cb918dc76c8d67
@@ -131,7 +129,7 @@ build() {
   CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
 
   "$srcdir/gcc/configure" \
-    --enable-languages=c,c++,fortran,go,lto,objc,obj-c++,d \
+    --enable-languages=c,c++,ada,fortran,go,lto,objc,obj-c++,d \
     --enable-bootstrap \
     "${_confflags[@]:?_confflags unset}"
 
@@ -273,7 +271,7 @@ package_gcc() {
 
   make -C gcc DESTDIR="$pkgdir" install-man install-info
   rm "$pkgdir"/usr/share/man/man1/{gccgo,gfortran,lto-dump,gdc}.1
-  rm "$pkgdir"/usr/share/info/{gccgo,gfortran,gdc}.info
+  rm "$pkgdir"/usr/share/info/{gccgo,gfortran,gnat-style,gnat_rm,gnat_ugn,gdc}.info
 
   make -C libcpp DESTDIR="$pkgdir" install
   make -C gcc DESTDIR="$pkgdir" install-po
@@ -325,6 +323,32 @@ package_gcc-objc() {
   make DESTDIR="$pkgdir" -C $CHOST/libobjc install-headers
   install -dm755 "$pkgdir/${_libdir}"
   install -m755 gcc/cc1obj{,plus} "$pkgdir/${_libdir}/"
+
+  # Install Runtime Library Exception
+  install -d "$pkgdir/usr/share/licenses/$pkgname/"
+  ln -s /usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION \
+    "$pkgdir/usr/share/licenses/$pkgname/"
+}
+
+package_gcc-ada() {
+  pkgdesc='Ada front-end for GCC (GNAT) (git version)'
+  depends=("gcc=$pkgver-$pkgrel" libisl.so)
+
+  cd gcc-build/gcc
+  make DESTDIR="$pkgdir" ada.install-{common,info}
+  install -m755 gnat1 "$pkgdir/${_libdir}"
+
+  cd "$srcdir"/gcc-build/$CHOST/libada
+  make DESTDIR="${pkgdir}" INSTALL="install" \
+    INSTALL_DATA="install -m644" install-libada
+
+  ln -s gcc "$pkgdir/usr/bin/gnatgcc"
+
+  # insist on dynamic linking, but keep static libraries because gnatmake complains
+  mv "$pkgdir"/${_libdir}/adalib/libgna{rl,t}-${_majorver}.so "$pkgdir/usr/lib"
+  ln -s libgnarl-${_majorver}.so "$pkgdir/usr/lib/libgnarl.so"
+  ln -s libgnat-${_majorver}.so "$pkgdir/usr/lib/libgnat.so"
+  rm -f "$pkgdir"/${_libdir}/adalib/libgna{rl,t}.so
 
   # Install Runtime Library Exception
   install -d "$pkgdir/usr/share/licenses/$pkgname/"


### PR DESCRIPTION
This PR (re-)enables gcc-ada support in Arch Linux ARM. I found myself with the need for it when trying to compile [ghdl](https://ghdl.github.io/ghdl/#), a popular open-source VHDL simulator written in Ada.

First off, I have seen https://github.com/archlinuxarm/PKGBUILDs/pull/1557, where this was previously considered in 2018. Since I know it's a big ask and more work than just enabling the extra package in the PKGBUILD, I tried (and succeeded) bootstrapping the package at least on aarch64 (Apple M2). Since gcc-ada itself requires gcc-ada to compile, I started using suitable foreign GCC binaries provided by Fedora. 

The bootstrap flow I have used is provided here: https://gist.github.com/thasti/60ea4c72b085a01ae98fe07a1934c7bd

A few remarks: In fact, I found that the gcc PKGBUILD on master does not currently compile (even without any changes), since some of the patches do not apply cleanly. Therefore (and to minimize the number of variables in the results), my approach was to build the same releases (glibc, binutils, gcc) as currently provided in the binary ALARM repositories. With the resulting packages, I was able to successfully build a working gcc & gcc-ada and can compile and use ghdl. 

The patch provided in the gist above cleanly applies to 7343534c5ba7e7c659f9c2df9872dfb724c345c9 - and results in this commit: https://github.com/thasti/PKGBUILDs/tree/enable_gcc_ada. To get from from that branch to this PR, I merely solved the conflicts arising from rebasing the branch onto master, but was not able to build-test them at that stage any longer (due to the GCC patches not applying cleanly).

I hope the addition of gcc-ada can be considered for an upcoming Archlinux ARM release. If there's anything else I could provide to help with that effort, please let me know!
