### PR TITLE
core/linux-aarch64: enable dynamic kernel preemption

### DIFF
--- a/core/linux-aarch64/PKGBUILD
+++ b/core/linux-aarch64/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-5.19
 _kernelname=${pkgbase#linux}
 _desc="AArch64 multi-platform"
 pkgver=5.19.8
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -29,7 +29,7 @@ md5sums=('f91bfe133d2cb1692f705947282e123a'
          '702a69746536f24fd5ebde90eed26048'
          'e0514a3e8f7383c1304faeff0121dfb5'
          '965c9f68072084cdbf1e083779d2ef0e'
-         '417932cd6167ff0b47c6dc297e3eb3fb'
+         '73cc6ddc21c578d7b6a0d6f8f0fb3ea8'
          '7c97cf141750ad810235b1ad06eb9f75'
          '61c5ff73c136ed07a7aadbf58db3d96a'
          '584777ae88bce2c5659960151b64c7d8'
@@ -191,6 +191,7 @@ _package-headers() {
 _package-chromebook() {
   pkgdesc="The Linux Kernel - ${_desc} - Chromebooks"
   depends=('linux-aarch64')
+  makedepends=('openssl-1.1')
   conflicts=('linux-aarch64-rc-chromebook')
   install=${pkgname}.install
 

--- a/core/linux-aarch64/config
+++ b/core/linux-aarch64/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.19.7 Kernel Configuration
+# Linux/arm64 5.19.8 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.1.0"
 CONFIG_CC_IS_GCC=y
@@ -110,7 +110,7 @@ CONFIG_PREEMPT_BUILD=y
 CONFIG_PREEMPT=y
 CONFIG_PREEMPT_COUNT=y
 CONFIG_PREEMPTION=y
-# CONFIG_PREEMPT_DYNAMIC is not set
+CONFIG_PREEMPT_DYNAMIC=y
 # CONFIG_SCHED_CORE is not set
 
 #


### PR DESCRIPTION
This pull request enables dynamic kernel preemption in `core/linux-aarch64` package and fixes building of `package-chromebook`, which is currently broken. The default kernel preemption stays unchanged, so this pull request does not introduce any changes to already existing systems. It only allows changing kernel preemption during runtime (which isn't currently possible).