### PR TITLE
Deno

### DIFF
--- a/extra/deno/Cargo.toml.patch
+++ b/extra/deno/Cargo.toml.patch
@@ -1,0 +1,26 @@
+--- Cargo.toml.orig	2023-07-15 15:39:59.618904488 +0000
++++ Cargo.toml	2023-07-15 22:04:36.249321112 +0000
+@@ -169,9 +169,9 @@
+ 
+ # NB: the `bench` and `release` profiles must remain EXACTLY the same.
+ [profile.release]
+-codegen-units = 1
++codegen-units = 32
+ incremental = true
+-lto = true
++lto = false
+ opt-level = 'z' # Optimize for size
+ 
+ # Build release with debug symbols: cargo build --profile=release-with-debug
+@@ -181,9 +181,9 @@
+ 
+ # NB: the `bench` and `release` profiles must remain EXACTLY the same.
+ [profile.bench]
+-codegen-units = 1
++codegen-units = 32
+ incremental = true
+-lto = true
++lto = false
+ opt-level = 'z' # Optimize for size
+ 
+ # Key generation is too slow on `debug`

--- a/extra/deno/PKGBUILD
+++ b/extra/deno/PKGBUILD
@@ -3,8 +3,6 @@
 
 # ALARM: Will Christensen <wirwc[at]gmail.com>
 # - edit Config.toml for release codegen-units to 32, lto to false
-# - use tmp folder due to smaller ARM targets having limited swap
-# - adjust check and package to use tmp location for release
 
 
 pkgname=deno
