### PR TITLE
core/linux-armv7 enable dtb symbols

### DIFF
--- a/core/linux-armv7/PKGBUILD
+++ b/core/linux-armv7/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-6.2
 _kernelname=${pkgbase#linux}
 _desc="ARMv7 multi-platform"
 pkgver=6.2.10
-pkgrel=1
+pkgrel=2
 rcnver=6.2.0
 rcnrel=multiv7-r0
 arch=('armv7h')
@@ -105,7 +105,9 @@ build() {
   #yes "" | make config
 
   # build!
-  make ${MAKEFLAGS} zImage modules dtbs
+  make ${MAKEFLAGS} zImage modules
+  # Generate device tree blobs with symbols to support applying device tree overlays in U-Boot
+  make ${MAKEFLAGS} DTC_FLAGS="-@" dtbs
 }
 
 _package() {


### PR DESCRIPTION
Similar to #1623, linux-armv7 needs symbols on the /boot/dtbs for overlays to work. Tested on my Banana Pi M2 Zero and the sun8i-h3-uart3.dtbo from ripped from Armbian and m2-zero-eth0.dtbo from [this blog post](https://lisy.dev/banana-pi-m2-zero.html).