### PR TITLE
Include chromedriver in chromium package

### DIFF
--- a/extra/chromium/PKGBUILD
+++ b/extra/chromium/PKGBUILD
@@ -272,6 +272,7 @@ package() {
   cd ../chromium-$pkgver
 
   install -D out/Release/chrome "$pkgdir/usr/lib/chromium/chromium"
+  install -D out/Release/chromedriver.unstripped "$pkgdir/usr/bin/chromedriver"
   install -Dm4755 out/Release/chrome_sandbox "$pkgdir/usr/lib/chromium/chrome-sandbox"
 
   install -Dm644 chrome/installer/linux/common/desktop.template \


### PR DESCRIPTION
See [here](https://archlinuxarm.org/forum/viewtopic.php?f=9&t=16306) for more information. I'm not sure why this was removed initially, but I successfully compiled the chromedriver binary on my Arch Linux ARM (Raspberry Pi 4) system and it works without issues. It's even compiled by default in the PKGBUILD, just not packaged for some reason.