### PR TITLE
Depend on initramfs instead of mkinitcpio

### DIFF
--- a/core/linux-aarch64-rc/PKGBUILD
+++ b/core/linux-aarch64-rc/PKGBUILD
@@ -11,7 +11,7 @@ _srcname=linux-${_rcver}-rc${_rcrel}
 _kernelname=${pkgbase#linux}
 _desc="AArch64 multi-platform (release candidate)"
 pkgver=${_rcver}.rc${_rcrel}
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -67,7 +67,7 @@ build() {
 
 _package() {
   pkgdesc="The Linux Kernel and modules - ${_desc}"
-  depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
+  depends=('coreutils' 'linux-firmware' 'kmod' 'initramfs')
   optdepends=('wireless-regdb: to set the correct wireless channels of your country')
   provides=("linux=${pkgver}" "WIREGUARD-MODULE")
   replaces=('linux-armv8-rc')

--- a/core/linux-aarch64/PKGBUILD
+++ b/core/linux-aarch64/PKGBUILD
@@ -9,7 +9,7 @@ _srcname=linux-6.14
 _kernelname=${pkgbase#linux}
 _desc="AArch64 multi-platform"
 pkgver=6.14.6
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -72,7 +72,7 @@ build() {
 
 _package() {
   pkgdesc="The Linux Kernel and modules - ${_desc}"
-  depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
+  depends=('coreutils' 'linux-firmware' 'kmod' 'initramfs')
   optdepends=('wireless-regdb: to set the correct wireless channels of your country')
   provides=("linux=${pkgver}" "KSMBD-MODULE" "WIREGUARD-MODULE")
   conflicts=('linux')

--- a/core/linux-armv7/PKGBUILD
+++ b/core/linux-armv7/PKGBUILD
@@ -8,7 +8,7 @@ _srcname=linux-6.14
 _kernelname=${pkgbase#linux}
 _desc="ARMv7 multi-platform"
 pkgver=6.14.6
-pkgrel=1
+pkgrel=2
 rcnver=6.14.0
 rcnrel=multiv7-r1
 arch=('armv7h')
@@ -88,7 +88,7 @@ build() {
 
 _package() {
   pkgdesc="The Linux Kernel and modules - ${_desc}"
-  depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
+  depends=('coreutils' 'linux-firmware' 'kmod' 'initramfs')
   optdepends=('wireless-regdb: to set the correct wireless channels of your country')
   provides=("linux=${pkgver}" "KSMBD-MODULE" "WIREGUARD-MODULE")
   conflicts=('linux')

--- a/core/linux-clearfog/PKGBUILD
+++ b/core/linux-clearfog/PKGBUILD
@@ -9,7 +9,7 @@ _commit=a45051aa9e8b3bfeb9f73b1ad20c1c9474753084
 _srcname=linux-stable-${_commit}
 _kernelname=${pkgname#linux}
 pkgver=4.4.64
-pkgrel=1
+pkgrel=2
 bfqver=v7r11
 
 arch=('armv7h')
@@ -79,7 +79,7 @@ build() {
 
 package_linux-clearfog() {
   pkgdesc="The Linux Kernel and modules - SolidRun ClearFog boards"
-  depends=('coreutils' 'linux-firmware' 'module-init-tools>=3.16' 'mkinitcpio>=0.7')
+  depends=('coreutils' 'linux-firmware' 'module-init-tools>=3.16' 'initramfs')
   optdepends=('crda: to set the correct wireless channels of your country')
   provides=('kernel26' "linux=${pkgver}" 'aufs_friendly')
   install=${pkgname}.install

--- a/core/linux-imx6/PKGBUILD
+++ b/core/linux-imx6/PKGBUILD
@@ -12,7 +12,7 @@ _srcname=linux-fslc-sr-${_commit}
 _kernelname=${pkgname#linux}
 _basekernel=3.14
 pkgver=${_basekernel}.79
-pkgrel=3
+pkgrel=4
 cryptodev_commit=f116a93224fc7b85f83d2c53f565f8fd86165ecc
 
 arch=('armv7h')
@@ -120,7 +120,7 @@ build() {
 
 package_linux-imx6() {
   pkgdesc="The Linux Kernel and modules - i.MX6 processors"
-  depends=('coreutils' 'linux-firmware' 'module-init-tools>=3.16' 'mkinitcpio>=0.7')
+  depends=('coreutils' 'linux-firmware' 'module-init-tools>=3.16' 'initramfs')
   optdepends=('crda: to set the correct wireless channels of your country')
   provides=('kernel26' "linux=${pkgver}" 'aufs_friendly' 'cryptodev_friendly')
   conflicts=('linux-trimslice' 'linux-omap')

--- a/core/linux-odroid-c1/PKGBUILD
+++ b/core/linux-odroid-c1/PKGBUILD
@@ -9,7 +9,7 @@ _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="ODROID-C1"
 pkgver=3.10.107
-pkgrel=5
+pkgrel=6
 arch=('armv7h')
 url="https://github.com/hardkernel/linux"
 license=('GPL2')
@@ -81,7 +81,7 @@ build() {
 
 _package() {
   pkgdesc="The Linux Kernel and modules - ${_desc}"
-  depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
+  depends=('coreutils' 'linux-firmware' 'kmod' 'initramfs')
   optdepends=('crda: to set the correct wireless channels of your country')
   provides=('kernel26' "linux=${pkgver}")
   conflicts=('linux')

--- a/core/linux-odroid-xu3/PKGBUILD
+++ b/core/linux-odroid-xu3/PKGBUILD
@@ -9,7 +9,7 @@ _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="ODROID-XU3/XU4/HC1, odroid-6.6.y branch"
 pkgver=6.6.68
-pkgrel=1
+pkgrel=2
 arch=('armv7h')
 url="https://github.com/hardkernel/linux"
 license=('GPL2')
@@ -45,7 +45,7 @@ build() {
 
 _package() {
   pkgdesc="The Linux Kernel and modules - ${_desc}"
-  depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
+  depends=('coreutils' 'linux-firmware' 'kmod' 'initramfs')
   optdepends=('wireless-regdb: to set the correct wireless channels of your country')
   provides=("linux=${pkgver}" "WIREGUARD-MODULE")
   conflicts=('linux')

--- a/core/linux-odroid/PKGBUILD
+++ b/core/linux-odroid/PKGBUILD
@@ -8,7 +8,7 @@ pkgname=('linux-odroid-x' 'linux-odroid-x2' 'linux-odroid-u2' 'linux-headers-odr
 _kernelname=${pkgname#linux}
 _basekernel=3.8
 pkgver=${_basekernel}.13.30
-pkgrel=5
+pkgrel=6
 arch=('armv7h')
 url="http://github.com/hardkernel/linux/"
 license=('GPL2')
@@ -54,7 +54,7 @@ prepare() {
 
 package_linux-odroid-x() {
   pkgdesc="The Linux Kernel and modules - ODROID-X kernel and modules"
-  depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
+  depends=('coreutils' 'linux-firmware' 'kmod' 'initramfs')
   optdepends=('crda: to set the correct wireless channels of your country')
   provides=('kernel26' "linux=${pkgver}")
   conflicts=('linux-odroidx' 'linux-odroid-x-mali' 'linux-odroid-u2' 'linux-odroid-u2-mali' 'linux-odroid-x2')
@@ -102,7 +102,7 @@ package_linux-odroid-x() {
 
 package_linux-odroid-x2() {
   pkgdesc="The Linux Kernel and modules - ODROID-X2 kernel and modules"
-  depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
+  depends=('coreutils' 'linux-firmware' 'kmod' 'initramfs')
   optdepends=('crda: to set the correct wireless channels of your country')
   provides=('kernel26' "linux=${pkgver}")
   conflicts=('linux-odroidx' 'linux-odroid-x-mali' 'linux-odroid-u2' 'linux-odroid-u2-mali' 'linux-odroid-x')
@@ -150,7 +150,7 @@ package_linux-odroid-x2() {
 
 package_linux-odroid-u2() {
   pkgdesc="The Linux Kernel and modules - ODROID-U2 kernel and modules"
-  depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
+  depends=('coreutils' 'linux-firmware' 'kmod' 'initramfs')
   optdepends=('crda: to set the correct wireless channels of your country')
   provides=('kernel26' "linux=${pkgver}")
   conflicts=('linux-odroidx' 'linux-odroid-x' 'linux-odroid-x-mali' 'linux-odroid-u2-mali' 'linux-odroid-x2')

--- a/core/linux-rpi-16k/PKGBUILD
+++ b/core/linux-rpi-16k/PKGBUILD
@@ -12,7 +12,7 @@ _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _regen=
 pkgver=6.12.27
-pkgrel=1
+pkgrel=2
 pkgdesc='Linux'
 url="https://github.com/raspberrypi/linux"
 arch=(aarch64)
@@ -89,7 +89,7 @@ _package() {
     firmware-raspberrypi
     kmod
     linux-firmware
-    'mkinitcpio>=0.7'
+    initramfs
     raspberrypi-bootloader
   )
   optdepends=(

--- a/core/linux-rpi/PKGBUILD
+++ b/core/linux-rpi/PKGBUILD
@@ -10,7 +10,7 @@ _srcname=linux-${_commit}
 _kernelname=${pkgbase#linux}
 _regen=
 pkgver=6.12.27
-pkgrel=1
+pkgrel=2
 pkgdesc='Linux'
 url="https://github.com/raspberrypi/linux"
 arch=(armv7h aarch64)
@@ -102,7 +102,7 @@ _package() {
     firmware-raspberrypi
     kmod
     linux-firmware
-    'mkinitcpio>=0.7'
+    initramfs
     raspberrypi-bootloader
   )
   optdepends=(

--- a/core/linux-utilite-dt/PKGBUILD
+++ b/core/linux-utilite-dt/PKGBUILD
@@ -15,7 +15,7 @@ _srcname=linux-kernel-${_commit}
 _kernelname=${pkgname#linux}
 _basekernel=3.10
 pkgver=${_basekernel}.70
-pkgrel=2
+pkgrel=3
 arch=('armv7h')
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -89,7 +89,7 @@ build() {
 
 package_linux-utilite-dt() {
   pkgdesc="The Linux Kernel and modules - i.MX6 processors for all utilite-i"
-  depends=('coreutils' 'linux-firmware' 'module-init-tools>=3.16' 'mkinitcpio>=0.7')
+  depends=('coreutils' 'linux-firmware' 'module-init-tools>=3.16' 'initramfs')
   optdepends=('crda: to set the correct wireless channels of your country')
   provides=('kernel26' "linux=${pkgver}")
   conflicts=('linux-trimslice' 'linux-omap' 'linux-utilite' 'linux-imx6-cubox-dt' 'linux-imx6-cubox')

--- a/core/linux-utilite/PKGBUILD
+++ b/core/linux-utilite/PKGBUILD
@@ -9,7 +9,7 @@ _srcname=utilite-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="CompuLab Utilite alternate kernel"
 pkgver=3.0.35
-pkgrel=18
+pkgrel=19
 arch=('armv7h')
 url="https://github.com/wolfgar/utilite/tree/devel"
 license=('GPL2')
@@ -78,7 +78,7 @@ build() {
 
 _package() {
   pkgdesc="The Linux Kernel and modules - ${_desc}"
-  depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
+  depends=('coreutils' 'linux-firmware' 'kmod' 'initramfs')
   optdepends=('crda: to set the correct wireless channels of your country')
   provides=('kernel26' "linux=${pkgver}")
   conflicts=('linux')

--- a/core/linux-zedboard/PKGBUILD
+++ b/core/linux-zedboard/PKGBUILD
@@ -9,7 +9,7 @@ _srcname=linux-xlnx-${_commit}
 _kernelname=${pkgbase#linux}
 _desc="ZedBoard"
 pkgver=3.19.0
-pkgrel=3
+pkgrel=4
 arch=('armv7h')
 url="https://github.com/Xilinx/linux-xlnx"
 license=('GPL2')
@@ -82,7 +82,7 @@ build() {
 
 _package() {
   pkgdesc="The Linux Kernel and modules - ${_desc}"
-  depends=('coreutils' 'linux-firmware' 'kmod' 'mkinitcpio>=0.7')
+  depends=('coreutils' 'linux-firmware' 'kmod' 'initramfs')
   optdepends=('crda: to set the correct wireless channels of your country')
   provides=('kernel26' "linux=${pkgver}" 'aufs_friendly')
   conflicts=('linux')


### PR DESCRIPTION
This removes the `mkinitcpio` dependency from most kernel packages and replaces it with `initramfs` to allow alternative initcpio creation, which is done on mainline Arch.

Small note: these depend on `mkinitcpio>=0.7`, but `mkinitcpio` only started providing `initramfs` after this version, so, this replacement is valid.

The following kernel packages were *excluded* from this change because they provide custom hooks that run `mkinitcpio` directly:

* `linux-am33x`
* `linux-armv7-rc`
* `linux-espressobin`
* `linux-odroid-c2`
* `linux-odroid-n2`

These hooks are probably unnecessary because `mkinticpio` provides its own hook, but I didn't want to make any invasive changes.