### PR TITLE
core/linux-odroid-xu3 to 6.6.40-2

### DIFF
--- a/core/linux-odroid-xu3/PKGBUILD
+++ b/core/linux-odroid-xu3/PKGBUILD
@@ -4,12 +4,12 @@
 buildarch=4
 
 pkgbase=linux-odroid-xu3
-_commit=30c3784c60265b33a78b7c369fe6f25d2525fb4b
+_commit=7a31a6985343ff8a8078988c1cf9be6e5c4df42e
 _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="ODROID-XU3/XU4/HC1, odroid-6.6.y branch"
 pkgver=6.6.40
-pkgrel=1
+pkgrel=2
 arch=('armv7h')
 url="https://github.com/hardkernel/linux"
 license=('GPL2')
@@ -18,7 +18,7 @@ options=('!strip')
 source=("linux-odroid-$_commit.tar.gz::https://github.com/hardkernel/linux/archive/${_commit}.tar.gz"
         'config'
         'linux.preset')
-md5sums=('f407ef5630954f324f9c6b01d03e5e46'
+md5sums=('b9b48dca203a814e4e12a395ebf9059b'
          '6779c133ce155d8ec39704bc9b6aba8a'
          '86d4a35722b5410e3b29fc92dae15d4b')
 


### PR DESCRIPTION
Bump for https://github.com/hardkernel/linux/pull/438