### PR TITLE
Include a possible fix for cgroup_enable=memory

### DIFF
--- a/core/linux-rpi/PKGBUILD
+++ b/core/linux-rpi/PKGBUILD
@@ -5,12 +5,12 @@
 # Contributer: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
 
 pkgbase=linux-rpi
-_commit=075daad17cb8f5163dee1e483b2902a66519586d
+_commit=00a0c4800839d64f9126861f10e5484c934b162d
 _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _regen=
 pkgver=6.12.3
-pkgrel=1
+pkgrel=2
 pkgdesc='Linux'
 url="https://github.com/raspberrypi/linux"
 arch=(armv7h aarch64)
@@ -30,7 +30,7 @@ source=("linux-$pkgver-${_commit:0:10}.tar.gz::https://github.com/raspberrypi/li
         linux.preset
         archarm.diffconfig
 )
-md5sums=('851623f7446b1454f9465b5a5e725912'
+md5sums=('035ca4fdd68321be4377a9dd04a0a0dd'
          '3bab7426d8c8818dda8353da3892a41f'
          '44f69a0637b34eb772980614f9246d01'
          'a157c5bfc0f03d0728c92bd953b06265'


### PR DESCRIPTION
Please see https://github.com/raspberrypi/linux/pull/6524 and https://archlinuxarm.org/forum/viewtopic.php?f=23&t=17131