### PR TITLE
alarm/amzn-ena-aarch64-dkms to 2.14.0-1

### DIFF
--- a/alarm/amzn-ena-aarch64-dkms/PKGBUILD
+++ b/alarm/amzn-ena-aarch64-dkms/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: iDigitalFlame <idf@idfla.me>
 pkgname="amzn-ena-aarch64-dkms"
-pkgver="2.13.3"
+pkgver="2.14.0"
 pkgrel="1"
 pkgdesc="Linux kernel driver for Amazon's Elastic Network Adapter (ENA)"
 arch=("aarch64")
@@ -10,8 +10,8 @@ depends=("dkms" "linux-aarch64" "linux-aarch64-headers")
 install="amzn-drivers.install"
 source=("https://github.com/amzn/amzn-drivers/archive/refs/tags/ena_linux_${pkgver}.tar.gz"
         "dkms.conf")
-sha256sums=("c5177525b4579ea1398e5f09b58e11d6e5185879a514217ccbdc9fe28c254f91"
-            "0d7f937831fd57e245a0bc4441e9a3e39c21a106b82410d646296c9b0aca55b1")
+sha256sums=("c8004d5761a78a080e85ebaae7442e099f23450a44850bb2f2e4015a8b469dea"
+            "acf5de9208de194b5dfe801a19df5307edd7bc3b934fad8a6cfae0315be12b61")
 buildarch=8
 
 package() {

--- a/alarm/amzn-ena-aarch64-dkms/dkms.conf
+++ b/alarm/amzn-ena-aarch64-dkms/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="ena"
-PACKAGE_VERSION="2.13.3"
+PACKAGE_VERSION="2.14.0"
 CLEAN="make -C ena clean"
 MAKE="make -C ena/ BUILD_KERNEL=$kernelver"
 BUILT_MODULE_NAME[0]="ena"


### PR DESCRIPTION
Changes/Updates:

- Driver updated to the latest upstream release: 2.14.0 (from 2.13.3)

Tests:

- [X] Build tested
- [X] Built in clean chroot
- [X] Tested in a live AWS ArchLinuxARM instance