### PR TITLE
xdg-desktop-portal 1.16.0-1: revert back to autoconf

### DIFF
--- a/extra/xdg-desktop-portal/PKGBUILD
+++ b/extra/xdg-desktop-portal/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
+# Contributor: Bartłomiej Piotrowski <bpiotrowski@archlinux.org>
+# Contributor: Patrick Griffis <tingping@tingping.se>
+
+pkgname=xdg-desktop-portal
+pkgver=1.16.0
+pkgrel=1
+pkgdesc="Desktop integration portals for sandboxed apps"
+url="https://github.com/flatpak/xdg-desktop-portal"
+arch=(x86_64)
+license=(LGPL)
+depends=(glib2 pipewire fuse3 geoclue rtkit systemd)
+makedepends=(autoconf xmlto docbook-xsl git flatpak libportal)
+options=(debug)
+_commit=88af6c8ca4106fcf70925355350a669848e9fd5a  # tags/1.16.0^0
+source=("git+https://github.com/flatpak/xdg-desktop-portal#commit=$_commit")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+  git describe --tags | sed 's/[^-]*-g/r&/;s/-/+/g'
+}
+
+prepare() {
+  cd $pkgname
+  autoreconf -vfi
+}
+
+build() {
+  cd $pkgname
+  ./configure \
+    --build=${CHOST} \
+    --host=${CHOST} \
+    --prefix=/usr
+  make
+}
+
+# check() {
+#  make test-portals
+# }
+
+package() {
+  depends+=(xdg-desktop-portal-impl)
+  cd $pkgname
+  make DESTDIR="$pkgdir" install
+}
+
+# vim:set sw=2 sts=-1 et:


### PR DESCRIPTION
Build xdg-desktop-portal with autoconf instead of meson.
This is required because meson doesn't detect correct string size for armv7h causing segfaults when loading the libraries.
No other changes have been made.