### PR TITLE
alarm/devtools-alarm to 20230307-1

### DIFF
--- a/alarm/devtools-alarm/0009-arm-helpers.patch
+++ b/alarm/devtools-alarm/0009-arm-helpers.patch
@@ -15,15 +15,6 @@ diff --git a/Makefile b/Makefile
 index d888cc1..0b834c2 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -28,6 +28,8 @@ BINPROGS = \
- 	$(IN_PROGS)
- 
- CONFIGFILES = \
-+	makepkg-aarch64.conf \
-+	makepkg-armv7h.conf \
- 	makepkg-x86_64.conf \
- 	makepkg-x86_64_v3.conf \
- 	pacman-extra.conf \
 @@ -59,10 +61,16 @@ COMMITPKG_LINKS = \
  	gnome-unstablepkg
  
@@ -41,11 +32,11 @@ index d888cc1..0b834c2 100644
  	staging-x86_64-build \
  	staging-x86_64_v3-build \
  	multilib-build \
-diff --git a/makepkg-aarch64.conf b/makepkg-aarch64.conf
+diff --git a/config/makepkg/aarch64.conf b/config/makepkg/aarch64.conf
 new file mode 100644
 index 0000000..63ba695
 --- /dev/null
-+++ b/makepkg-aarch64.conf
++++ b/config/makepkg/aarch64.conf
 @@ -0,0 +1,162 @@
 +#!/hint/bash
 +# shellcheck disable=2034
@@ -209,11 +200,11 @@ index 0000000..63ba695
 +#-- Command used to run pacman as root, instead of trying sudo and su
 +#PACMAN_AUTH=()
 +# vim: set ft=sh ts=2 sw=2 et:
-diff --git a/makepkg-armv7h.conf b/makepkg-armv7h.conf
+diff --git a/config/makepkg/armv7h.conf b/config/makepkg/armv7h.conf
 new file mode 100644
 index 0000000..ef28ddb
 --- /dev/null
-+++ b/makepkg-armv7h.conf
++++ b/config/makepkg/armv7h.conf
 @@ -0,0 +1,162 @@
 +#!/hint/bash
 +# shellcheck disable=2034

--- a/alarm/devtools-alarm/PKGBUILD
+++ b/alarm/devtools-alarm/PKGBUILD
@@ -8,8 +8,8 @@
 
 pkgname=devtools-alarm
 _pkgname=devtools
-pkgver=20220621
-pkgrel=2
+pkgver=20230307
+pkgrel=1
 pkgdesc='Tools for Arch Linux ARM package maintainers'
 arch=('any')
 license=('GPL')
@@ -20,8 +20,8 @@ depends=('bash' 'openssh' 'subversion' 'rsync' 'arch-install-scripts'
          'git' 'bzr' 'mercurial' 'diffutils' 'util-linux' 'awk')
 makedepends=('asciidoc')
 optdepends=('btrfs-progs: btrfs support')
