### PR TITLE
alarm/uboot-sunxi to 2024.07-2

### DIFF
--- a/alarm/uboot-sunxi/PKGBUILD
+++ b/alarm/uboot-sunxi/PKGBUILD
@@ -18,11 +18,11 @@ pkgname=('uboot-a10-olinuxino-lime'
          'uboot-pcduino3'
          'uboot-pcduino3-nano')
 pkgver=2024.07
-pkgrel=1
+pkgrel=2
 arch=('armv7h')
 url="http://git.denx.de/u-boot.git/"
 license=('GPL')
-makedepends=('git' 'bc' 'dtc' 'python' 'swig')
+makedepends=('git' 'bc' 'dtc' 'python-setuptools' 'swig')
 backup=(boot/boot.txt boot/boot.scr)
 source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
         'boot.txt'


### PR DESCRIPTION
makedepends was missing python-setuptools.

Fixes build broken by #2045.