### PR TITLE
re-enable python-protobuf, using a separate PKGBUILD with pypi tarball as source

### DIFF
--- a/extra/protobuf/PKGBUILD
+++ b/extra/protobuf/PKGBUILD
@@ -10,11 +10,15 @@
 # ALARM: Kevin Mihelich <kevin@archlinuxarm.org>
 #  - remove makedpends on bazel
 #  - remove python package
+# ALARM: BrainDamage <braindamage@archlinux.org>
+#  - re-enable python package
+#  - split off python-protobuf to its own PKGBUILD file
 
 pkgbase='protobuf'
 pkgname=('protobuf')
 pkgver=27.2
 pkgrel=1
+# Note: python-protobuf needs to be updated alongside this package to the same version
 # Note: libphonenumber needs a rebuild for every version bump
 pkgdesc="Protocol Buffers - Google's data interchange format"
 arch=('x86_64')

--- a/extra/python-protobuf/.SRCINFO
+++ b/extra/python-protobuf/.SRCINFO
@@ -1,0 +1,17 @@
+pkgbase = python-protobuf
+	pkgdesc = Protocol Buffers - Google's data interchange format
+	pkgver = 27.2
+	pkgrel = 1
+	url = https://developers.google.com/protocol-buffers/
+	arch = aarch64
+	arch = armv7h
+	license = BSD
+	makedepends = python-build
+	makedepends = python-installer
+	makedepends = python-wheel
+	depends = python
+	depends = protobuf=27.2
+	source = https://files.pythonhosted.org/packages/source/p/protobuf/protobuf-5.27.2.tar.gz
+	sha256sums = f3ecdef226b9af856075f28227ff2c90ce3a594d092c39bee5513573f25e2714
+
+pkgname = python-protobuf

--- a/extra/python-protobuf/PKGBUILD
+++ b/extra/python-protobuf/PKGBUILD
@@ -1,0 +1,29 @@
+# ALARM: BrainDamage <braindamage@archlinux.org>
+#  - use pypi tarball as source
+#  - use normal python toolchain to build
+
+pkgname=python-protobuf
+_basename=protobuf
+pkgver=27.2
+_ver=5
+pkgrel=1
+pkgdesc="Protocol Buffers - Google's data interchange format"
+arch=('aarch64' 'armv7h')
+url='https://developers.google.com/protocol-buffers/'
+license=('BSD')
+depends=('python' "protobuf=${pkgver}")
+makedepends=('python-build' 'python-installer' 'python-wheel')
+source=("https://files.pythonhosted.org/packages/source/${_basename::1}/${_basename}/${_basename}-${_ver}.${pkgver}.tar.gz")
+sha256sums=('f3ecdef226b9af856075f28227ff2c90ce3a594d092c39bee5513573f25e2714')
+
+
+build() {
+	cd "${_basename}-${_ver}.${pkgver}"
+	export PYTHONHASHSEED=0
+	python -m build --wheel --no-isolation
+}
+
+package() {
+	cd "${_basename}-${_ver}.${pkgver}"
+	python -m installer --compile-bytecode 1 --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
python-protobuf is a depedendency of several packages, but it was dropped in commit fa75cecf701de0d42eecba9dfb292fe94ea479f5, breaking system updates due to version pinning requirements in the package itself.

This PR re-introduces python-protobuf as a separate PKGBUILD file, without bazel as build dependency, relying on upstream python package tarball releases and usual python toolchains. This alternative toolchain is only available in the python package tarball release and is not present by default in the normal protobuf all-in-one tarball.

Two minor downsides of this solution are:
 - When the main protobuf package is updated, this file must be updated alongside due to binary compatibility. Before they were a single file with split packages, now it's two.
 - This package will compile its own protobuf binaries during build to generate the bindings, only to discard them later, creating a small waste of resources.

I have considered adding the pypi url to the the sources array in the regular package, but the pypi tarball still calls the directory the same as the all-in-one package. Merging them is quite risky and I don't think it's a sound or robust practice. Strictly speaking, the python tarball dir has an extra prefix number that differentiates it from the all-in-one archive, but that may change in the future. By pre-emptively splitting the build to separate steps we can avoid several potential problems which would also be hard to debug.