### PR TITLE
add package: extra/ruff

### DIFF
--- a/extra/ruff/PKGBUILD
+++ b/extra/ruff/PKGBUILD
@@ -1,0 +1,75 @@
+# Maintainer: David Runge <dvzrv@archlinux.org>
+# Maintainer: Caleb Maclennan <caleb@alerque.com>
+# Maintainer: Leonidas Spyropoulos <artafinde@archlinux.org>
+# Maintainer: Daniel M. Capella <polyzen@archlinux.org>
+
+# ALARM:
+#  - build aarch64 with 16k page support
+
+pkgbase=ruff
+pkgname=("$pkgbase" "python-$pkgbase")
+pkgver=0.9.5
+pkgrel=1.1
+pkgdesc='An extremely fast Python linter, written in Rust'
+arch=(x86_64)
+url=https://github.com/astral-sh/$pkgbase
+license=(MIT)
+depends=(
+  gcc-libs
+  glibc
+)
+makedepends=(
+  cargo
+  git
+  maturin
+  python-installer
+)
+options=(!lto)
+source=("git+$url.git#tag=$pkgver")
+sha512sums=('8081c30569bb321a944591c9f626214bd6f507df467c26d16e2cfefbab7cb05ca502b7aa1a01d9f68a2e525e44c4c21bf79d2a15a473b1c01a58fd147affdabe')
+b2sums=('88f1d3c9ef27b2a624ca583ce6c003a64c360bc8d85feaf5eb5d232afc3d1457477a4b13125d2e5caec292941e214b2543ecf7c7eb41764d4a529ebdeb58117f')
+
+prepare() {
+  cd $pkgbase
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+  cd $pkgbase
+
+  [[ $CARCH == "aarch64" ]] && export JEMALLOC_SYS_WITH_LG_PAGE=16
+
+  maturin build --locked --release --all-features --target "$(rustc -vV | sed -n 's/host: //p')" --strip
+}
+
+check() {
+  cd $pkgbase
+  cargo test -p ruff --frozen --all-features -- --skip display_default_settings
+}
+
+_package_common() {
+  install -Dm0644 -t "$pkgdir/usr/share/licenses/$pkgname/" LICENSE
+  install -Dm0644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
+}
+
+package_ruff() {
+  cd $pkgbase
+  _package_common
+  local _target="target/$(rustc -vV | sed -n 's/host: //p')/release/ruff"
+  install -Dm0755 -t "$pkgdir/usr/bin/" "$_target"
+  $_target generate-shell-completion bash   | install -Dm0644 /dev/stdin "$pkgdir/usr/share/bash-completion/completions/$pkgbase.bash"
+  $_target generate-shell-completion elvish | install -Dm0644 /dev/stdin "$pkgdir/usr/share/elvish/lib/$pkgbase.elv"
+  $_target generate-shell-completion fish   | install -Dm0644 /dev/stdin "$pkgdir/usr/share/fish/vendor_completions.d/$pkgbase.fish"
+  $_target generate-shell-completion zsh    | install -Dm0644 /dev/stdin "$pkgdir/usr/share/zsh/site-functions/_$pkgbase"
+}
+
+package_python-ruff() {
+  depends=(python "$pkgbase")
+
+  cd $pkgbase
+  _package_common
+  python -m installer -d "$pkgdir" target/wheels/*.whl
+
+  cd "$pkgdir"
+  rm -rf usr/bin
+}


### PR DESCRIPTION
Similar to some other packages, uv needs to be built with `JEMALLOC_SYS_WITH_LG_PAGE=16` to work on some aarch64 systems. Upstream is doing this for their official builds (https://github.com/astral-sh/ruff/pull/4247) and I confirmed this works on my Apple M1.

This is a followup from https://github.com/archlinuxarm/PKGBUILDs/pull/2089