-source=(${url}/uploads/8217baae0afcdb540bde9f5b030f05a9/devtools-${pkgver}.tar.gz
-        ${url}/uploads/8570458d06b07d5a3ff8d30a1fc392d4/devtools-${pkgver}.tar.gz.sig
+source=(${url}/uploads/dd8ad73d91417e228d94134e238b9043/devtools-${pkgver}.tar.gz
+        ${url}/uploads/3b99e9787a1ccbaf0cd3b7f1380f9e2e/devtools-${pkgver}.tar.gz.sig
         '0001-makechrootpkg-cache-dir.patch'
         '0002-arch-nspawn-keep-mirrorlist.patch'
         '0003-makechrootpkg-distcc.patch'
@@ -40,7 +40,7 @@ validpgpkeys=(
   '6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD' # Allan McRae (Developer) <allan@archlinux.org>
   'E240B57E2C4630BA768E2F26FC1B547C8D8172C8' # Levente Polyak <anthraxx@archlinux.org>
 )
-sha256sums=('0938d41b4bc469e62d86d2a287612a090640f6eebde92137b8bd7727b89e95dd'
+sha256sums=('0e1f8d7f37882cf18e79ab7e74581d79593e0f15f10b378b2443f0a2d557b523'
             'SKIP'
             '71ce5686b8dece2a181561dc32bb981c6b7d1a8d5e4c7884785de0db2f844cd4'
             'd835956292340e5283eb4f0f0634964b0445449a138ea9d377221aa1c8575a74'
@@ -50,8 +50,8 @@ sha256sums=('0938d41b4bc469e62d86d2a287612a090640f6eebde92137b8bd7727b89e95dd'
             '302a65bc27341b5ca3996763936ed85ef4335e6cee696ffae8c9796a44a7465a'
             '411c0f84b3cfbec4e86782c7ef8d990770a98b344fda1c5e2bc16add54e0482b'
             'e6d12573d7d66b0d64ff2975adde7ffc1b3cdf8e7851444dd2235b60ebe994ae'
-            '2e15998f10abe77cfe62893ebcf637f13ab1cf21ac9b51254c3fdb446fe69078')
-b2sums=('007f62b6cb3f06904fcafec4869a43136643bd364a7f0f314c792c08fbdafafaf8a268f8a372f78402deaa1f87bfc3f2fc7099f78742c6776d4ac49fe4884d58'
+            '2b3fc1467c6087e0651b7ebf5b8fa43d6cfa7fa5071f6833645cf066d14ddab8')
+b2sums=('348ad392840f49a71f17b39bf71a3a18d3610293de29029c0dcacb7aa23cef437258ec2f9dd454ac782ece82656d75af55a669a2f42294cd7fb6b041a79d2259'
         'SKIP'
         'dd0f62be73c262002cf3fa34caea3c88709b8deb85a2bf7c658d1cd63d51eb618fc5b03a4ef420876ac77660753dc69549dead1fdcfea71728775191f2e80ed9'
         'dfc5e501f4b61229daa071184bb8846c08ac17b226f134cd26c3a90610ab3419042c5259e0762603243f424d17c97133f05d99c92784327317d50b60cbb2a24b'
@@ -61,18 +61,19 @@ b2sums=('007f62b6cb3f06904fcafec4869a43136643bd364a7f0f314c792c08fbdafafaf8a268f
         'f5a81fd9e2f67d7aa66c9f1365af102039a8fdd502ccd22b5570a90672c37795d0b2aa64cd1d3d09a70943f003a929c6211394f680002b164d71e33a884204fc'
         'c25c589c1f6584a08c30f875947fc5a1230c072ff5a87db0b5356a293a0ad7f374903a0a75ec92fd18549a917931cee7aff445b4f8f8dfc86309c1dfa0bdefa1'
         '03b6e0b136b91ec60b9c3f22b54aa66475d4c21f047bf33db2a0703ee0f200c04f3a4ce60af1edba8292d04f3c31d5aaac1357bf644236b686f09f207535e90c'
-        'c0b6b15469ac04fcd1a1e6040c013934284773508e43db8bffb5395de0c3885a76f922e6821474bbfcd0ad3df972e6558824004487ca321d11fd502636faab92')
+        '1ba0ef9ff2fb6af6210c6c50f3f6e79678b3dbdbbbbc9ed15f88ddc505256ec6e030d6d3e898b4ed71449eace01fb98183a8f53426c60fc5e6b22d528073a0f9')
 
 prepare() {
-  cd "${_pkgname}-${pkgver}"
-  patch -p1 -i ../0001-makechrootpkg-cache-dir.patch
-  patch -p1 -i ../0002-arch-nspawn-keep-mirrorlist.patch
-  patch -p1 -i ../0003-makechrootpkg-distcc.patch
-  patch -p1 -i ../0004-arch-nspawn-arm-fix.patch
-  patch -p1 -i ../0005-makechrootpkg-no-default-logging.patch
-  patch -p1 -i ../0006-archbuild-no-setarch.patch
-  patch -p1 -i ../0007-makechrootpkg-don-t-delete-MAKEFLAGS-and-PACKAGER.patch
-  patch -p1 -i ../0008-makechrootpkg-gotmpdir.patch
+  cd "${_pkgname}-${pkgver}/src"
+  patch -p1 -i ../../0001-makechrootpkg-cache-dir.patch
+  patch -p1 -i ../../0002-arch-nspawn-keep-mirrorlist.patch
+  patch -p1 -i ../../0003-makechrootpkg-distcc.patch
+  patch -p1 -i ../../0004-arch-nspawn-arm-fix.patch
+  patch -p1 -i ../../0005-makechrootpkg-no-default-logging.patch
+  patch -p1 -i ../../0006-archbuild-no-setarch.patch
+  patch -p1 -i ../../0007-makechrootpkg-don-t-delete-MAKEFLAGS-and-PACKAGER.patch
+  patch -p1 -i ../../0008-makechrootpkg-gotmpdir.patch
+  cd ..
   patch -p1 -i ../0009-arm-helpers.patch
 }
 


### PR DESCRIPTION
Hello!
I know I am not the maintainer of this package but I though I would submit a fix for an issue that I receive while using the package.

**Cause**

The current version `20220621-2` causes an error when attempting to run `extra-aarch64-build` as `pacstrap` no longer supports the `-d` command argument. When running it I receive the error message:

```shell
[pkg@builder 2.8.4]$ extra-aarch64-build
==> Creating chroot for [extra] (aarch64)...
Create subvolume '/var/lib/archbuild/extra-aarch64/root'
==> ERROR: pacstrap: invalid option -- 'd'
==> ERROR: Failed to install all packages
==> ERROR: Aborting...
[pkg@builder 2.8.4]$
```

Fixed in [this line](https://gitlab.archlinux.org/archlinux/devtools/-/blob/master/src/mkarchroot.in#L84).

Instead of manually editing the `/usr/bin/mkarchroot` file and removing the `d` in the `pacstrap` command line, I realized the package was out of date and I modified the `PKGBUILD` and the `0009-arm-helpers.patch` files as the directory structure of the project has changed since the last package version.

Feel free to reject and have the maintainer fix/use my patches to fix if that works better :).

**Tests**

- [X] Build tested
- [X] Built in clean chroot
- [X] Used the updated version to test the original failing `extra-aarch64-build` build (which worked)