### PR TITLE
alarm/amzn-ena-aarch64-dkms to 2.13.3-1

### DIFF
--- a/alarm/amzn-ena-aarch64-dkms/PKGBUILD
+++ b/alarm/amzn-ena-aarch64-dkms/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: iDigitalFlame <idf@idfla.me>
 pkgname="amzn-ena-aarch64-dkms"
-pkgver="2.13.2"
+pkgver="2.13.3"
 pkgrel="1"
 pkgdesc="Linux kernel driver for Amazon's Elastic Network Adapter (ENA)"
 arch=("aarch64")
@@ -10,8 +10,8 @@ depends=("dkms" "linux-aarch64" "linux-aarch64-headers")
 install="amzn-drivers.install"
 source=("https://github.com/amzn/amzn-drivers/archive/refs/tags/ena_linux_${pkgver}.tar.gz"
         "dkms.conf")
-sha256sums=("d0847acb62b6782b7182b81fad243cf84805c016b2676f93150a25cc89d99bd8"
-            "77314485c87ff0043b453729e733e10069a4fd30c7e29c3beacc07a504ce1f97")
+sha256sums=("c5177525b4579ea1398e5f09b58e11d6e5185879a514217ccbdc9fe28c254f91"
+            "0d7f937831fd57e245a0bc4441e9a3e39c21a106b82410d646296c9b0aca55b1")
 buildarch=8
 
 package() {

--- a/alarm/amzn-ena-aarch64-dkms/dkms.conf
+++ b/alarm/amzn-ena-aarch64-dkms/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="ena"
-PACKAGE_VERSION="2.13.2"
+PACKAGE_VERSION="2.13.3"
 CLEAN="make -C ena clean"
 MAKE="make -C ena/ BUILD_KERNEL=$kernelver"
 BUILT_MODULE_NAME[0]="ena"


### PR DESCRIPTION
Changes/Updates:
- Driver updated to the latest upstream release: 2.13.3 (from 2.13.2)

Tests:
- [X] Build tested
- [X] Built in clean chroot
- [X] Tested in a live AWS ArchLinuxARM instance