### PR TITLE
evolution-data-server 3.46.3-1: disable tests on armv7h

### DIFF
--- a/extra/evolution-data-server/PKGBUILD
+++ b/extra/evolution-data-server/PKGBUILD
@@ -1,0 +1,86 @@
+# Maintainer: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
+# Contributor: Jan de Groot <jgc@archlinux.org>
+
+pkgname=evolution-data-server
+pkgver=3.46.3
+pkgrel=1
+pkgdesc="Centralized access to appointments and contacts"
+url="https://wiki.gnome.org/Apps/Evolution"
+arch=(x86_64)
+depends=(
+  gcr-4
+  gnome-online-accounts
+  krb5
+  libcanberra
+  libgweather-4
+  libical
+  libphonenumber
+  nss
+  sqlite
+  webkit2gtk-4.1
+  webkit2gtk-5.0
+)
+makedepends=(
+  boost
+  cmake
+  git
+  gobject-introspection
+  gperf
+  gtk-doc
+  ninja
+  vala
+)
+provides=(
+  libcamel-1.2.so
+  libebackend-1.2.so
+  libebook-1.2.so
+  libebook-contacts-1.2.so
+  libecal-2.0.so
+  libedata-book-1.2.so
+  libedata-cal-2.0.so
+  libedataserver-1.2.so
+  libedataserverui-1.2.so
+  libedataserverui4-1.0.so
+)
+license=(GPL)
+_commit=ac9f84b358d13d9b04b63b64434691063787045b  # tags/3.46.3^0
+source=("git+https://gitlab.gnome.org/GNOME/evolution-data-server.git#commit=$_commit")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+  git describe --tags | sed 's/[^-]*-g/r&/;s/-/+/g'
+}
+
+prepare() {
+  cd $pkgname
+}
+
+build() {
+  local cmake_options=(
+    -DCMAKE_INSTALL_PREFIX=/usr
+    -DLIBEXEC_INSTALL_DIR=/usr/lib
+    -DSYSCONF_INSTALL_DIR=/etc
+    -DENABLE_GTK_DOC=ON
+    -DENABLE_INTROSPECTION=ON
+    -DENABLE_VALA_BINDINGS=ON
+    -DWITH_GWEATHER4=ON
+    -DWITH_LIBDB=OFF
+    -DWITH_PHONENUMBER=ON
+  )
+
+  cmake -S $pkgname -B build -G Ninja "${cmake_options[@]}"
+  cmake --build build
+}
+
+# Disabling tests on armv7h
+#check() {
+#  cd build
+#  ctest --output-on-failure --stop-on-failure
+#}
+
+package() {
+  DESTDIR="$pkgdir" cmake --install build
+}
+
+# vim:set sw=2 sts=-1 et:


### PR DESCRIPTION
Requires webkit2gtk-5.0 to be updated in the repository, see: https://github.com/archlinuxarm/PKGBUILDs/pull/1980

This disables the tests as they seem to fail on armv7h.
However the resulting package works fine for my machine.

The current version (3.44.4-2) in the repository, seems to crash when loading the gnome-calendar.

This is the last package that requiring updating for having a fully crash-free gnome-desktop experience.