### PR TITLE
alarm/amzn-ena-aarch64-dkms to 2.8.5-1

### DIFF
--- a/alarm/amzn-ena-aarch64-dkms/PKGBUILD
+++ b/alarm/amzn-ena-aarch64-dkms/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: iDigitalFlame <idf@idfla.me>
 pkgname="amzn-ena-aarch64-dkms"
-pkgver="2.8.4"
+pkgver="2.8.5"
 pkgrel="1"
 pkgdesc="Linux kernel driver for Amazon's Elastic Network Adapter (ENA)"
 arch=("aarch64")
@@ -10,8 +10,8 @@ depends=("dkms" "linux-aarch64" "linux-aarch64-headers")
 install="amzn-drivers.install"
 source=("https://github.com/amzn/amzn-drivers/archive/refs/tags/ena_linux_${pkgver}.tar.gz"
         "dkms.conf")
-sha256sums=("b124296c9bae2e5f63e90d88d64e86d3697d7aa714bf16363928707abbb9e49a"
-            "52f3e6d638fe1287347d398964bdc3978104d696094678ee76e712fed0e6b31e")
+sha256sums=("5007ad3b521fb782e2d99d51ac2e3e3db2ae8dec0a8d84783467abc9991c789f"
+            "239242dc97403e376406777ce7fa08823651c7d69afb83e4fd0a0d462e319e71")
 buildarch=8
 
 package() {

--- a/alarm/amzn-ena-aarch64-dkms/dkms.conf
+++ b/alarm/amzn-ena-aarch64-dkms/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="ena"
-PACKAGE_VERSION="2.8.4"
+PACKAGE_VERSION="2.8.5"
 CLEAN="make -C ena clean"
 MAKE="make -C ena/ BUILD_KERNEL=$kernelver"
 BUILT_MODULE_NAME[0]="ena"


### PR DESCRIPTION
Changes/Updates:

- Driver updated to the latest release: 2.8.5 (from 2.8.4)

Tests:

- [X] Build tested
- [X] Built in clean chroot
- [X] Tested in a live AWS ArchLinuxARM instance