### PR TITLE
fake-hwclock: Add hwclock --systohc to synchronize hardware clock

### DIFF
--- a/alarm/fake-hwclock/PKGBUILD
+++ b/alarm/fake-hwclock/PKGBUILD
@@ -6,7 +6,7 @@
 
 pkgname=fake-hwclock
 pkgver=0.3
-pkgrel=1
+pkgrel=1.1
 pkgdesc="Saves time on shutdown and restores it on boot from a file"
 arch=('any')
 license=('GPL')
@@ -16,7 +16,7 @@ source=('fake-hwclock.sh'
         'fake-hwclock-save.service'
         'fake-hwclock-save.timer')
 
-md5sums=('713f9cd5d8dc0073b5eca5dd14de1271'
+md5sums=('6af777b6c8ce7bac91a04a7a66209987'
          'fa52aac3db246575c3cc8c1bf608766c'
          '9f93ed2b74260d204a9c285d35ee2daa'
          'b2b494cb4ba99eb12df3cb4188902ca4')

--- a/alarm/fake-hwclock/fake-hwclock.sh
+++ b/alarm/fake-hwclock/fake-hwclock.sh
@@ -8,6 +8,7 @@ loadclock() {
 	if [ $(date +%s) -lt $savedtime ]; then
 		echo "Restoring saved system time"
 		date -s @$savedtime
+		hwclock --systohc
 	else
 		echo "Not restoring old system time"
 	fi


### PR DESCRIPTION
### Description

This PR adds the command `hwclock --systohc` to the `fake-hwclock` script located in `/usr/lib/systemd/scripts/fake-hwclock.sh`. The purpose of this addition is to ensure that after restoring the system time from the saved state, the hardware clock (RTC) is synchronized with the system time. This is crucial for maintaining accurate timekeeping on systems without a reliable RTC, especially in cases where the system may be rebooted or powered off frequently.

### Rationale

The `fake-hwclock` package is intended to simulate an RTC on systems that lack one. However, after restoring the system time, there is currently no step that updates the actual hardware clock with the restored time. By adding `hwclock --systohc`, we ensure that the RTC is kept in sync with the restored time, improving the reliability of timekeeping across reboots.

### Changes Introduced

- The `fake-hwclock.sh` script now includes the command `hwclock --systohc` immediately after the time is restored using `date -s @$savedtime`.

### Compliance

- `pkgver` remains unchanged as this is a minor enhancement.
- `pkgrel` has been incremented to `1.1` to reflect the change and ensure proper tracking against upstream.
- Checksums have been verified