### PR TITLE
Update PKGBUILD to latest release

### DIFF
--- a/alarm/rpi-eeprom/PKGBUILD
+++ b/alarm/rpi-eeprom/PKGBUILD
@@ -3,14 +3,14 @@
 pkgbase=rpi-eeprom
 pkgname=(rpi4-eeprom rpi5-eeprom)
 
-_commit=7a1a01c24f48f800ff9ac6fe43fe1e109abf5f9d
-pkgver=20240417
+_commit=9a5a522ee8a17d4d445b4bb108c4da75bed829fe
+pkgver=20240420
 pkgrel=1
 arch=(any)
 url='https://github.com/raspberrypi/rpi-eeprom'
 license=(custom)
 source=("$pkgbase-$pkgver-${_commit:0:10}.tar.gz::https://github.com/raspberrypi/rpi-eeprom/archive/$_commit.tar.gz")
-md5sums=('0f66fccbfab0f9a7a56221af14d4c5e6')
+md5sums=('9fe2f99558f46ae404efbcf985ddea02')
 
 package_rpi4-eeprom() {
   pkgdesc="Bootloader and VLI USB controller EEPROM update for bcm2711/RPi4 SoC"
@@ -47,7 +47,7 @@ package_rpi4-eeprom() {
 }
 
 package_rpi5-eeprom() {
-  pkgdesc="Bootloader and VLI USB controller EEPROM update for bcm2712/RPi5 SoC"
+  pkgdesc="Bootloader EEPROM update for bcm2712/RPi5 SoC"
   depends=(binutils coreutils nano pciutils python raspberrypi-utils)
   optdepends=(
     'flashrom: alternative method for updating firmware'


### PR DESCRIPTION
There was another default release for Pi 5. This PR updates to this release. Furthermore, just as a cosmetic fix, the Pi 5 does not I have a VL805 for which the EEPROM could be updated, and therefor I cleaned the pkgdesc.