### PR TITLE
graphene 1.10.8-1: disable neon simd on armv7h

### DIFF
--- a/extra/graphene/PKGBUILD
+++ b/extra/graphene/PKGBUILD
@@ -1,0 +1,60 @@
+# Maintainer: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
+ 
+pkgname=graphene
+pkgver=1.10.8
+pkgrel=1
+pkgdesc="A thin layer of graphic data types"
+url="https://ebassi.github.io/graphene/"
+arch=(x86_64)
+license=(MIT)
+makedepends=(git gtk-doc gobject-introspection meson glib2)
+checkdepends=(python-gobject python-tappy)
+options=(debug)
+_commit=4e2578450809c2099400cf85caf18eafcd7100aa  # tags/1.10.8^0
+source=("git+https://github.com/ebassi/graphene#commit=$_commit"
+        "git+https://github.com/ebassi/mutest"
+        no-installed-tests.diff)
+sha256sums=('SKIP'
+            'SKIP'
+            'fd7c41b25920077158d7de77f5d073e3a5a215c4d96c3b9bd016ffda615be4c4')
+
+pkgver() {
+  cd graphene
+  git describe --tags | sed 's/[^-]*-g/r&/;s/-/+/g'
+}
+
+prepare() {
+  cd graphene
+
+  # Don't install tests
+  git apply -3 ../no-installed-tests.diff
+
+  git submodule init
+  git submodule set-url subprojects/mutest "$srcdir/mutest"
+  git submodule update
+}
+
+build() {
+  if [ "${arch}" == "armv7h" ]; then
+    EXTRAFLAGS="-D arm_neon=false"
+  fi
+  arch-meson graphene build \
+    -D gtk_doc=true \
+    $EXTRAFLAGS \
+    -D installed_tests=false
+  meson compile -C build
+}
+
+check() {
+  meson test -C build --print-errorlogs
+}
+
+package() {
+  depends=(libg{lib,object}-2.0.so)
+  provides=(libgraphene-1.0.so)
+
+  meson install -C build --destdir "$pkgdir"
+  install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 graphene/LICENSE.txt
+}
+
+# vim:set sw=2 et:

--- a/extra/graphene/no-installed-tests.diff
+++ b/extra/graphene/no-installed-tests.diff
@@ -1,0 +1,15 @@
+diff --git i/tests/meson.build w/tests/meson.build
+index 0a6a355..0120c29 100644
+--- i/tests/meson.build
++++ w/tests/meson.build
+@@ -67,7 +67,9 @@ src_build_path = meson.current_build_dir() / '../src'
+ 
+ if build_gir and host_system == 'linux' and not meson.is_cross_build()
+   foreach unit: ['introspection.py']
+-    install_data(unit, install_dir: installed_test_bindir)
++    if get_option('installed_tests')
++      install_data(unit, install_dir: installed_test_bindir)
++    endif
+ 
+     wrapper = '@0@.test'.format(unit)
+     custom_target(wrapper,


### PR DESCRIPTION
This disables neon simd on armv7h devices only, because it crashes otherwise.
See: https://github.com/ebassi/graphene/issues/215
Redhat does the same thing in their spec file.

This is required to get the gnome-shell desktop running again om armv7h devices.
One would need to build and push an updated gnome-shell package though (it builds fine here).