### PR TITLE
add allow-weak-key-signatures for archlinuxarm-keyring workaround

### DIFF
--- a/core/pacman/PKGBUILD
+++ b/core/pacman/PKGBUILD
@@ -38,6 +38,7 @@ source=(https://gitlab.archlinux.org/pacman/pacman/-/releases/v$pkgver/downloads
         0001-Sychronize-filesystem.patch
         0002-Revert-close-stdin-before-running-install-scripts.patch
         0003-Revert-alpm_run_chroot-always-connect-parent2child-p.patch
+        1001-add-allow-weak-key-signatures-for-archlinuxarm-keyri.patch
         pacman.conf
         makepkg.conf)
 sha256sums=('5a60ac6e6bf995ba6140c7d038c34448df1f3daa4ae7141d2cad88eeb5f1f9d9'
@@ -52,6 +53,7 @@ sha256sums=('5a60ac6e6bf995ba6140c7d038c34448df1f3daa4ae7141d2cad88eeb5f1f9d9'
             '98b500555072c84fb5c55a860685adf99eb3bdf674bf11855a9e9920746363fb'
             '64e56e6f66f935029bb7c81382b98b71a39a69c13b1e4f80455fdbb1718e051e'
             'd344075eb0d5a0aefb1aed27eb337be78221080808f9f516215d675bcdd27ca2'
+            '3e452cc4602414d913982deea06c1bbf18b08c56349cc2e518fc81eef10ffbae'
             '6456e1ad704565d1e401b2b94fcfd1c75be290aa92ac9437343625209e7793ab'
             '72969c7f4ce130e3424f28f3b300abea62d07450cd83b107f2f66c3c66330c00')
 


### PR DESCRIPTION
One of the master keys is based on SHA1, and current gnupg ignores it. This is just a workaround to make it work until the key ist updated or replaced.