### PR TITLE
Change Cantor dependencies to knewstuff5 and ktexteditor5

### DIFF
--- a/extra/cantor/PKGBUILD
+++ b/extra/cantor/PKGBUILD
@@ -13,7 +13,7 @@ url='https://apps.kde.org/cantor/'
 arch=(x86_64)
 license=(GPL LGPL FDL)
 groups=(kde-applications kde-education)
-depends=(analitza libspectre ktexteditor knewstuff libqalculate qt5-xmlpatterns qt5-tools qt5-webengine poppler-qt5)
+depends=(analitza libspectre ktexteditor5 knewstuff5 libqalculate qt5-xmlpatterns qt5-tools qt5-webengine poppler-qt5)
 makedepends=(extra-cmake-modules python kdoctools luajit r)
 optdepends=('maxima: Maxima backend'
             'octave: Octave backend'


### PR DESCRIPTION
Changes dependencies of Cantor from ktexteditor and knewstuff to ktexteditor5 and knewstuff5 to match the renamed KDE packages. This change matches upstream Arch Linux [https://gitlab.archlinux.org/archlinux/packaging/packages/cantor/-/blob/main/PKGBUILD?ref_type=heads#L13](https://gitlab.archlinux.org/archlinux/packaging/packages/cantor/-/blob/main/PKGBUILD?ref_type=heads#L13)

Without this change, updates on KDE are broken because Cantor depends on ktexteditor and knewstuff which no longer exist  in the repo.

My bug report on the forum is [here](https://archlinuxarm.org/forum/viewtopic.php?f=15&t=16635). 