### PR TITLE
Update PKGBUILD to latest upstream commit covering new default releases

### DIFF
--- a/alarm/rpi-eeprom/PKGBUILD
+++ b/alarm/rpi-eeprom/PKGBUILD
@@ -3,14 +3,14 @@
 pkgbase=rpi-eeprom
 pkgname=(rpi4-eeprom rpi5-eeprom)
 
-_commit=1bd0a1052b2e74d7af04de18d30b5edb12d8a423
-pkgver=20250326
+_commit=0f6920518f8e13f4ee1167cdccaaea29170ae5c9
+pkgver=20250522
 pkgrel=1
 arch=(any)
 url='https://github.com/raspberrypi/rpi-eeprom'
 license=(custom)
 source=("$pkgbase-$pkgver-${_commit:0:10}.tar.gz::https://github.com/raspberrypi/rpi-eeprom/archive/$_commit.tar.gz")
-md5sums=('21ea3ae37e56ec250f20eca483cbcf0c')
+md5sums=('81d223c7e6f161e37d61067a4187f6d8')
 
 package_rpi4-eeprom() {
   pkgdesc="Bootloader and VLI USB controller EEPROM update for bcm2711/RPi4 SoC"


### PR DESCRIPTION
Thanks for considering this. 