### PR TITLE
add package: extra/uv

### DIFF
--- a/extra/uv/PKGBUILD
+++ b/extra/uv/PKGBUILD
@@ -1,0 +1,90 @@
+# Maintainer: Orhun Parmaksız <orhun@archlinux.org>
+# Maintainer: Caleb Maclennan <caleb@alerque.com>
+# Contributor: MithicSpirit <rpc01234 at gmail dot com>
+# Contributor: David Runge <dvzrv@archlinux.org>
+# Contributor: Leonidas Spyropoulos <artafinde@archlinux.org>
+# Contributor: Daniel M. Capella <polyzen@archlinux.org>
+# Contributor: Guillaume Gauvrit <guillaume@gauvr.it>
+
+# ALARM:
+#  - build aarch64 with 16k page support
+
+pkgbase=uv
+pkgname=("$pkgbase" "python-$pkgbase")
+pkgver=0.5.29
+pkgrel=1.1
+pkgdesc='An extremely fast Python package installer and resolver written in Rust'
+arch=('x86_64')
+url="https://github.com/astral-sh/uv"
+license=('MIT' 'Apache-2.0')
+depends=('gcc-libs' # 'libgcc_s.so'
+         'glibc' # 'libc.so' 'libm.so'
+         'zlib' # 'libz.so'
+         'bzip2' # 'libbz2.so'
+         )
+makedepends=('cargo' 'maturin' 'python-installer' 'cmake' 'git')
+checkdepends=('python' 'python-zstandard' 'libxcrypt-compat' 'clang')
+options=('!lto')
+source=("git+$url.git#tag=$pkgver")
+sha256sums=('c824557644ccbadf3ff897d9ca9dfead501e1fdd059391c626dfd887d34555f7')
+
+prepare() {
+  cd "$pkgbase"
+  local tripple="$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$tripple"
+  mkdir completions
+}
+
+# Note --frozen doesn't work here because cargo fetch didn't get everything
+# maturin ends up trying to use so we make do with --locked ...
+build() {
+  cd "$pkgbase"
+  local tripple="$(rustc -vV | sed -n 's/host: //p')"
+
+  [[ $CARCH == "aarch64" ]] && export JEMALLOC_SYS_WITH_LG_PAGE=16
+
+  maturin build --locked --release --all-features --target "$tripple" --strip --compatibility linux
+  local compgen="target/$tripple/release/uv --generate-shell-completion"
+  $compgen bash >"completions/$pkgbase"
+  $compgen elvish >"completions/$pkgbase.elv"
+  $compgen fish >"completions/$pkgbase.fish"
+  $compgen zsh >"completions/_$pkgbase"
+}
+
+check() {
+  cd "$pkgbase"
+  # The upstream cargo tests are unit tests against a matrix of Python versions
+  # using vendored Python installs. Even collapsing the matrix to match our
+  # system Python version and patching around the path issues to use it,
+  # a majority of the unit tests are irrelevant.
+  local tripple="$(rustc -vV | sed -n 's/host: //p')"
+  local _target="target/$tripple/release/uv"
+  $_target -V | grep -F "$pkgname $pkgver"
+}
+
+_package_common() {
+  install -Dm0644 -t "$pkgdir/usr/share/licenses/$pkgname/" LICENSE-*
+  install -Dm0644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
+}
+
+package_uv() {
+  cd "$pkgbase"
+  _package_common
+  local _target="target/$(rustc -vV | sed -n 's/host: //p')/release/uv"
+  install -Dm0755 -t "$pkgdir/usr/bin/" "$_target"
+  install -Dm0755 -t "$pkgdir/usr/bin/" "${_target}x"
+  install -Dm 644 "completions/$pkgbase" -t "$pkgdir/usr/share/bash-completion/completions/"
+  install -Dm 644 "completions/$pkgbase.elv" -t "$pkgdir/usr/share/elvish/lib/"
+  install -Dm 644 "completions/$pkgbase.fish" -t "$pkgdir/usr/share/fish/vendor_completions.d/"
+  install -Dm 644 "completions/_$pkgbase" -t "$pkgdir/usr/share/zsh/site-functions/"
+}
+
+package_python-uv() {
+  cd "$pkgbase"
+  _package_common
+  depends=(python "$pkgbase")
+  python -m installer -d "$pkgdir" target/wheels/*.whl
+  rm -rf "$pkgdir/usr/bin"
+}
+
+# vim: ts=2 sw=2 et:


### PR DESCRIPTION
Similar to some other packages, uv needs to be built with `JEMALLOC_SYS_WITH_LG_PAGE=16` to work on some aarch64 systems. Upstream is doing this for their official builds (https://github.com/astral-sh/uv/issues/6528) and I confirmed this works on my Apple M1. The PKGBUILD from official Arch doesn't set this, so the `uv` package is broken and crashes. This change should fix that. The rest of the additions are just a copy from Arch's packaging repo.