### PR TITLE
Add jupyter-notebook

### DIFF
--- a/extra/jupyter-notebook/PKGBUILD
+++ b/extra/jupyter-notebook/PKGBUILD
@@ -1,0 +1,53 @@
+# Maintainer: Antonio Rojas <arojas@archlinux.org>
+# Contributor: Kyle Keen <keenerd@gmail.com>
+
+pkgname=jupyter-notebook
+_pipname=notebook
+pkgver=7.3.2
+pkgrel=1
+pkgdesc='The language-agnostic HTML notebook application for Project Jupyter'
+arch=(any)
+url='https://github.com/jupyter/notebook'
+license=(BSD-3-Clause)
+depends=(jupyter-notebook-shim
+         jupyter-server
+         jupyterlab
+         python
+         python-jupyter-client
+         python-jupyter-core
+         python-jupyterlab-server
+         python-tornado
+         python-traitlets)
+makedepends=(git
+             nodejs
+             python-build
+             python-setuptools
+             python-hatch-jupyter-builder
+             python-installer)
+checkdepends=(python-pytest-jupyter
+              python-pytest-timeout
+              python-requests)
+replaces=(jupyter-retrolab)
+source=(git+https://github.com/jupyter/notebook#tag=v$pkgver)
+sha256sums=('050c03067771fe82cb39ab04d4c9eee1721ea8367228be5efcccf761aa5ef266')
+
+build() {
+  cd notebook
+  python -m build --wheel --no-isolation --skip-dependency-check
+}
+
+check() {
+  cd notebook
+  python -m venv --system-site-packages test-env
+  test-env/bin/python -m installer dist/*.whl
+  test-env/bin/python -m pytest -v -W ignore::DeprecationWarning
+}
+
+package() {
+  cd notebook
+  python -m installer --destdir="$pkgdir" dist/*.whl
+  mv "$pkgdir"/{usr/,}etc
+
+  install -Dm644 LICENSE -t "$pkgdir"/usr/share/licenses/$pkgname
+  install -Dm644 jupyter-notebook.desktop -t "$pkgdir"/usr/share/applications
+}


### PR DESCRIPTION
Add build dependency of python-setuptools.

Somehow python-setuptools is installed automatically on x86 probably pulled in by some other dependencies that I'm too lazy to track down....
