### PR TITLE
alarm/amzn-ena-aarch64-dkms to 2.9.1-1

### DIFF
--- a/alarm/amzn-ena-aarch64-dkms/PKGBUILD
+++ b/alarm/amzn-ena-aarch64-dkms/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: iDigitalFlame <idf@idfla.me>
 pkgname="amzn-ena-aarch64-dkms"
-pkgver="2.8.9"
+pkgver="2.9.1"
 pkgrel="1"
 pkgdesc="Linux kernel driver for Amazon's Elastic Network Adapter (ENA)"
 arch=("aarch64")
@@ -10,8 +10,8 @@ depends=("dkms" "linux-aarch64" "linux-aarch64-headers")
 install="amzn-drivers.install"
 source=("https://github.com/amzn/amzn-drivers/archive/refs/tags/ena_linux_${pkgver}.tar.gz"
         "dkms.conf")
-sha256sums=("6449eb8a526b7895119567efa3b1d5aff420fb7a389b6be910adb6af9ebb0901"
-            "368579721fdfb3bd9a82528d0b317ac63f9838ec34f1f1de3eb31998863ebf41")
+sha256sums=("80737d1f3048c3c09a6d9acae2dd479e2d2470d93aaa44ec6a0ed657130436d4"
+            "e8fc556c0b4d0e8f7f11ba4a6a37cfba4f349292d8d3b8a052ccdab05e9c8bdf")
 buildarch=8
 
 package() {

--- a/alarm/amzn-ena-aarch64-dkms/dkms.conf
+++ b/alarm/amzn-ena-aarch64-dkms/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="ena"
-PACKAGE_VERSION="2.8.9"
+PACKAGE_VERSION="2.9.1"
 CLEAN="make -C ena clean"
 MAKE="make -C ena/ BUILD_KERNEL=$kernelver"
 BUILT_MODULE_NAME[0]="ena"


### PR DESCRIPTION
Changes/Updates:

- Driver updated to the latest release: 2.9.1 (from 2.8.9)

Tests:

- [X] Build tested
- [X] Built in clean chroot
- [X] Tested in a live AWS ArchLinuxARM instance