### PR TITLE
Initial port of `extra/bitwarden` for aarch64

### DIFF
--- a/extra/bitwarden/PKGBUILD
+++ b/extra/bitwarden/PKGBUILD
@@ -1,0 +1,84 @@
+# Maintainer: Alexander Epaneshnikov <alex19ep@archlinux.org>
+# Contributor: libertylocked <libertylocked@disroot.org>
+
+# ALARM: Avery Dorgan <avery@averydorgan.com>
+# - generate new checksum for nativelib.patch with aarch64 updates
+# - remove electron-builder x86 architecture flag
+# - changed package() dir from linux-unpacked to linux-*unpacked
+
+buildarch=8
+
+pkgname=bitwarden
+pkgver=2023.10.1
+pkgrel=1.1
+_electronversion=25
+pkgdesc='A secure and free password manager for all of your devices'
+arch=('x86_64' 'aarch64')
+url='https://github.com/bitwarden/clients/tree/master/apps/desktop'
+license=('GPL3')
+depends=("electron$_electronversion" 'libnotify' 'libsecret' 'libxtst' 'libxss' 'libnss_nis')
+makedepends=('git' 'npm' 'python' 'node-gyp' 'nodejs-lts-hydrogen' 'jq' 'rust')
+source=(bitwarden::git+https://github.com/bitwarden/clients.git#tag=desktop-v$pkgver
+        messaging.main.ts.patch
+        nativelib.patch
+        ${pkgname}.sh
+        ${pkgname}.desktop)
+sha512sums=('SKIP'
+            'babcae0dba4d036e5d2cd04d8932b63253bc7b27b14d090932066e9d39383f7565c06d72dae9f96e741b494ef7e50a1fe7ec33905aa3124b427a8bf404df5762'
+            'c58563556dbd836e30dc4a9cc0e256f5c458441a1f896e4282ad89bf0923a197c028814351e4dffc22a327117a0e7993a640860c09f30d2dae6da985a1f8e847'
+            '98d2860bef2283fd09710fbbc5362d7ef2cd8eca26f35805ea258f2dacba78bd6aab14c834388a5089a8150eb0f32a82577aab10f8ad68e1a6371959b2802ad4'
+            'fdc047aadc1cb947209d7ae999d8a7f5f10ae46bf71687080bc13bc3082cc5166bbbe88c8f506b78adb5d772f5366ec671b04a2f761e7d7f249ebe5726681e30')
+
+prepare() {
+	cd bitwarden/apps/desktop
+
+	export npm_config_build_from_source=true
+	export npm_config_cache="$srcdir/npm_cache"
+	export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+
+	# This patch is required to make "Start automatically on login" work
+	patch --strip=1 src/main/messaging.main.ts "$srcdir/messaging.main.ts.patch"
+
+	# Patch build to make it work with system electron
+	export SYSTEM_ELECTRON_VERSION=$(electron$_electronversion -v | sed 's/v//g')
+	export ELECTRONVERSION=$_electronversion
+	sed -i "s|@electronversion@|${ELECTRONVERSION}|" "$srcdir/bitwarden.sh"
+	# jq < package.json \
+	#    '.build["electronVersion"]=$ENV.SYSTEM_ELECTRON_VERSION | .build["electronDist"]="/usr/lib/electron\(env.ELECTRONVERSION)"' \
+	#    > package.json.patched
+	# mv package.json.patched package.json
+	cd ../../
+	patch --strip=1 apps/desktop/desktop_native/index.js "$srcdir/nativelib.patch"
+	npm ci
+}
+
+build() {
+	cd bitwarden/apps/desktop
+	electronDist=/usr/lib/electron$_electronversion
+	electronVer=$(electron$_electronversion --version | tail -c +2)
+	export npm_config_build_from_source=true
+	export npm_config_cache="$srcdir/npm_cache"
+	export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+	pushd desktop_native/
+	npm run build
+	popd
+	npm run build
+	npm run clean:dist 
+	npm exec -c "electron-builder --linux --dir -c.electronDist=$electronDist \
+	             -c.electronVersion=$electronVer"
+}
+
+package(){
+	cd bitwarden/apps/desktop
+	install -vDm644 dist/linux-*unpacked/resources/app.asar -t "${pkgdir}/usr/lib/${pkgname}"
+	install -vDm644 build/package.json -t "${pkgdir}/usr/lib/${pkgname}"
+	cp -vr dist/linux-*unpacked/resources/app.asar.unpacked -t "${pkgdir}/usr/lib/${pkgname}"
+
+	for i in 16 32 64 128 256 512 1024; do
+		install -vDm644 resources/icons/${i}x${i}.png "${pkgdir}/usr/share/icons/hicolor/${i}x${i}/apps/${pkgname}.png"
+	done
+	install -vDm644 resources/icon.png "${pkgdir}/usr/share/icons/hicolor/1024x1024/apps/${pkgname}.png"
+
+	install -vDm755 "${srcdir}/${pkgname}.sh" "${pkgdir}/usr/bin/bitwarden-desktop"
+	install -vDm644 "${srcdir}"/${pkgname}.desktop -t "${pkgdir}"/usr/share/applications
+}

