### PR TITLE
alarm/firmware-veyron to 1.0-2

### DIFF
--- a/alarm/firmware-veyron/PKGBUILD
+++ b/alarm/firmware-veyron/PKGBUILD
@@ -4,17 +4,15 @@ buildarch=4
 
 pkgname=firmware-veyron
 pkgver=1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Additional firmware for Veyron chromebooks"
 arch=('armv7h')
 url="https://archlinuxarm.org"
 license=('custom')
-source=('https://archlinuxarm.org/builder/src/veyron/brcmfmac4354-sdio.bin'
-        'https://archlinuxarm.org/builder/src/veyron/brcmfmac4354-sdio.txt')
-md5sums=('a3a73454d750f6b01170c7cbaa02c952'
-         '13e41678ae81bdd70b3778fb2dc29662')
+source=('https://archlinuxarm.org/builder/src/veyron/brcmfmac4354-sdio.txt')
+md5sums=('13e41678ae81bdd70b3778fb2dc29662')
 
 package() {
   install -m 0755 -d "${pkgdir}/usr/lib/firmware/updates/brcm"
-  install -m 0644 brcmfmac4354-sdio.{bin,txt} "${pkgdir}/usr/lib/firmware/updates/brcm"
+  install -m 0644 brcmfmac4354-sdio.txt "${pkgdir}/usr/lib/firmware/updates/brcm"
 }


### PR DESCRIPTION
[This post on the forums](https://archlinuxarm.org/forum/viewtopic.php?f=44&t=15943) describes the situation in detail.

`brcmfmac4354-sdio.bin` is now provided by the `core/linux-firmware` package.

The `brcmfmac4354-sdio.bin` file that is currently provided by the `alarm/firmware-veyron` package was last updated in 2016, but [the firmware has continued to receive updates since then](https://lore.kernel.org/linux-wireless/?q=brcmfmac4354-sdio). This outdated firmware is in a higher priority location in the firmware search path (`/lib/firmware/updates`) than the file provided by the `core/linux-firmware` package (`/lib/firmware`). On my ASUS C201P, my wireless interface only began working after I deleted the outdated file.

This updated PKGBUILD no longer provides `brcmfmac4354-sdio.bin`.

The other file provided by the package, `brcmfmac4354-sdio.txt`, is still necessary for my wireless interface to function.