### PR TITLE
added community/dtools

### DIFF
--- a/community/dtools/PKGBUILD
+++ b/community/dtools/PKGBUILD
@@ -1,0 +1,53 @@
+# Maintainer: Dan Printzell <wild@archlinux.org>
+# Maintainer: Filipe Laíns (FFY00) <lains@archlinux.org>
+# Contributor: Mihails Strasunse <public@dicebot.lv>
+
+# ALARM: Vladimir Panteleev <alarm-dtools@cy.md>
+#  - replace dmd dependency with ldc (DMD can only target x86/x86_64)
+#  - replace libphobos with liblphobos (DMD's standard library with LDC)
+#  - move liblphobos to depends (LDC links stdlib dynamically by default)
+#  - use ldmd in build() (ldmd is LDC's DMD-compatible entry point)
+
+pkgname=dtools
+pkgver=2.102.1
+pkgrel=1
+pkgdesc='Ancilliary tools for the D programming language'
+license=('Boost')
+groups=('dlang')
+arch=('x86_64')
+url='https://www.dlang.org'
+makedepends=('ldc')
+provides=('ddemangle' 'dustmite' 'rdmd')
+conflicts=('ddemangle' 'dustmite' 'rdmd')
+depends=('curl' 'liblphobos')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/dlang/tools/archive/v$pkgver.tar.gz")
+sha512sums=('260375f2cd80392435b14daee262509d37f858c96cee54b47a826f1f6276e665ced1b0e25811150117b4a7e09a7205bbeb4b60131d6aba4d350187a7ba00a835')
+
+build() {
+    DMD=ldmd
+
+    # Add $LDFLAGS to the compilation, and remove -flto
+    _linkflags=$(echo -ne $LDFLAGS | cut -d\" -f2 | tail -c+4 | sed -e "s/,/ -L=/g" -e "s/-flto=auto//")
+
+    cd tools-$pkgver
+    # rdmd is used to build others
+    $DMD -od. -ofdtools-rdmd -L--build-id $_linkflags rdmd.d
+
+    for tool in DustMite/dustmite ddemangle catdoc detab tolf dget; do
+        ./dtools-rdmd --compiler=$DMD --build-only -od. -ofdtools-`basename $tool` $_linkflags $tool.d
+    done
+}
+
+package() {
+    cd tools-$pkgver
+
+    mkdir -p "$pkgdir/usr/bin"
+    for tool in rdmd ddemangle catdoc detab tolf dget dustmite; do
+        install -m755 -t "$pkgdir/usr/bin" $pkgname-$tool
+    done
+
+    cd "$pkgdir"
+    ln -s dtools-rdmd usr/bin/rdmd
+    ln -s dtools-dustmite usr/bin/dustmite
+    ln -s dtools-ddemangle usr/bin/ddemangle
+}


### PR DESCRIPTION
[Upstream](https://github.com/archlinux/svntogit-community/blob/packages/dtools/trunk/PKGBUILD) uses `dmd` directly, which can only target `x86` and `x86_64`.

This version uses `ldc` which can target more architectures, including ARM.