--- a/extra/bitwarden/bitwarden.desktop
+++ b/extra/bitwarden/bitwarden.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Bitwarden
+GenericName=Password Manager
+Comment=A secure and free password manager for all of your devices.
+Exec=bitwarden-desktop
+Terminal=false
+MimeType=x-scheme-handler/bitwarden
+Type=Application
+Icon=bitwarden
+Categories=Utility;
+StartupWMClass=Bitwarden

--- a/extra/bitwarden/bitwarden.sh
+++ b/extra/bitwarden/bitwarden.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+export ELECTRON_IS_DEV=0
+cd /usr/lib/bitwarden
+exec electron@electronversion@ /usr/lib/bitwarden/app.asar $@

--- a/extra/bitwarden/messaging.main.ts.patch
+++ b/extra/bitwarden/messaging.main.ts.patch
@@ -1,0 +1,11 @@
+--- messaging.main.ts.orig	2022-02-11 15:39:49.768671680 +0300
++++ messaging.main.ts	2022-02-11 15:42:22.326127915 +0300
+@@ -114,7 +114,7 @@
+ Version=${app.getVersion()}
+ Name=Bitwarden
+ Comment=Bitwarden startup script
+-Exec=${app.getPath("exe")}
++Exec=bitwarden-desktop
+ StartupNotify=false
+ Terminal=false`;
+ 

--- a/extra/bitwarden/nativelib.patch
+++ b/extra/bitwarden/nativelib.patch
@@ -1,0 +1,38 @@
+diff --git a/apps/desktop/desktop_native/index.js b/apps/desktop/desktop_native/index.js
+index 1cf7ea943..b12a34bc3 100644
+--- a/apps/desktop/desktop_native/index.js
++++ b/apps/desktop/desktop_native/index.js
+@@ -151,13 +151,13 @@ switch (platform) {
+     switch (arch) {
+       case 'x64':
+         localFileExisted = existsSync(
+-          join(__dirname, 'desktop_native.linux-x64-musl.node')
++          join(__dirname, 'desktop_native.linux-x64-gnu.node')
+         )
+         try {
+           if (localFileExisted) {
+-            nativeBinding = require('./desktop_native.linux-x64-musl.node')
++            nativeBinding = require('./desktop_native.linux-x64-gnu.node')
+           } else {
+-            nativeBinding = require('@bitwarden/desktop-native-linux-x64-musl')
++            nativeBinding = require('@bitwarden/desktop-native-linux-x64-gnu')
+           }
+         } catch (e) {
+           loadError = e
+@@ -165,13 +165,13 @@ switch (platform) {
+         break
+       case 'arm64':
+         localFileExisted = existsSync(
+-          join(__dirname, 'desktop_native.linux-arm64-musl.node')
++          join(__dirname, 'desktop_native.linux-arm64-gnu.node')
+         )
+         try {
+           if (localFileExisted) {
+-            nativeBinding = require('./desktop_native.linux-arm64-musl.node')
++            nativeBinding = require('./desktop_native.linux-arm64-gnu.node')
+           } else {
+-            nativeBinding = require('@bitwarden/desktop-native-linux-arm64-musl')
++            nativeBinding = require('@bitwarden/desktop-native-linux-arm64-gnu')
+           }
+         } catch (e) {
+           loadError = e


### PR DESCRIPTION
This PR provides a port of the upstream [`extra/bitwarden`](https://gitlab.archlinux.org/archlinux/packaging/packages/bitwarden) package for the aarch64 architecture. [Bitwarden](https://bitwarden.com/), as a password manager, provides an invaluable tool to arm users, particularly for mobile users.

It is known working via clean chroot and build/install on a Pinephone Pro. At present, I am unable to get this to install on armv7h as the [aur package electron25-bin](https://aur.archlinux.org/packages/electron25-bin) does not have armv7h as an architecture, possibly owing to the fact the [upstream seems to offer an armv7l](https://github.com/electron/electron/releases/tag/v27.1.3), but not armv7h package. I'm happy to work to get that ported, but don't really know where to start!
