### PR TITLE
alarm/amzn-ena-aarch64-dkms to 2.13.1-1

### DIFF
--- a/alarm/amzn-ena-aarch64-dkms/PKGBUILD
+++ b/alarm/amzn-ena-aarch64-dkms/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: iDigitalFlame <idf@idfla.me>
 pkgname="amzn-ena-aarch64-dkms"
-pkgver="2.13.0"
+pkgver="2.13.1"
 pkgrel="1"
 pkgdesc="Linux kernel driver for Amazon's Elastic Network Adapter (ENA)"
 arch=("aarch64")
@@ -10,8 +10,8 @@ depends=("dkms" "linux-aarch64" "linux-aarch64-headers")
 install="amzn-drivers.install"
 source=("https://github.com/amzn/amzn-drivers/archive/refs/tags/ena_linux_${pkgver}.tar.gz"
         "dkms.conf")
-sha256sums=("82022dcf1050a0309fa098b2cd1457e2efe3a3c37f385cd15a723e7f7a90784f"
-            "3d3e5f963a0d80568ea89bf22a2eda9cea7f805e1fc6c35c498a8379cb6b2313")
+sha256sums=("d3d5a7239f3843ecea1f2ba08c5d5e2599d517ea10d708b25315528b79148009"
+            "396c7592cabf5b97da142bfd750af5564b4f7b04e27ef893c30f00e8560ecd9f")
 buildarch=8
 
 package() {

--- a/alarm/amzn-ena-aarch64-dkms/dkms.conf
+++ b/alarm/amzn-ena-aarch64-dkms/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="ena"
-PACKAGE_VERSION="2.13.0"
+PACKAGE_VERSION="2.13.1"
 CLEAN="make -C ena clean"
 MAKE="make -C ena/ BUILD_KERNEL=$kernelver"
 BUILT_MODULE_NAME[0]="ena"


### PR DESCRIPTION
Changes/Updates:

- Driver updated to the latest upstream release: 2.13.1 (from 2.13.0)

Tests:

- [X] Build tested
- [X] Built in clean chroot
- [X] Tested in a live AWS ArchLinuxARM instance