### PR TITLE
Patch to prevent freeze during boot if gpio device connected

### DIFF
--- a/alarm/uboot-raspberrypi/0002-fix-serial-console.patch
+++ b/alarm/uboot-raspberrypi/0002-fix-serial-console.patch
@@ -1,0 +1,36 @@
+From 3ced0f1608d6ded3d8474ea4a98aec00ae67fe9e Mon Sep 17 00:00:00 2001
+From: Maulik Patel <maulikp163@gmail.com>
+Date: Mon, 10 Jun 2024 18:32:25 +0530
+Subject: [PATCH] disable uart for u-boot
+
+---
+ board/raspberrypi/rpi/rpi.env | 2 ++
+ configs/rpi_4_defconfig       | 5 +++++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/board/raspberrypi/rpi/rpi.env b/board/raspberrypi/rpi/rpi.env
+index 30228285ed..44a427512c 100644
+--- a/board/raspberrypi/rpi/rpi.env
++++ b/board/raspberrypi/rpi/rpi.env
+@@ -3,6 +3,8 @@
+ /* environment for Raspberry Pi boards */
+ 
+ dhcpuboot=usb start; dhcp u-boot.uimg; bootm
++bootdelay=-2
++silent=1
+ 
+ /* Environment */
+ stdin=serial,usbkbd
+diff --git a/configs/rpi_4_defconfig b/configs/rpi_4_defconfig
+index 2541b83a3d..a5dc879d6a 100644
+--- a/configs/rpi_4_defconfig
++++ b/configs/rpi_4_defconfig
+@@ -65,3 +65,8 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_VIDEO_BCM2835=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+ CONFIG_PHYS_TO_BUS=y
++CONFIG_BOOTDELAY=-2
++CONFIG_SILENT_CONSOLE=y
++CONFIG_SYS_DEVICE_NULLDEV=y
++CONFIG_SILENT_CONSOLE_UPDATE_ON_SET=y
++CONFIG_SILENT_U_BOOT_ONLY=y

--- a/alarm/uboot-raspberrypi/PKGBUILD
+++ b/alarm/uboot-raspberrypi/PKGBUILD
@@ -47,6 +47,7 @@ source=(
         bcm2710-rpi-cm3.v7
         bcm2711-rpi-4-b.v7
         '0001-rpi-increase-space-for-kernel.patch'
+        '0002-fix-serial-console.patch'
         'boot.txt.v2'
         'boot.txt.v3'
         'mkscr')
@@ -81,6 +82,7 @@ md5sums=('f750ca945f4a4d6a69b36259c8b68689'
          '8dea82ecb9ec769246767836c74fb8f7'
          '35074bb767e8b259c5825b0c1f17fd60'
          '636c8ac2098ebf0acdc2ff15430edf0d'
+         'daa8314d29129e1b1ae0b316604bf8be'
          'f8ad4508b9734e9e13aedb9f7419d7a3'
          'be8abe44b86d63428d7ac3acc64ee3bf'
          '021623a04afd29ac3f368977140cfbfd')
@@ -89,6 +91,7 @@ prepare() {
   cd u-boot-${pkgver/rc/-rc}
 
   patch -p1 -i ../0001-rpi-increase-space-for-kernel.patch
+  patch -p1 -i ../0002-fix-serial-console.patch
 }
 
 build() {

--- a/alarm/uboot-raspberrypi/PKGBUILD
+++ b/alarm/uboot-raspberrypi/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=uboot-raspberrypi
 pkgver=2024.07
-pkgrel=3
+pkgrel=4
 pkgdesc="U-Boot for Raspberry Pi"
 arch=('armv7h' 'aarch64')
 url='https://docs.u-boot.org/en/latest'


### PR DESCRIPTION
This fixes an issue where u-boot would hang whenever a device (for example the GPS hat from Adafruit)  is connected to the raspberry pi's GPIO header.

These devices usually output something to the serial console during the startup phase of u-boot, making u-boot think it has to interrupt its boot sequence because somebody is trying to interrupt it's startup.

This also aligns the rpi4 behavior with the one from Raspbian, which does not interrupt its boot sequence with a GPIO device attached