@@ -32,26 +30,27 @@ prepare() {
 build() {
   cd $pkgname
   # For systems with less than 4.5 GB swap 
-  CARGO_TARGET_DIR=tmp
+  CARGO_TARGET_DIR=tmp cargo install mdbook
   cargo build --release
 }
 
 check() {
   cd $pkgname
   ls -lsa
-  ./tmp/release/deno run cli/tests/testdata/run/002_hello.ts
+  # ./tmp/release/deno run cli/tests/testdata/run/002_hello.ts
+  ./target/release/deno run cli/tests/testdata/run/002_hello.ts
 }
 
 package() {
   cd $pkgname
-  install -Dm755 tmp/release/deno "$pkgdir"/usr/bin/deno
+  install -Dm755 target/release/deno "$pkgdir"/usr/bin/deno
 
   install -dm755 "$pkgdir"/usr/share/bash-completion/completions
-  ./tmp/release/deno completions bash > "$pkgdir"/usr/share/bash-completion/completions/deno
+  ./target/release/deno completions bash > "$pkgdir"/usr/share/bash-completion/completions/deno
   install -dm755 "$pkgdir"/usr/share/zsh/site-functions
-  ./tmp/release/deno completions zsh > "$pkgdir"/usr/share/zsh/site-functions/_deno
+  ./target/release/deno completions zsh > "$pkgdir"/usr/share/zsh/site-functions/_deno
   install -dm755 "$pkgdir"/usr/share/fish/vendor_functions.d
-  ./tmp/release/deno completions fish > "$pkgdir"/usr/share/fish/vendor_functions.d/deno.fish
+  ./target/release/deno completions fish > "$pkgdir"/usr/share/fish/vendor_functions.d/deno.fish
 
   install -Dm644 LICENSE.md -t "$pkgdir"/usr/share/licenses/$pkgname/
 }

--- a/extra/deno/PKGBUILD
+++ b/extra/deno/PKGBUILD
@@ -3,6 +3,8 @@
 
 # ALARM: Will Christensen <wirwc[at]gmail.com>
 # - edit Config.toml for release codegen-units to 32, lto to false
+# - use tmp folder due to smaller ARM targets having limited swap
+# - adjust check and package to use tmp location for release
 
 
 pkgname=deno
@@ -36,20 +38,20 @@ build() {
 
 check() {
   cd $pkgname
-  ./target/release/deno run cli/tests/testdata/run/002_hello.ts
+  ls -lsa
+  ./tmp/release/deno run cli/tests/testdata/run/002_hello.ts
 }
 
 package() {
   cd $pkgname
-  install -Dm755 target/release/deno "$pkgdir"/usr/bin/deno
+  install -Dm755 tmp/release/deno "$pkgdir"/usr/bin/deno
 
   install -dm755 "$pkgdir"/usr/share/bash-completion/completions
-  ./target/release/deno completions bash > "$pkgdir"/usr/share/bash-completion/completions/deno
+  ./tmp/release/deno completions bash > "$pkgdir"/usr/share/bash-completion/completions/deno
   install -dm755 "$pkgdir"/usr/share/zsh/site-functions
-  ./target/release/deno completions zsh > "$pkgdir"/usr/share/zsh/site-functions/_deno
+  ./tmp/release/deno completions zsh > "$pkgdir"/usr/share/zsh/site-functions/_deno
   install -dm755 "$pkgdir"/usr/share/fish/vendor_functions.d
-  ./target/release/deno completions fish > "$pkgdir"/usr/share/fish/vendor_functions.d/deno.fish
+  ./tmp/release/deno completions fish > "$pkgdir"/usr/share/fish/vendor_functions.d/deno.fish
 
   install -Dm644 LICENSE.md -t "$pkgdir"/usr/share/licenses/$pkgname/
 }
-

--- a/extra/deno/PKGBUILD
+++ b/extra/deno/PKGBUILD
@@ -30,7 +30,7 @@ prepare() {
 build() {
   cd $pkgname
   # For systems with less than 4.5 GB swap 
-  CARGO_TARGET_DIR=tmp cargo install mdbook
+  CARGO_TARGET_DIR=tmp
   cargo build --release
 }
 

--- a/extra/deno/PKGBUILD
+++ b/extra/deno/PKGBUILD
@@ -24,13 +24,13 @@ prepare() {
   cd $pkgname
   # https://github.com/denoland/deno/issues/19528
   git cherry-pick -n c8dc6b14ec5c1b6de28118ed3b07d037eaaaf702
-  patch -Np1 -i ../Cargo.toml.patch -u Cargo.toml
+  patch -Np1  -u Cargo.toml -i ../../Cargo.toml.patch
 }
 
 build() {
   cd $pkgname
   # For systems with less than 4.5 GB swap 
-  CARGO_TARGET_DIR=tmp cargo install
+  CARGO_TARGET_DIR=tmp cargo install mdbook
   cargo build --release
 }
 

--- a/extra/deno/PKGBUILD
+++ b/extra/deno/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+# Contributor: Metal A-wing <1 at 233 dot email>
+
+# ALARM: Will Christensen <wirwc[at]gmail.com>
+# - edit Config.toml for release codegen-units to 32, lto to false
+
+
+pkgname=deno
+pkgver=1.35.1
+_commit=b4824bf45f3d12e1b53e7eb5afcd49c38a575210
+pkgrel=1
+pkgdesc="A secure runtime for JavaScript and TypeScript"
+arch=('x86_64' 'aarch64')
+url="https://deno.land"
+license=('MIT')
+options=('!lto')
+depends=('gcc-libs')
+makedepends=('git' 'python' 'rust' 'nodejs')
+source=("git+https://github.com/denoland/deno.git#commit=$_commit" "Cargo.toml.patch")
+sha512sums=('SKIP'
+            'a0041dcece68c4d7e1e40d7b78e508e976260cd56eb30f606ec277e9d7ddd9b5d41e2a18f8fb426e6f14c670ef14c5d0801453874c0793d7d7b553e7080e387f')
+
+prepare() {
+  cd $pkgname
+  # https://github.com/denoland/deno/issues/19528
+  git cherry-pick -n c8dc6b14ec5c1b6de28118ed3b07d037eaaaf702
+  patch -Np1 -i ../Cargo.toml.patch -u Cargo.toml
+}
+
+build() {
+  cd $pkgname
+  # For systems with less than 4.5 GB swap 
+  CARGO_TARGET_DIR=tmp cargo install
+  cargo build --release
+}
+
+check() {
+  cd $pkgname
+  ./target/release/deno run cli/tests/testdata/run/002_hello.ts
+}
+
+package() {
+  cd $pkgname
+  install -Dm755 target/release/deno "$pkgdir"/usr/bin/deno
+
+  install -dm755 "$pkgdir"/usr/share/bash-completion/completions
+  ./target/release/deno completions bash > "$pkgdir"/usr/share/bash-completion/completions/deno
+  install -dm755 "$pkgdir"/usr/share/zsh/site-functions
+  ./target/release/deno completions zsh > "$pkgdir"/usr/share/zsh/site-functions/_deno
+  install -dm755 "$pkgdir"/usr/share/fish/vendor_functions.d
+  ./target/release/deno completions fish > "$pkgdir"/usr/share/fish/vendor_functions.d/deno.fish
+
+  install -Dm644 LICENSE.md -t "$pkgdir"/usr/share/licenses/$pkgname/
+}
+


### PR DESCRIPTION
**Addition:** Adds necessary changes for building natively on ARM targets for [deno](https://deno.land). 

Tests:
- [x] Build tested
- [x] Builds in clean chroot
- [x] Tested on a live M1 Mac Mini running Asahi Linux and builds on an Odroid N2.