### PR TITLE
Adding aarch64 for extra/netdata

### DIFF
--- a/extra/netdata/.SRCINFO
+++ b/extra/netdata/.SRCINFO
@@ -1,9 +1,10 @@
 pkgbase = netdata
 	pkgdesc = Real-time performance monitoring, in the greatest possible detail, over the web
 	pkgver = 1.44.3
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/netdata/netdata
 	arch = x86_64
+	arch = aarch64
 	license = GPL
 	makedepends = cups
 	makedepends = go

--- a/extra/netdata/PKGBUILD
+++ b/extra/netdata/PKGBUILD
@@ -6,11 +6,11 @@
 
 pkgname=netdata
 pkgver=1.44.3
-pkgrel=1
+pkgrel=2
 _go_ver="0.57.2"
 pkgdesc="Real-time performance monitoring, in the greatest possible detail, over the web"
 url="https://github.com/netdata/netdata"
-arch=('x86_64')
+arch=('x86_64' 'aarch64')
 license=('GPL')
 backup=('etc/netdata/netdata.conf')
 depends=('libmnl' 'libnetfilter_acct' 'zlib' 'judy' 'libuv' 'json-c' 'libcap' 'lz4' 'openssl' 'which' 'snappy' 'protobuf'


### PR DESCRIPTION
Adds aarch64 for extra/netdata. It might have caused a problem with the missing go plugin.