### PR TITLE
alarm/devtools-alarm: Remove -d option from pacstrap

### DIFF
--- a/alarm/devtools-alarm/0010-remove-deprecated-d-option.patch
+++ b/alarm/devtools-alarm/0010-remove-deprecated-d-option.patch
@@ -1,0 +1,30 @@
+From a510331698bb13ca11ccd7db3f9beef75f87744c Mon Sep 17 00:00:00 2001
+From: Morten Linderud <foxboron@archlinux.org>
+Date: Mon, 21 Nov 2022 10:51:02 +0100
+Subject: [PATCH] mkarchroot: remove deprecated -d option
+
+It's been deprecated for a few years now.
+
+https://github.com/archlinux/arch-install-scripts/commit/91562aa99cd8237a2dec1aff5101949e40bf7d75
+
+Signed-off-by: Morten Linderud <foxboron@archlinux.org>
+---
+ src/mkarchroot.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/mkarchroot.in b/src/mkarchroot.in
+index d199bed..45ad19c 100644
+--- a/src/mkarchroot.in
++++ b/src/mkarchroot.in
+@@ -81,7 +81,7 @@ for file in "${files[@]}"; do
+ 	cp "$file" "$working_dir$file"
+ done
+ 
+-unshare --mount pacstrap -${umode}Mcd ${pac_conf:+-C "$pac_conf"} "$working_dir" \
++unshare --mount pacstrap -${umode}Mc ${pac_conf:+-C "$pac_conf"} "$working_dir" \
+ 	"${cache_dirs[@]/#/--cachedir=}" "$@" || die 'Failed to install all packages'
+ 
+ printf '%s.UTF-8 UTF-8\n' C en_US de_DE > "$working_dir/etc/locale.gen"
+-- 
+GitLab
+

--- a/alarm/devtools-alarm/PKGBUILD
+++ b/alarm/devtools-alarm/PKGBUILD
@@ -9,7 +9,7 @@
 pkgname=devtools-alarm
 _pkgname=devtools
 pkgver=20220621
-pkgrel=2
+pkgrel=3
 pkgdesc='Tools for Arch Linux ARM package maintainers'
 arch=('any')
 license=('GPL')
@@ -30,7 +30,8 @@ source=(${url}/uploads/8217baae0afcdb540bde9f5b030f05a9/devtools-${pkgver}.tar.g
         '0006-archbuild-no-setarch.patch'
         '0007-makechrootpkg-don-t-delete-MAKEFLAGS-and-PACKAGER.patch'
         '0008-makechrootpkg-gotmpdir.patch'
-        '0009-arm-helpers.patch')
+        '0009-arm-helpers.patch'
+        '0010-remove-deprecated-d-option.patch')
 validpgpkeys=(
   '4AA4767BBC9C4B1D18AE28B77F2D434B9741E8AC' # Pierre Schmitz <pierre@archlinux.org>
   '86CFFCA918CF3AF47147588051E8B148A9999C34' # Evangelos Foutras <foutrelis@archlinux.org>
@@ -50,7 +51,8 @@ sha256sums=('0938d41b4bc469e62d86d2a287612a090640f6eebde92137b8bd7727b89e95dd'
             '302a65bc27341b5ca3996763936ed85ef4335e6cee696ffae8c9796a44a7465a'
             '411c0f84b3cfbec4e86782c7ef8d990770a98b344fda1c5e2bc16add54e0482b'
             'e6d12573d7d66b0d64ff2975adde7ffc1b3cdf8e7851444dd2235b60ebe994ae'
-            '2e15998f10abe77cfe62893ebcf637f13ab1cf21ac9b51254c3fdb446fe69078')
+            '2e15998f10abe77cfe62893ebcf637f13ab1cf21ac9b51254c3fdb446fe69078'
+            '074d1402a7472539ae26421da840a4555197c2069e15892729a40d5e898e06b1')
 b2sums=('007f62b6cb3f06904fcafec4869a43136643bd364a7f0f314c792c08fbdafafaf8a268f8a372f78402deaa1f87bfc3f2fc7099f78742c6776d4ac49fe4884d58'
         'SKIP'
         'dd0f62be73c262002cf3fa34caea3c88709b8deb85a2bf7c658d1cd63d51eb618fc5b03a4ef420876ac77660753dc69549dead1fdcfea71728775191f2e80ed9'
@@ -61,7 +63,8 @@ b2sums=('007f62b6cb3f06904fcafec4869a43136643bd364a7f0f314c792c08fbdafafaf8a268f
         'f5a81fd9e2f67d7aa66c9f1365af102039a8fdd502ccd22b5570a90672c37795d0b2aa64cd1d3d09a70943f003a929c6211394f680002b164d71e33a884204fc'
         'c25c589c1f6584a08c30f875947fc5a1230c072ff5a87db0b5356a293a0ad7f374903a0a75ec92fd18549a917931cee7aff445b4f8f8dfc86309c1dfa0bdefa1'
         '03b6e0b136b91ec60b9c3f22b54aa66475d4c21f047bf33db2a0703ee0f200c04f3a4ce60af1edba8292d04f3c31d5aaac1357bf644236b686f09f207535e90c'
-        'c0b6b15469ac04fcd1a1e6040c013934284773508e43db8bffb5395de0c3885a76f922e6821474bbfcd0ad3df972e6558824004487ca321d11fd502636faab92')
+        'c0b6b15469ac04fcd1a1e6040c013934284773508e43db8bffb5395de0c3885a76f922e6821474bbfcd0ad3df972e6558824004487ca321d11fd502636faab92'
+        '8cf610d5478d214303971618eda9806ffa054545b402a580edd0a52c86477528664f89639070b28ed41fec376ca34cc98abb593cd4243278fcdba8108bcdf5bc')
 
 prepare() {
   cd "${_pkgname}-${pkgver}"
@@ -74,6 +77,7 @@ prepare() {
   patch -p1 -i ../0007-makechrootpkg-don-t-delete-MAKEFLAGS-and-PACKAGER.patch
   patch -p1 -i ../0008-makechrootpkg-gotmpdir.patch
   patch -p1 -i ../0009-arm-helpers.patch
+  patch -p2 -i ../0010-remove-deprecated-d-option.patch
 }
 
 build() {


### PR DESCRIPTION
An upstream update dropped the deprecated -d option from pacstrap, which broke mkarchroot in devtools-alarm. Apply the upstream devtools patch to fix this issue.

Bug report reference: https://archlinuxarm.org/forum/viewtopic.php?f=15&t=16282