### PR TITLE
core/linux-odroid-xu3: Add cpio makedep

### DIFF
--- a/core/linux-odroid-xu3/PKGBUILD
+++ b/core/linux-odroid-xu3/PKGBUILD
@@ -13,7 +13,7 @@ pkgrel=1
 arch=('armv7h')
 url="https://github.com/hardkernel/linux"
 license=('GPL2')
-makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'git')
+makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'git' 'cpio')
 options=('!strip')
 source=("linux-odroid-$_commit.tar.gz::https://github.com/hardkernel/linux/archive/${_commit}.tar.gz"
         'config'


### PR DESCRIPTION
@graysky2 apparently this was needed after all. I had gotten the same [less-than-useful error as the build server](https://archlinuxarm.org/builder/in-log/linux-odroid-xu3-6.6.36-1-armv7.log.html.gz), and if you try to continue the build it asks for cpio. A fresh build with cpio already installed does not error like this.