### PR TITLE
Enable Arm-specific features of pixman

### DIFF
--- a/extra/pixman/PKGBUILD
+++ b/extra/pixman/PKGBUILD
@@ -7,7 +7,7 @@
 
 pkgname=pixman
 pkgver=0.42.2
-pkgrel=1
+pkgrel=1.1
 pkgdesc="The pixel-manipulation library for X and cairo"
 arch=(x86_64)
 url="https://cgit.freedesktop.org/pixman/"
@@ -21,18 +21,30 @@ sha512sums=('3476e2676e66756b1af61b1e532cd80c985c191fb7956eb01702b419726cce99e79
 #validpgpkeys=('') # Maarten Lankhorst <maarten.lankhorst@linux.intel.com>
 
 build() {
-  arch-meson $pkgbase-$pkgver build \
-    -D loongson-mmi=disabled \
-    -D vmx=disabled \
-    -D arm-simd=disabled \
-    -D neon=disabled \
-    -D a64-neon=disabled \
-    -D iwmmxt=disabled \
-    -D mmx=disabled \
-    -D sse2=disabled \
-    -D ssse3=disabled \
-    -D mips-dspr2=disabled \
-    -D gtk=disabled
+  if [ "${CARCH}" == aarch64 ]; then
+    arch-meson $pkgbase-$pkgver build \
+      -D loongson-mmi=disabled \
+      -D vmx=disabled \
+      -D arm-simd=disabled \
+      -D neon=disabled \
+      -D iwmmxt=disabled \
+      -D mmx=disabled \
+      -D sse2=disabled \
+      -D ssse3=disabled \
+      -D mips-dspr2=disabled \
+      -D gtk=disabled
+  else
+    arch-meson $pkgbase-$pkgver build \
+      -D loongson-mmi=disabled \
+      -D vmx=disabled \
+      -D a64-neon=disabled \
+      -D mmx=disabled \
+      -D sse2=disabled \
+      -D ssse3=disabled \
+      -D mips-dspr2=disabled \
+      -D gtk=disabled
+  fi
+
   ninja -C build
 }
 


### PR DESCRIPTION
The lack of Arm-specific features do not only result in bad performance, but causes behavioral changes as there is no fallback for pixman_blt(), for example.