### PR TITLE
extra/chromium: optimize eu-strip building logic

### DIFF
--- a/extra/chromium/0004-Optimize-eu-strip-building-logic.patch
+++ b/extra/chromium/0004-Optimize-eu-strip-building-logic.patch
@@ -1,0 +1,29 @@
+From dd231c7db95c106ab3915a58dcc696c167a403d5 Mon Sep 17 00:00:00 2001
+From: 7Ji <pugokushin@gmail.com>
+Date: Sat, 26 Aug 2023 17:38:58 +0800
+Subject: [PATCH] Optimize eu-strip building logic
+
+use elfutils.git passed from makepkg
+---
+ buildtools/third_party/eu-strip/build.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/buildtools/third_party/eu-strip/build.sh b/buildtools/third_party/eu-strip/build.sh
+index c073e9a..2670c64 100755
+--- a/buildtools/third_party/eu-strip/build.sh
++++ b/buildtools/third_party/eu-strip/build.sh
+@@ -1,9 +1,9 @@
+ #!/bin/sh -xe
+ 
+ rm -rf elfutils
+-git clone https://sourceware.org/git/elfutils.git
++mkdir elfutils
+ cd elfutils
+-git checkout elfutils-0.170
++git --git-dir "${elfutils_git}" --work-tree . checkout -f elfutils-0.170
+ autoheader
+ aclocal
+ autoconf
+-- 
+2.42.0
+

--- a/extra/chromium/PKGBUILD
+++ b/extra/chromium/PKGBUILD
@@ -43,7 +43,9 @@ source=(https://commondatastorage.googleapis.com/chromium-browser-official/chrom
         use-oauth2-client-switches-as-default.patch
         0001-widevine-support-for-arm.patch
         0002-Run-blink-bindings-generation-single-threaded.patch
-        0003-Fix-eu-strip-build-for-newer-GCC.patch)
+        0003-Fix-eu-strip-build-for-newer-GCC.patch
+        0004-Optimize-eu-strip-building-logic.patch
+        git+https://sourceware.org/git/elfutils.git)
 sha256sums=('e85ef479a1a4972ffd4d2e389cbaf341df4c7cca63e4ebbb38d175fda106d9a9'
             '213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a'
             '25ad7c1a5e0b7332f80ed15ccf07d7e871d8ffb4af64df7c8fef325a527859b0'
@@ -52,7 +54,9 @@ sha256sums=('e85ef479a1a4972ffd4d2e389cbaf341df4c7cca63e4ebbb38d175fda106d9a9'
             'e393174d7695d0bafed69e868c5fbfecf07aa6969f3b64596d0bae8b067e1711'
             '2fd6bc8aa729a0c156a397fefc4b11408824e6291470b77c44c21b2f926182f7'
             '7cc7bb03f74ef28c9bba4047df85fa72965a6b2e394be3455503c034896b0cf5'
-            '92d40f87244f96808976d601af4a141e864e6c3d719b34815c0fecdda1512f57')
+            '92d40f87244f96808976d601af4a141e864e6c3d719b34815c0fecdda1512f57'
+            'ac940ff39aae2dfe73967195eeb39fabe439eaa4ba5d5cd3f30ca1fb2030252c'
+            'SKIP')
 
 if (( _manual_clone )); then
   source[0]=fetch-chromium-release
@@ -114,6 +118,7 @@ prepare() {
   patch -p1 -i ../0001-widevine-support-for-arm.patch
   patch -p1 -i ../0002-Run-blink-bindings-generation-single-threaded.patch
   patch -p1 -i ../0003-Fix-eu-strip-build-for-newer-GCC.patch
+  patch -p1 -i ../0004-Optimize-eu-strip-building-logic.patch
 
   if [[ $CARCH == "armv7h" ]]; then
     export ALARM_NINJA_JOBS="4"
@@ -179,7 +184,7 @@ build() {
 
   # Rebuild eu-strip
   pushd buildtools/third_party/eu-strip
-  ./build.sh
+  elfutils_git="${srcdir}/elfutils/.git" ./build.sh
   popd
 
   export CC=clang


### PR DESCRIPTION
Use elfutils.git maintained and passed by makepkg instead of cloning at build time

Cloning inside the scope of build() is out of makepkg's control, and adds a break point that's not even build-related. It also wastes bandwidth as for each build the source of elfutils.git need to be cloned freshly.

Let's update the PKGBUILD so makepkg would maintain the source of elfutils.git, and the build.sh would use the .git passed by makepkg. Even better, if builder has SRCDEST that's shared between a lot of packages this would save more bandwidth.