### PR TITLE
alarm/firmware-imx to 8.24.r0.fbe0a4c

### DIFF
--- a/alarm/firmware-imx/PKGBUILD
+++ b/alarm/firmware-imx/PKGBUILD
@@ -4,28 +4,28 @@
 
 buildarch=4
 pkgname=firmware-imx
-pkgver=8.14
-pkgrel=2
+pkgver=8.24.r0.fbe0a4c
+pkgrel=1
 pkgdesc="Freescale proprietary firmware for i.MX6 SoC"
 url="https://community.freescale.com/docs/DOC-95560"
 arch=('armv7h')
 license=('proprietay')
-source=("https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/${pkgname}-${pkgver}.bin")
-sha256sums=('bfe9c57857e8442e7eb26ba3e1020733b09a7c9b83952ad4822980546c58a7f4')
+source=("https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/${pkgname}-${pkgver//.r0./-}.bin")
+sha256sums=('2e27962332197ebebbb30138f6dfb365361d48d7efa565df97c4f79285b1ca50')
 
 prepare() {
   cd "${srcdir}"
   #extract the firmware
-  sh ${pkgname}-${pkgver}.bin --force --auto-accept
+  sh ${pkgname}-${pkgver//.r0./-}.bin --force --auto-accept
 }
 
 package() {
   mkdir -p "${pkgdir}/usr/lib/firmware/vpu"
-  cp "${srcdir}/${pkgname}-${pkgver}/firmware/vpu/vpu_fw_imx6d.bin" "${pkgdir}/usr/lib/firmware/vpu"
-  cp "${srcdir}/${pkgname}-${pkgver}/firmware/vpu/vpu_fw_imx6q.bin" "${pkgdir}/usr/lib/firmware/vpu"
+  cp "${srcdir}/${pkgname}-${pkgver//.r0./-}/firmware/vpu/vpu_fw_imx6d.bin" "${pkgdir}/usr/lib/firmware/vpu"
+  cp "${srcdir}/${pkgname}-${pkgver//.r0./-}/firmware/vpu/vpu_fw_imx6q.bin" "${pkgdir}/usr/lib/firmware/vpu"
 
-  install -D -m0644 "${srcdir}/${pkgname}-${pkgver}/COPYING" "$pkgdir/opt/fsl/licenses/LICENSE.${pkgname}"
+  install -D -m0644 "${srcdir}/${pkgname}-${pkgver//.r0./-}/COPYING" "${pkgdir}/opt/fsl/licenses/LICENSE.${pkgname}"
   
   mkdir -p "${pkgdir}/etc/ld.so.conf.d"
-  echo "/opt/fsl/lib" > "${pkgdir}/etc/ld.so.conf.d/$pkgname.conf"
+  echo "/opt/fsl/lib" > "${pkgdir}/etc/ld.so.conf.d/${pkgname}.conf"
 }


### PR DESCRIPTION
Version used on Yocto Project 5.0 LTS (scarthgap): https://layers.openembedded.org/layerindex/recipe/402107/