### PR TITLE
 alarm/amzn-ena-aarch64-dkms to 2.11.0-1 

### DIFF
--- a/alarm/amzn-ena-aarch64-dkms/PKGBUILD
+++ b/alarm/amzn-ena-aarch64-dkms/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: iDigitalFlame <idf@idfla.me>
 pkgname="amzn-ena-aarch64-dkms"
-pkgver="2.9.1"
+pkgver="2.11.0"
 pkgrel="1"
 pkgdesc="Linux kernel driver for Amazon's Elastic Network Adapter (ENA)"
 arch=("aarch64")
@@ -10,8 +10,8 @@ depends=("dkms" "linux-aarch64" "linux-aarch64-headers")
 install="amzn-drivers.install"
 source=("https://github.com/amzn/amzn-drivers/archive/refs/tags/ena_linux_${pkgver}.tar.gz"
         "dkms.conf")
-sha256sums=("80737d1f3048c3c09a6d9acae2dd479e2d2470d93aaa44ec6a0ed657130436d4"
-            "e8fc556c0b4d0e8f7f11ba4a6a37cfba4f349292d8d3b8a052ccdab05e9c8bdf")
+sha256sums=("7a52a06c34e5b9c13c9fee9bfc2383a7398b982cfec38ab03779e6b015ae91e4"
+            "cfa28a7313381bf32099a91fad31f531cb57fb0e7b6a47dea7ae3f9a652c8dd2")
 buildarch=8
 
 package() {

--- a/alarm/amzn-ena-aarch64-dkms/dkms.conf
+++ b/alarm/amzn-ena-aarch64-dkms/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="ena"
-PACKAGE_VERSION="2.9.1"
+PACKAGE_VERSION="2.11.0"
 CLEAN="make -C ena clean"
 MAKE="make -C ena/ BUILD_KERNEL=$kernelver"
 BUILT_MODULE_NAME[0]="ena"


### PR DESCRIPTION
Changes/Updates:

- Driver updated to the latest release: 2.11.0 (from 2.9.1)

Tests:

- [X] Build tested
- [X] Built in clean chroot
- [X] Tested in a live AWS ArchLinuxARM instance