### PR TITLE
extra/firefox: Re-enable webrtc for aarch64

### DIFF
--- a/extra/firefox/PKGBUILD
+++ b/extra/firefox/PKGBUILD
@@ -172,8 +172,6 @@ END
     echo "ac_add_options --disable-webrtc" >> .mozconfig
   elif [[ $CARCH == "aarch64" ]]; then
     echo 'ac_add_options --enable-rust-simd' >> .mozconfig
-    # webrtc on ARMv8 FTBFS in 109.0
-    echo "ac_add_options --disable-webrtc" >> .mozconfig
   fi
 
   echo 'ac_add_options --enable-optimize="-g0 -O2"' >> .mozconfig


### PR DESCRIPTION
The issues with webrtc compilation in the previous few versions were caused by a dumb typo in the webrtc patch that was added a few versions ago. This typo concerned a missing source file in the build scripts. This file was only missing for the aarch64 build setup (x86_64, x86 and arm where fine). The patch was made upstream by fedora, and they probably didn't notice the typo since they don't have an official aarch64 variant.

The patch has been removed for 111.0 since the issue has been solved upstream. Firefox 111.0 now compiles with webrtc on aarch64 without any problems. I did check this myself.