### PR TITLE
Bump alarm/uboot-sunxi to 2024.07-1

### DIFF
--- a/alarm/uboot-sunxi/PKGBUILD
+++ b/alarm/uboot-sunxi/PKGBUILD
@@ -17,19 +17,19 @@ pkgname=('uboot-a10-olinuxino-lime'
          'uboot-pcduino'
          'uboot-pcduino3'
          'uboot-pcduino3-nano')
-pkgver=2017.01
-pkgrel=2
+pkgver=2024.07
+pkgrel=1
 arch=('armv7h')
 url="http://git.denx.de/u-boot.git/"
 license=('GPL')
-makedepends=('git' 'bc' 'dtc' 'python2')
+makedepends=('git' 'bc' 'dtc' 'python' 'swig')
 backup=(boot/boot.txt boot/boot.scr)
 source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
         'boot.txt'
         'mkscr')
-md5sums=('ad2d82d5b4fa548b2b95bbc26c9bad79'
-         '95f60c0ae1315e986d8a2aee15d5f854'
-         '021623a04afd29ac3f368977140cfbfd')
+sha256sums=('f591da9ab90ef3d6b3d173766d0ddff90c4ed7330680897486117df390d83c8f'
+            '24ca87bc2941bc5c6230e9004c0305fa63c5c007160bd438d296691bd979f27a'
+            'a4fc8b6b92bc364d6542670d294aa618a8501fb8729f415cc0a3eed776ef0c8e')
 
 boards=('A10-OLinuXino-Lime'
         'A10s-OLinuXino-M'
@@ -44,12 +44,6 @@ boards=('A10-OLinuXino-Lime'
         'Linksprite_pcDuino'
         'Linksprite_pcDuino3'
         'Linksprite_pcDuino3_Nano')
-
-prepare() {
-  cd u-boot-${pkgver}
-
-  sed -i 's/env python$/&2/' tools/binman/binman{,.py}
-}
 
 build() {
   cd u-boot-${pkgver}


### PR DESCRIPTION
Supersedes #1803, and should bring all of the new features of u-boot to this platform.

I have tested it on both A10-Olinuxino-Lime and A20-Olinuxino-Lime2, and checked that the latter does get gigabit Ethernet enabled.