### PR TITLE
alarm/amzn-ena-aarch64-dkms to 2.8.3-1

### DIFF
--- a/alarm/amzn-ena-aarch64-dkms/PKGBUILD
+++ b/alarm/amzn-ena-aarch64-dkms/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: iDigitalFlame <idf@idfla.me>
 pkgname="amzn-ena-aarch64-dkms"
-pkgver="2.8.0"
+pkgver="2.8.3"
 pkgrel="1"
 pkgdesc="Linux kernel driver for Amazon's Elastic Network Adapter (ENA)"
 arch=("aarch64")
@@ -8,14 +8,14 @@ url="https://github.com/amzn/amzn-drivers"
 license=("GPL")
 depends=("dkms" "linux-aarch64" "linux-aarch64-headers")
 install="amzn-drivers.install"
-source=("https://github.com/amzn/amzn-drivers/archive/refs/tags/ena_linux_2.8.0.tar.gz"
+source=("https://github.com/amzn/amzn-drivers/archive/refs/tags/ena_linux_${pkgver}.tar.gz"
         "dkms.conf")
-sha256sums=("345d3ac82aae53e4541dd437590f98b4136b15570d42ac6301380ae9d7976274"
-            "15b04f8e0cd64e2e28f126277a638259f14e8b1f18e75e28780ceb6c1d1fa2a3")
+sha256sums=("357ee02b7233514463d6d47d97f498a1840e83a86ba48c505994a71755998a44"
+            "6787747d1432d74a365768002494ab672b626568d73fe5ff13435191218628ee")
 buildarch=8
 
 package() {
     mkdir -p "${pkgdir}/usr/src" 2> /dev/null
-    cp -R "${srcdir}/amzn-drivers-ena_linux_2.8.0/kernel/linux" "${pkgdir}/usr/src/amzn-drivers-${pkgver}"
+    cp -R "${srcdir}/amzn-drivers-ena_linux_${pkgver}/kernel/linux" "${pkgdir}/usr/src/amzn-drivers-${pkgver}"
     install -Dm644 "dkms.conf" "${pkgdir}/usr/src/amzn-drivers-${pkgver}/dkms.conf"
 }

--- a/alarm/amzn-ena-aarch64-dkms/amzn-drivers.install
+++ b/alarm/amzn-ena-aarch64-dkms/amzn-drivers.install
@@ -2,15 +2,16 @@ post_install() {
     _ver=$(echo $1|awk -F'-' '{print $1}')
     dkms add -m amzn-drivers -v $_ver
     dkms build -m amzn-drivers -v $_ver
-    printf 'Make sure to add "ena" to the "mkinitcpio.conf" "MODULES" section'
-    printf ' and rebuild the intramfs with "mkinitcpio -P"\n'
+    printf 'Make sure to add "ena" to the "/etc/mkinitcpio.conf" "MODULES" section'
+    printf ' and rebuild the initramfs with "mkinitcpio -P"\n'
 }
 
 post_upgrade() {
     _ver_new=$(echo $1|awk -F'-' '{print $1}')
     _ver_old=$(echo $2|awk -F'-' '{print $1}')
-    dkms uninstall -m amzn-drivers -v $_ver_old --all
-    dkms remove -m amzn-drivers -v $_ver_old --all
-    dkms unbuild -m amzn-drivers -v $_ver_old --all
+    # Omitting error from dkms removal as the old driver may have been removed already.
+    dkms uninstall -m amzn-drivers -v $_ver_old --all 2> /dev/null
+    dkms remove -m amzn-drivers -v $_ver_old --all 2> /dev/null
+    dkms unbuild -m amzn-drivers -v $_ver_old --all 2> /dev/null
     dkms build -m amzn-drivers -v $_ver_new
 }

--- a/alarm/amzn-ena-aarch64-dkms/dkms.conf
+++ b/alarm/amzn-ena-aarch64-dkms/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="ena"
-PACKAGE_VERSION="2.8.0"
+PACKAGE_VERSION="2.8.3"
 CLEAN="make -C ena clean"
 MAKE="make -C ena/ BUILD_KERNEL=$kernelver"
 BUILT_MODULE_NAME[0]="ena"


### PR DESCRIPTION
Changes/Updates:
- Driver updated to latest release: 2.8.3 (from 2.8.0)
- Fixed a misspelling in the first install message.

Tests:
- [X] Build tested
- [X] Built in clean chroot
- [X] Tested in a live AWS ArchLinuxARM instance