### PR TITLE
core/systemd to 254.1

### DIFF
--- a/core/systemd/PKGBUILD
+++ b/core/systemd/PKGBUILD
@@ -13,8 +13,8 @@ pkgname=('systemd'
          'systemd-resolvconf'
          'systemd-sysvcompat'
          'systemd-ukify')
-_tag='34818a93c640ce377f0d00849a74e029624b4a12' # git rev-parse v${_tag_name}
-_tag_name=254
+_tag='2c4171c3c4146fcb32253bfb6423b5a3ee42a553' # git rev-parse v${_tag_name}
+_tag_name=254.1
 pkgver="${_tag_name/-/}"
 pkgrel=1
 arch=('x86_64')


### PR DESCRIPTION
Port of https://gitlab.archlinux.org/archlinux/packaging/packages/systemd/-/commit/a5ee36bfd27adf58c419b596cbbc27c293640e97

This update is urgent as it contains an fix to https://github.com/systemd/systemd/issues/28671

Version 254 contains a bad /usr/lib/udev/rules.d/60-persistent-storage.rules file which will cause `ID_NAME` and `ID_SERIAL` fields missing for MMC/Memstick block devices and `/dev/disk/by-id/mmc*` links to not be created. This will break a user's boot configuration or fstab if they're using `/dev/disk/by-id/ mmc*` links as rootfs identifier or fstab mounting sources.

As most alarm users might be using a device with SD/eMMC support, they will encounter the bug and that needs to be fixed.