### PR TITLE
Draft: extra/dart: unify arm PKGBUILD with upstream

### DIFF
--- a/extra/dart/DEPS.patch
+++ b/extra/dart/DEPS.patch
@@ -1,0 +1,131 @@
+diff --git a/DEPS b/DEPS
+index 627823962f8..2a66a2d7e12 100644
+--- a/DEPS
++++ b/DEPS
+@@ -64,9 +64,8 @@ vars = {
+   # Checkout the flute benchmark only when benchmarking.
+   "checkout_flute": False,
+ 
+-  # Checkout Android dependencies only on Mac and Linux.
+-  "download_android_deps":
+-    "host_os == mac or (host_os == linux and host_cpu == x64)",
++  # Do not checkout Android dependencies.
++  "download_android_deps": False,
+ 
+   # Checkout extra javascript engines for testing or benchmarking.
+   # d8, the V8 shell, is always checked out.
+@@ -81,7 +80,7 @@ vars = {
+   "gn_version": "git_revision:e4702d7409069c4f12d45ea7b7f0890717ca3f4b",
+ 
+   "reclient_version": "git_revision:c7349324c93c6e0d85bc1e00b5d7526771006ea0",
+-  "download_reclient": True,
++  "download_reclient": False,
+ 
+   # Update from https://chrome-infra-packages.appspot.com/p/fuchsia/sdk/core
+   "fuchsia_sdk_version": "version:16.20231105.3.1",
+@@ -503,37 +502,7 @@ Var("dart_root") + "/third_party/pkg/tar":
+   Var("dart_root") + "/third_party/pkg/yaml":
+       Var("dart_git") + "yaml.git" + "@" + Var("yaml_rev"),
+ 
+-  Var("dart_root") + "/buildtools/sysroot/linux": {
+-      "packages": [
+-          {
+-              "package": "fuchsia/third_party/sysroot/linux",
+-              "version": "git_revision:fa7a5a9710540f30ff98ae48b62f2cdf72ed2acd",
+-          },
+-      ],
+-      "condition": "host_os == linux",
+-      "dep_type": "cipd",
+-  },
+-  Var("dart_root") + "/buildtools/sysroot/focal": {
+-      "packages": [
+-          {
+-              "package": "fuchsia/third_party/sysroot/focal",
+-              "version": "git_revision:fa7a5a9710540f30ff98ae48b62f2cdf72ed2acd",
+-          },
+-      ],
+-      "condition": "host_os == linux",
+-      "dep_type": "cipd",
+-  },
+-
+   # Keep consistent with pkg/test_runner/lib/src/options.dart.
+-  Var("dart_root") + "/buildtools/linux-x64/clang": {
+-      "packages": [
+-          {
+-              "package": "fuchsia/third_party/clang/linux-amd64",
+-              "version": Var("clang_version"),
+-          },
+-      ],
+-      "dep_type": "cipd",
+-  },
+   Var("dart_root") + "/buildtools/mac-x64/clang": {
+       "packages": [
+           {
+@@ -600,16 +569,6 @@ Var("dart_root") + "/third_party/pkg/tar":
+     "dep_type": "cipd",
+   },
+ 
+-  Var("dart_root") + "/buildtools": {
+-      "packages": [
+-          {
+-              "package": "gn/gn/${{platform}}",
+-              "version": Var("gn_version"),
+-          },
+-      ],
+-      "condition": "host_os != 'win'",
+-      "dep_type": "cipd",
+-  },
+   Var("dart_root") + "/buildtools/win": {
+       "packages": [
+           {
+@@ -621,14 +580,6 @@ Var("dart_root") + "/third_party/pkg/tar":
+       "dep_type": "cipd",
+   },
+ 
+-  Var("dart_root") + "/buildtools/ninja": {
+-      "packages": [{
+-          "package": "infra/3pp/tools/ninja/${{platform}}",
+-          "version": Var("ninja_tag"),
+-      }],
+-      "dep_type": "cipd",
+-  },
+-
+   Var("dart_root") + "/third_party/android_tools/ndk": {
+       "packages": [
+           {
+@@ -693,35 +644,6 @@ Var("dart_root") + "/third_party/pkg/tar":
+     "dep_type": "cipd",
+   },
+ 
+-  # TODO(37531): Remove these cipd packages and build with sdk instead when
+-  # benchmark runner gets support for that.
+-  Var("dart_root") + "/benchmarks/FfiBoringssl/native/out/": {
+-      "packages": [
+-          {
+-              "package": "dart/benchmarks/ffiboringssl",
+-              "version": "commit:a86c69888b9a416f5249aacb4690a765be064969",
+-          },
+-      ],
+-      "dep_type": "cipd",
+-  },
+-  Var("dart_root") + "/benchmarks/FfiCall/native/out/": {
+-      "packages": [
+-          {
+-              "package": "dart/benchmarks/fficall",
+-              "version": "ebF5aRXKDananlaN4Y8b0bbCNHT1MnkGbWqfpCpiND4C",
+-          },
+-      ],
+-          "dep_type": "cipd",
+-  },
+-  Var("dart_root") + "/benchmarks/NativeCall/native/out/": {
+-      "packages": [
+-          {
+-              "package": "dart/benchmarks/nativecall",
+-              "version": "w1JKzCIHSfDNIjqnioMUPq0moCXKwX67aUfhyrvw4E0C",
+-          },
+-      ],
+-          "dep_type": "cipd",
+-  },
+   Var("dart_root") + "/third_party/browsers/chrome": {
+       "packages": [
+           {

--- a/extra/dart/PKGBUILD
+++ b/extra/dart/PKGBUILD
@@ -1,6 +1,7 @@
 # Maintainer: Alexander Rødseth <rodseth@gmail.com>
 # Maintainer: Felix Yan <felixonmars@archlinux.org>
 # Maintainer: Orhun Parmaksız <orhun@archlinux.org>
+# Contributor: Daniele Basso <d dot bass05 at proton dot me>
 # Contributor: T. Jameson Little <t.jameson.little at gmail dot com>
 # Contributor: Usagi Ito <usagi@WonderRabbitProject.net>
 # Contributor: siasia <http://pastebin.com/qsBEmNCw>
@@ -9,36 +10,115 @@
 
 # ALARM: Kevin Mihelich <kevin@archlinuxarm.org>
 #  - added source and sha512 for ARMv7h, AArch64 builds of Dart
+# ALARM: The one with the braid <info@braid.business>
+# - unify with upstream PKGBUILD
+# - map $CARCH architectures to Dart internal architectures
+# - declare all Dart upstream supported architectures
 
 pkgname=dart
 pkgver=3.3.2
-pkgrel=1
+_commit=bc4150a9a23da4b3497c1d76b196e97a3e10b6cc #https://github.com/dart-lang/sdk/commits/stable/
+pkgrel=2
 pkgdesc='The dart programming language SDK'
-arch=('x86_64' 'armv7h' 'aarch64')
-url='https://www.dartlang.org/'
-depends=('bash')
+arch=('x86_64' 'i686' 'aarch64' 'armv7h' 'riscv64')
+# compiling the SDk will take quite an amount of memory
+highmem=1
+url='https://dart.dev/'
+depends=('glibc')
 license=('BSD')
-makedepends=('setconf')
-options=('!strip')
-source_x86_64+=("$pkgname-$pkgver-64.zip::https://storage.googleapis.com/dart-archive/channels/stable/release/$pkgver/sdk/dartsdk-linux-x64-release.zip")
-source_armv7h+=("$pkgname-$pkgver-arm.zip::https://storage.googleapis.com/dart-archive/channels/stable/release/$pkgver/sdk/dartsdk-linux-arm-release.zip")
-source_aarch64+=("$pkgname-$pkgver-arm64.zip::https://storage.googleapis.com/dart-archive/channels/stable/release/$pkgver/sdk/dartsdk-linux-arm64-release.zip")
-sha512sums_x86_64=('35bac41f4155495415d8532b5713f28457627fb882cf1a144f0498265c3e345bb4aa6ac1796a30c6475cfc3c0895e990d3211ed850a9971dd19e6eacb31cd7dd')
-sha512sums_armv7h=('d103420aab5c8b4e6a910f66e4de37498bbc68798fc2cfb658d0be8523b3dbd81719ef204718cc5e929e43dc58bbaaf7aeba131259b0f10815832e1d65911f00')
-sha512sums_aarch64=('d65d4746c94919bffb7e1e79ad94e20339e63144750311b8a180b511ca7d1ffd7176c2d9e899dbf1a4304902c7446a3c730cfa937a75ac0ca92b36fa36906379')
+makedepends=(
+  'dart'
+  'git'
+  'gn'
+  'ninja'
+  'python'
+  'python-httplib2'
+  'python-six'
+  # TODO: once teapot-tools are packaged one day, use them instead of depot-tools clone
+  # 'teapot-tools'
+)
+source=(
+  "git+https://github.com/dart-lang/sdk.git#commit=$_commit"
+  "git+https://chromium.googlesource.com/chromium/tools/depot_tools.git"
+  "DEPS.patch"
+)
+sha256sums=('e77b487224ee78d981806c46353400cb0a7023f695284d1bbeb4566df1ffb280'
+            'SKIP'
+            'db6576a70c6719e26795b9824546058b79fefa64158c1002d36546d826084403')
 
 prepare() {
-  # Fix permissions
-  find "$pkgname-sdk" -type d -exec chmod a+rx '{}' + \
-    -or -type f -exec chmod a+r '{}' +
+  cat >.gclient <<EOF
+solutions = [
+  {
+    "name": "sdk",
+    "url": "file://${srcdir}/sdk",
+    "deps_file": "DEPS",
+    "managed": False,
+    "custom_deps": {},
+    "custom_vars": {},
+  },
+]
+EOF
 
-  cd "$pkgname-sdk/bin"
+  # TODO: remove once teapot-tools are packages
+  export PATH+=":$PWD/depot_tools" DEPOT_TOOLS_UPDATE=0
 
-  # Extract license (AUTHORS and LICENSE files are missing)
-  head -n5 "../include/dart_api.h" > ../../LICENSE
+  patch -Np 1 --input=$srcdir/DEPS.patch -d sdk
+
+  # TODO: refactor once teapot-tools are packages
+  # gclient sync \
+  python depot_tools/gclient.py sync \
+      --nohooks \
+      --no-history \
+      --shallow \
+      -r ${srcdir}/sdk@${_commit}
+
+  dart tools/generate_package_config.dart
+  python tools/generate_sdk_version_file.py
+
+  sed -i 's|prefix = rebased_clang_dir|prefix= ""|g' build/toolchain/linux/BUILD.gn # use system clang
+  sed -i 's|}/|}|g' build/toolchain/linux/BUILD.gn # use system clang
+  sed -i 's|rebase|#|g' build/toolchain/linux/BUILD.gn
+}
+
+build() {
+  cd sdk
+
+  # gn args --list out
+ 
+  case "$CARCH" in
+    "x86_64")
+      readonly DART_ARCH="x64"
+      ;;
+    "i686")
+      readonly DART_ARCH="ia32"
+      ;;
+    "aarch64")
+      readonly DART_ARCH="arm64"
+      ;;
+    "armv7h")
+      readonly DART_ARCH="arm"
+      ;;
+    "riscv64")
+      readonly DART_ARCH="riscv64"
+      ;;
+
+  esac
+
+  /usr/bin/gn gen -qv out --args='
+                        target_cpu = "'${DART_ARCH}'"
+                        is_debug = false
+                        is_release = true
+                        is_clang = false
+                        dart_platform_sdk = false
+                        verify_sdk_hash = false'
+  ninja create_sdk -v -C out
 }
 
 package() {
+  # cd to directory
+  cd sdk/out/
+
   # Create directories
   install -d "$pkgdir"{"/opt/$pkgname-sdk",/usr/{bin,"share/doc/$pkgname"}}
 
@@ -54,7 +134,7 @@ package() {
   install -Dm644 "$pkgdir/opt/$pkgname-sdk/README" -t "$pkgdir/usr/share/doc/$pkgname"
 
   # BSD License
-  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 ../LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
- update the PKGBUILD and patchset to the latest Arch upstream
- map $CARCH architectures to Dart internal architectures for ALARM support
- declare all Dart upstream supported architectures

## TODO :

- [ ] : try to build on all stated architectures, still into trying that