### PR TITLE
 alarm/amzn-ena-aarch64-dkms to 2.12.0-1

### DIFF
--- a/alarm/amzn-ena-aarch64-dkms/PKGBUILD
+++ b/alarm/amzn-ena-aarch64-dkms/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: iDigitalFlame <idf@idfla.me>
 pkgname="amzn-ena-aarch64-dkms"
-pkgver="2.11.0"
+pkgver="2.12.0"
 pkgrel="1"
 pkgdesc="Linux kernel driver for Amazon's Elastic Network Adapter (ENA)"
 arch=("aarch64")
@@ -10,8 +10,8 @@ depends=("dkms" "linux-aarch64" "linux-aarch64-headers")
 install="amzn-drivers.install"
 source=("https://github.com/amzn/amzn-drivers/archive/refs/tags/ena_linux_${pkgver}.tar.gz"
         "dkms.conf")
-sha256sums=("7a52a06c34e5b9c13c9fee9bfc2383a7398b982cfec38ab03779e6b015ae91e4"
-            "cfa28a7313381bf32099a91fad31f531cb57fb0e7b6a47dea7ae3f9a652c8dd2")
+sha256sums=("af02fe96fdc9a33e910fee35957c40af91596e4d9a5e7d0a6eaff604cf8cf770"
+            "a1f15bfe777d7939163773a97019ee86453f9ecc495baa81267f34c56d477d1c")
 buildarch=8
 
 package() {

--- a/alarm/amzn-ena-aarch64-dkms/dkms.conf
+++ b/alarm/amzn-ena-aarch64-dkms/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="ena"
-PACKAGE_VERSION="2.11.0"
+PACKAGE_VERSION="2.12.0"
 CLEAN="make -C ena clean"
 MAKE="make -C ena/ BUILD_KERNEL=$kernelver"
 BUILT_MODULE_NAME[0]="ena"


### PR DESCRIPTION
Changes/Updates:

- Driver updated to the latest upstream release: 2.12.0 (from 2.11.0)

Tests:

- [X] Build tested
- [X] Built in clean chroot
- [X] Tested in a live AWS ArchLinuxARM instance
