### PR TITLE
core/linux-odroid-xu3: Add conflicts/replaces for linux-odroid-n2

### DIFF
--- a/core/linux-odroid-xu3/PKGBUILD
+++ b/core/linux-odroid-xu3/PKGBUILD
@@ -7,7 +7,7 @@ pkgbase=linux-odroid-xu3
 _commit=30c3784c60265b33a78b7c369fe6f25d2525fb4b
 _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
-_desc="ODROID-XU3/XU4/HC1, odroid-6.6.y branch"
+_desc="ODROID-XU3/XU4/HC1/C4/N2, odroid-6.6.y branch"
 pkgver=6.6.40
 pkgrel=1
 arch=('armv7h')
@@ -48,7 +48,8 @@ _package() {
   depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
   optdepends=('wireless-regdb: to set the correct wireless channels of your country')
   provides=("linux=${pkgver}" "WIREGUARD-MODULE")
-  conflicts=('linux')
+  conflicts=('linux' 'linux-odroid-n2')
+  replaces=('linux-odroid-n2')
   backup=("etc/mkinitcpio.d/${pkgbase}.preset")
   install=${pkgname}.install
 
@@ -85,7 +86,8 @@ _package() {
 _package-headers() {
   pkgdesc="Header files and scripts for building modules for linux kernel - ${_desc}"
   provides=("linux-headers=${pkgver}")
-  conflicts=('linux-headers')
+  conflicts=('linux-headers' 'linux-odroid-n2-headers')
+  replaces=('linux-odroid-n2-headers')
 
   cd $_srcname
   local builddir="$pkgdir/usr/lib/modules/$(<version)/build"


### PR DESCRIPTION
"Yes, we are using odroid-6.6.y for C4 Series, N2 Series and XU4."
https://github.com/hardkernel/linux/issues/437#issuecomment-2233498714