### PR TITLE
core/linux-rpi: make boot option specific for pi4...

### DIFF
--- a/core/linux-rpi/PKGBUILD
+++ b/core/linux-rpi/PKGBUILD
@@ -32,7 +32,7 @@ source=("linux-$pkgver-${_commit:0:10}.tar.gz::https://github.com/raspberrypi/li
 )
 md5sums=('3315e570d75d48a2f3c2de336510585e'
          '3bab7426d8c8818dda8353da3892a41f'
-         '44f69a0637b34eb772980614f9246d01'
+         '577f0f85bd08490fdd8ebe47d2486463'
          'a157c5bfc0f03d0728c92bd953b06265'
          '8b93b6ca167f70c60277f352f7b78024'
          '4d7ab0ab2625470ebb916176b5d9cf02')

--- a/core/linux-rpi/config.txt
+++ b/core/linux-rpi/config.txt
@@ -19,10 +19,6 @@ camera_auto_detect=1
 # Automatically load overlays for detected DSI displays
 display_auto_detect=1
 
-# Enable DRM VC4 V3D driver
-dtoverlay=vc4-kms-v3d
-max_framebuffers=2
-
 # Don't have the firmware create an initial video= setting in cmdline.txt.
 # Use the kernel's default instead.
 disable_fw_kms_setup=1
@@ -43,6 +39,16 @@ disable_overscan=1
 
 # Run as fast as firmware / board allows
 arm_boost=1
+
+[pi3]
+[pi3+]
+[pi4]
+[pi400]
+[pi5]
+[pi500]
+# Enable DRM VC4 V3D driver
+dtoverlay=vc4-kms-v3d
+max_framebuffers=2
 
 [cm4]
 # Enable host mode on the 2711 built-in XHCI USB controller.


### PR DESCRIPTION
... as Raspberry Pi 4 requires this, but Raspberry Pi 2 must not have it.