### PR TITLE
extra/mesa: Re-enable LTO for aarch64

### DIFF
--- a/extra/mesa/PKGBUILD
+++ b/extra/mesa/PKGBUILD
@@ -15,7 +15,7 @@ pkgbase=mesa
 pkgname=('vulkan-mesa-layers' 'opencl-mesa' 'vulkan-radeon' 'vulkan-swrast' 'vulkan-broadcom' 'vulkan-panfrost' 'libva-mesa-driver' 'mesa-vdpau' 'mesa')
 pkgdesc="An open-source implementation of the OpenGL specification"
 pkgver=22.3.1
-pkgrel=1
+pkgrel=2
 arch=('x86_64')
 makedepends=('python-mako' 'libxml2' 'libx11' 'xorgproto' 'libdrm' 'libxshmfence' 'libxxf86vm'
              'libxdamage' 'libvdpau' 'libva' 'wayland' 'wayland-protocols' 'zstd' 'elfutils' 'llvm'
@@ -60,7 +60,7 @@ build() {
 
   arch-meson mesa-$pkgver build \
     -D b_ndebug=true \
-    -D b_lto=false \
+    -D b_lto=$([[ $CARCH == aarch64 ]] && echo true || echo false) \
     -D platforms=x11,wayland \
     -D gallium-drivers=r300,r600,radeonsi,freedreno,nouveau,swrast,virgl,zink,d3d12${GALLIUM} \
     -D vulkan-drivers=amd,swrast,broadcom,panfrost \


### PR DESCRIPTION
LTO was disabled in 06c1615 without an explanation, so I assume it wasn't done intentionally, as the comment mentioning LTO was left in the PKGBUILD.

Bug report reference:
https://archlinuxarm.org/forum/viewtopic.php?f=15&t=16285