### PR TITLE
alarm/imx-vpu to 5.4.39.3

### DIFF
--- a/alarm/imx-vpu/PKGBUILD
+++ b/alarm/imx-vpu/PKGBUILD
@@ -1,27 +1,29 @@
 # Maintainer: CruX <crux@project-insanity.org>
 # Contributor: pepedog at archlinuxarm dot com
-# Contributor: Oleg Rakhmanov <oleg [at] archlinuxarm [dot] org>
 
 buildarch=4
 pkgname=imx-vpu
-pkgver=5.4.33
+pkgver=5.4.39.3
 pkgrel=1
 pkgdesc="Freescale proprietary extensions for i.MX6 SoC"
 url="https://community.freescale.com/docs/DOC-95560"
 arch=('armv7h')
 license=('proprietary')
-source=("http://www.freescale.com/lgfiles/NMG/MAD/YOCTO/${pkgname}-${pkgver}.bin" '99-mxc-vpu.rules')
-md5sums=('547074f0bb12fbf123f7998f2640c279'
+source=("http://www.freescale.com/lgfiles/NMG/MAD/YOCTO/${pkgname}-${pkgver}.bin"
+        '99-mxc-vpu.rules')
+md5sums=('6d6302189a6704874375afe62a65def0'
          'b749d82b96a323d8f914c63c65de9f92')
 
 prepare() {
   cd "${srcdir}"
-  #extract the sources
+  # extract the sources
   sh ${pkgname}-${pkgver}.bin --force --auto-accept
 }
 
 build() {
   cd "${pkgname}-${pkgver}"
+  # disable -mno-omit-leaf-frame-pointer
+  export CFLAGS="${CFLAGS//-mno-omit-leaf-frame-pointer}"
   export PLATFORM="IMX6Q"
   make all
 }
@@ -41,5 +43,3 @@ package() {
   install -D -m0644 "${srcdir}/${pkgname}-${pkgver}/COPYING" "$pkgdir/opt/fsl/licenses/LICENSE.${pkgname}"
   install -D -m0644 "${srcdir}/99-mxc-vpu.rules" "${pkgdir}/usr/lib/udev/rules.d/99-mxc-vpu.rules"
 }
-
-# vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Version used on Yocto Project 5.0 LTS (scarthgap): https://layers.openembedded.org/layerindex/recipe/402107/

I'm not sure if it's the right way, I had to remove `-mno-omit-leaf-frame-pointer` from `/etc/makepkg.conf` to avoid the build error:
```
==> Starting build()...
cc -DIMX6Q -Wall -fPIC -march=armv7-a -mfloat-abi=hard -mfpu=neon -O2 -pipe -fstack-protector-strong -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security         -fstack-clash-protection         -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -c vpu_io.c -o vpu_io.o
cc: error: unrecognized command-line option '-mno-omit-leaf-frame-pointer'; did you mean '-fno-omit-frame-pointer'?
make: *** [Makefile:37: vpu_io.o] Error 1
==> ERROR: A failure occurred in build().
    Aborting...
```