### PR TITLE
enable 64 bit time on armv7

### DIFF
--- a/core/pacman/PKGBUILD
+++ b/core/pacman/PKGBUILD
@@ -143,7 +143,7 @@ package() {
     armv7h)
       mycarch="armv7h"
       mychost="armv7l-unknown-linux-gnueabihf"
-      myflags="-march=armv7-a -mfloat-abi=hard -mfpu=neon "
+      myflags="-march=armv7-a -mfloat-abi=hard -mfpu=neon -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64 "
       ;;
     aarch64)
       mycarch="aarch64"


### PR DESCRIPTION
need further discussion. may need to rebuild all armv7 package.

https://blogs.gentoo.org/mgorny/2024/09/28/the-perils-of-transition-to-64-bit-time_t
https://blogs.gentoo.org/mgorny/2024/10/04/testing-the-safe-time64-transition-path