### PR TITLE
Add `extra/mixxx` 2.3.6

### DIFF
--- a/extra/mixxx/PKGBUILD
+++ b/extra/mixxx/PKGBUILD
@@ -1,0 +1,113 @@
+# Maintainer: David Runge <dvzrv@archlinux.org>
+# Maintainer: Lukas Fleischer <lfleischer@archlinux.org>
+# Contributor: Ali H. Caliskan <ali.h.caliskan AT gmail DOT com>
+# Contributor: Ryan Coyner <rcoyner@gmail.com>
+# Contributor: Stefan Husmann <stefan-husmann@t-online.de>
+
+# ALARM: fwcd <$(printf '%1$s%2$s@g%2$s.com' fwcd mail)>
+#  - remove unnecessary vamp-plugin-sdk dependency
+#  - remove unnecessary xorg-server-xvfb check dependency
+#  - use -G Ninja for parallel builds
+#  - add -D CMAKE_CXX_FLAGS="-Wno-error=restrict" to work around GCC issue
+
+pkgname=mixxx
+pkgver=2.3.6
+pkgrel=1
+pkgdesc="Free, open source software for digital DJing"
+arch=(x86_64 aarch64)
+url="https://www.mixxx.org"
+license=(GPL-2.0)
+groups=(pro-audio)
+# TODO: package libshout-idjc
+depends=(
+  gcc-libs
+  glibc
+  hicolor-icon-theme
+  hidapi
+  lame
+  libmad
+  libmodplug
+  libx11
+  openssl
+  opus
+  opusfile
+  qt5-base
+  qt5-script
+  qt5-svg
+  qt5-x11extras
+  qtkeychain
+  soundtouch
+  speex
+  sqlite
+  taglib
+  upower
+  wavpack
+)
+makedepends=(
+  chromaprint
+  cmake
+  faad2
+  ffmpeg
+  fftw
+  flac
+  glib2
+  glu
+  gperftools
+  libid3tag
+  libogg
+  libsndfile
+  libusb
+  libvorbis
+  lilv
+  lv2
+  ninja
+  qt5-tools
+  portaudio
+  portmidi
+  protobuf
+  rubberband
+)
+source=(https://github.com/${pkgname}dj/$pkgname/archive/$pkgver/$pkgname-$pkgver.tar.gz)
+sha512sums=('a92c2c92dc7619ac135d940f23ffdc101c528eca6322517805afb9eb48a84c6339cefb88b96bdac6ffb23967c2f93f621daf3e98bfecbf7f3fe7626ddcec4398')
+b2sums=('35bedb5f41a56577bc59411ca979e3e780c1da2420bc0a7ad98d998c89f8c272202ba42e8b8089904ca8e1a1b6ac5155d08d556538245ce3242b4ea5a670e6d2')
+
+build() {
+  local cmake_options=(
+    -B build
+    -G Ninja
+    -D CMAKE_BUILD_TYPE=Release
+    -D CMAKE_INSTALL_PREFIX=/usr
+    -D CMAKE_CXX_FLAGS="-Wno-error=restrict"
+    -S $pkgname-$pkgver
+    -W no-dev
+  )
+
+  cmake "${cmake_options[@]}"
+  cmake --build build --verbose
+}
+
+check() {
+  ctest --test-dir build --output-on-failure
+}
+
+package() {
+  depends+=(
+    chromaprint libchromaprint.so
+    flac libFLAC.so
+    ffmpeg libavcodec.so libavformat.so libavutil.so
+    fftw libfftw3.so
+    glib2 libgobject-2.0.so
+    libid3tag libid3tag.so
+    libogg libogg.so
+    libsndfile libsndfile.so
+    libusb libusb-1.0.so
+    libvorbis libvorbis.so libvorbisenc.so libvorbisfile.so
+    lilv liblilv-0.so
+    portaudio libportaudio.so
+    portmidi libportmidi.so
+    protobuf libprotobuf-lite.so
+    rubberband librubberband.so
+  )
+
+  DESTDIR="$pkgdir" cmake --install build
+}


### PR DESCRIPTION
[Mixxx](https://mixxx.org/) is a free and open-source DJ app.

Currently, the Arch Linux ARM repo hosts an outdated version of the package ([`mixxx` 2.3.2](https://archlinuxarm.org/packages/aarch64/mixxx)), which additionally contains broken dependencies:

```
$ sudo pacman -S mixxx
resolving dependencies...
warning: cannot resolve "libFLAC.so=8-64", a dependency of "mixxx"
warning: cannot resolve "libavcodec.so=59-64", a dependency of "mixxx"
warning: cannot resolve "libavformat.so=59-64", a dependency of "mixxx"
warning: cannot resolve "libavutil.so=57-64", a dependency of "mixxx"
warning: cannot resolve "libportmidi.so=1-64", a dependency of "mixxx"
warning: cannot resolve "libprotobuf-lite.so=31-64", a dependency of "mixxx"
:: The following package cannot be upgraded due to unresolvable dependencies:
      mixxx
```

Therefore this PR adds a slightly modified version of the [upstream `mixxx` 2.3.6 package](https://gitlab.archlinux.org/archlinux/packaging/packages/mixxx), which...

- removes two unavailable legacy dependencies (`vamp-plugin-sdk` and `xorg-server-xvfb`)
  - The `vamp-plugin-sdk` dependency [is obsolete as per the changelog](https://manual.mixxx.org/2.3/de/chapters/appendix/changelog#music-feature-analysis)
  - The `xorg-server-xvfb` dependency was only used for the check and turned out not to be needed after all
- adds `-D CMAKE_CXX_FLAGS="-Wno-error=restrict"` to work around a GCC issue
  - see [1] for an error log
  - this is likely an upstream issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651
- uses Ninja as a build system for fast parallel builds
  - while this diverges from the upstream `PKGBUILD` and introduces `ninja` as a `makedepend`, Ninja offers less verbose, parallel builds by default with output that doesn't interleave (thus making it much easier to track down issues)
  - additionally, the maintenance burden of using `-G Ninja` and having an extra `makedepends` for `ninja` shouldn't be too high

The `mixxx` package now successfully builds and runs on Arch Linux ARM. Feel free to let me know whether this works for you! I haven't tested the `make` build since it is ~10 times slower, though it should work too (and if staying as close as possible to the upstream `PKGBUILD` is important I can certainly revert the switch to Ninja).

---

[1] This is the error emitted when building the package without `-Wno-error=restrict`:

<details>

```
In file included from /usr/include/c++/12.1.0/string:40,
                 from /home/<user>/aur/mixxx/src/mixxx-2.3.6/lib/benchmark/include/benchmark/benchmark.h:185,
                 from /home/<user>/aur/mixxx/src/mixxx-2.3.6/lib/benchmark/src/benchmark.cc:15:
In static member function ‘static std::char_traits<char>::char_type* std::char_traits<char>::copy(char_type*, const char_type*, std::size_t)’,
    inlined from ‘static void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_S_copy(_CharT*, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.1.0/bits/basic_string.h:423:21,
    inlined from ‘std::__cxx11::basic_string<_CharT, _Traits, _Allocator>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_replace(size_type, size_type, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.1.0/bits/basic_string.tcc:532:22,
    inlined from ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::assign(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.1.0/bits/basic_string.h:1647:19,
    inlined from ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::operator=(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.1.0/bits/basic_string.h:815:28,
    inlined from ‘size_t benchmark::RunSpecifiedBenchmarks(BenchmarkReporter*, BenchmarkReporter*)’ at /home/<user>/aur/mixxx/src/mixxx-2.3.6/lib/benchmark/src/benchmark.cc:449:12:
/usr/include/c++/12.1.0/bits/char_traits.h:431:56: error: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ accessing 9223372036854775810 or more bytes at offsets [2, 9223372036854775807] and 1 may overlap up to 9223372036854775813 bytes at offset -3 [-Werror=restrict]
  431 |         return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));
      |                                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
```

</details>