### PR TITLE
Apply patch from raspberry kernel to fix PPS signal on 64-bit ARM

### DIFF
--- a/core/linux-aarch64-rc/0003-pps-Compatibility-hack-should-be-X86-specific.patch
+++ b/core/linux-aarch64-rc/0003-pps-Compatibility-hack-should-be-X86-specific.patch
@@ -1,0 +1,53 @@
+From fa7109e14af17148c6081396e02aa9a05cde91fb Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.com>
+Date: Mon, 22 May 2023 14:22:55 +0100
+Subject: [PATCH] pps: Compatibility hack should be X86-specific
+
+As of [1], using PPS_FETCH on a 64-bit ARM kernel with a 32-bit userland
+is broken, returning a timeout. This is because the requested 4-byte
+alignment for struct pps_ktime_compat (illegal on arm64) results in the
+timeout flags field being uninitialised.
+
+Make the hack specific to X86_64 builds with CONFIG_COMPAT defined.
+
+[1] commit c2a49fe8eeef ("pps: fix padding issue with PPS_FETCH for
+    ioctl_compat")
+
+See: https://github.com/raspberrypi/linux/issues/5430
+Fixes: c2a49fe8eeef ("pps: fix padding issue with PPS_FETCH for ioctl_compat")
+Signed-off-by: Phil Elwell <phil@raspberrypi.com>
+---
+ drivers/pps/pps.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/pps/pps.c b/drivers/pps/pps.c
+index 5d19baae6a38..0675c8a2e560 100644
+--- a/drivers/pps/pps.c
++++ b/drivers/pps/pps.c
+@@ -249,12 +249,13 @@ static long pps_cdev_ioctl(struct file *file,
+ static long pps_cdev_compat_ioctl(struct file *file,
+ 		unsigned int cmd, unsigned long arg)
+ {
+-	struct pps_device *pps = file->private_data;
+-	void __user *uarg = (void __user *) arg;
+ 
+ 	cmd = _IOC(_IOC_DIR(cmd), _IOC_TYPE(cmd), _IOC_NR(cmd), sizeof(void *));
+ 
++#ifdef CONFIG_X86_64
+ 	if (cmd == PPS_FETCH) {
++		struct pps_device *pps = file->private_data;
++		void __user *uarg = (void __user *) arg;
+ 		struct pps_fdata_compat compat;
+ 		struct pps_fdata fdata;
+ 		int err;
+@@ -289,6 +290,7 @@ static long pps_cdev_compat_ioctl(struct file *file,
+ 		return copy_to_user(uarg, &compat,
+ 				sizeof(struct pps_fdata_compat)) ? -EFAULT : 0;
+ 	}
++#endif
+ 
+ 	return pps_cdev_ioctl(file, cmd, arg);
+ }
+-- 
+2.46.0
+

--- a/core/linux-aarch64-rc/PKGBUILD
+++ b/core/linux-aarch64-rc/PKGBUILD
@@ -4,7 +4,7 @@
 buildarch=8
 
 _rcver=6.11
-_rcrel=5
+_rcrel=6
 
 pkgbase=linux-aarch64-rc
 _srcname=linux-${_rcver}-rc${_rcrel}
@@ -20,6 +20,7 @@ options=('!strip')
 source=("https://git.kernel.org/torvalds/t/${_srcname}.tar.gz"
         '0001-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch'
         '0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch'
+        '0003-pps-Compatibility-hack-should-be-X86-specific.patch'
         'pinctrl-rockchip-correct-RK3328-iomux-width-flag-for-GPIO2-B-pins.patch'
         'config'
         'generate_chromebook_its.sh'
@@ -29,6 +30,7 @@ source=("https://git.kernel.org/torvalds/t/${_srcname}.tar.gz"
 md5sums=('de6eafed84cbe0b046c5da35fccf7278'
          '7b08a199a97e3e2288e5c03d8e8ded2d'
          'c9d4e392555b77034e24e9f87c5ff0b3'
+         '2a762218c34ac99287bbc2d16b7d5eea'
          'd4add3377b26d8b6f0818f7dddfb8cda'
          '6f408ceb5e0229083a763a54975b796a'
          '7c97cf141750ad810235b1ad06eb9f75'
@@ -46,6 +48,7 @@ prepare() {
   # ALARM patches
   git apply ../0001-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
   git apply ../0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch
+  git apply ../0003-pps-Compatibility-hack-should-be-X86-specific.patch
 
   # https://archlinuxarm.org/forum/viewtopic.php?f=65&t=16981
   patch -p1 -i ../pinctrl-rockchip-correct-RK3328-iomux-width-flag-for-GPIO2-B-pins.patch

--- a/core/linux-aarch64/0003-pps-Compatibility-hack-should-be-X86-specific.patch
+++ b/core/linux-aarch64/0003-pps-Compatibility-hack-should-be-X86-specific.patch
@@ -1,0 +1,53 @@
+From fa7109e14af17148c6081396e02aa9a05cde91fb Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.com>
+Date: Mon, 22 May 2023 14:22:55 +0100
+Subject: [PATCH] pps: Compatibility hack should be X86-specific
+
+As of [1], using PPS_FETCH on a 64-bit ARM kernel with a 32-bit userland
+is broken, returning a timeout. This is because the requested 4-byte
+alignment for struct pps_ktime_compat (illegal on arm64) results in the
+timeout flags field being uninitialised.
+
+Make the hack specific to X86_64 builds with CONFIG_COMPAT defined.
+
+[1] commit c2a49fe8eeef ("pps: fix padding issue with PPS_FETCH for
+    ioctl_compat")
+
+See: https://github.com/raspberrypi/linux/issues/5430
+Fixes: c2a49fe8eeef ("pps: fix padding issue with PPS_FETCH for ioctl_compat")
+Signed-off-by: Phil Elwell <phil@raspberrypi.com>
+---
+ drivers/pps/pps.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/pps/pps.c b/drivers/pps/pps.c
+index 5d19baae6a38..0675c8a2e560 100644
+--- a/drivers/pps/pps.c
++++ b/drivers/pps/pps.c
+@@ -249,12 +249,13 @@ static long pps_cdev_ioctl(struct file *file,
+ static long pps_cdev_compat_ioctl(struct file *file,
+ 		unsigned int cmd, unsigned long arg)
+ {
+-	struct pps_device *pps = file->private_data;
+-	void __user *uarg = (void __user *) arg;
+ 
+ 	cmd = _IOC(_IOC_DIR(cmd), _IOC_TYPE(cmd), _IOC_NR(cmd), sizeof(void *));
+ 
++#ifdef CONFIG_X86_64
+ 	if (cmd == PPS_FETCH) {
++		struct pps_device *pps = file->private_data;
++		void __user *uarg = (void __user *) arg;
+ 		struct pps_fdata_compat compat;
+ 		struct pps_fdata fdata;
+ 		int err;
+@@ -289,6 +290,7 @@ static long pps_cdev_compat_ioctl(struct file *file,
+ 		return copy_to_user(uarg, &compat,
+ 				sizeof(struct pps_fdata_compat)) ? -EFAULT : 0;
+ 	}
++#endif
+ 
+ 	return pps_cdev_ioctl(file, cmd, arg);
+ }
+-- 
+2.46.0
+

--- a/core/linux-aarch64/PKGBUILD
+++ b/core/linux-aarch64/PKGBUILD
@@ -9,7 +9,7 @@ _srcname=linux-6.10
 _kernelname=${pkgbase#linux}
 _desc="AArch64 multi-platform"
 pkgver=6.10.6
-pkgrel=2
+pkgrel=3
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -19,6 +19,7 @@ source=("http://www.kernel.org/pub/linux/kernel/v6.x/${_srcname}.tar.xz"
         "http://www.kernel.org/pub/linux/kernel/v6.x/patch-${pkgver}.xz"
         '0001-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch'
         '0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch'
+        '0003-pps-Compatibility-hack-should-be-X86-specific.patch'
         'pinctrl-rockchip-correct-RK3328-iomux-width-flag-for-GPIO2-B-pins.patch'
         'config'
         'generate_chromebook_its.sh'
@@ -29,6 +30,7 @@ md5sums=('c0ce046a9a0d041e13cf222f81eae574'
          'dddaba3d5753cb5b4a94917d083a7f5e'
          '7b08a199a97e3e2288e5c03d8e8ded2d'
          'c9d4e392555b77034e24e9f87c5ff0b3'
+         '2a762218c34ac99287bbc2d16b7d5eea'
          'd4add3377b26d8b6f0818f7dddfb8cda'
          'ebfcd5d79878361e9d06d45b829a3bd6'
          '7c97cf141750ad810235b1ad06eb9f75'
@@ -49,6 +51,7 @@ prepare() {
   # ALARM patches
   git apply ../0001-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
   git apply ../0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch
+  git apply ../0003-pps-Compatibility-hack-should-be-X86-specific.patch
 
   # https://archlinuxarm.org/forum/viewtopic.php?f=65&t=16981
   patch -p1 -i ../pinctrl-rockchip-correct-RK3328-iomux-width-flag-for-GPIO2-B-pins.patch


### PR DESCRIPTION
This fixes PPS read timeouts on 64-bit ARM caused by another bug fix in the upstream kernel that was aimed for 32-bit ARM but was wrongly also applied to 64-bit.

See https://github.com/raspberrypi/linux/issues/5430 for further information. Patch is also taken from there