### PR TITLE
added extra/mimalloc

### DIFF
--- a/extra/mimalloc/.SRCINFO
+++ b/extra/mimalloc/.SRCINFO
@@ -1,0 +1,18 @@
+pkgbase = mimalloc
+	pkgdesc = General-purpose allocator with excellent performance characteristics
+	pkgver = 2.2.3
+	pkgrel = 1
+	url = https://github.com/microsoft/mimalloc
+	arch = x86_64
+	license = MIT
+	makedepends = git
+	makedepends = cmake
+	depends = glibc
+	source = mimalloc::git+https://github.com/microsoft/mimalloc#tag=v2.2.3
+	source = remove-staticlib-refs.patch
+	sha512sums = 69917fdee99f818e653e3cdb6ae3ad4c3131d715ec7752972ea28b0a801d077e30d6202f9c13e2114050b67553ea9c758fe0311ba3c2359f62f67501b53cd3f7
+	sha512sums = e8a32f066f269d449a765ddc54c192ce7b615e034753b1ffdc66153374e9b7f1973ebc7acf45a90f8ccf05962708f9288e4c5f3819abfe2c909530152e24437a
+	b2sums = 9fba0e21b5c6f87c562c40d1c0028318aeb114ce3e59fd055496769da1b2d35b3564b029db5260fca601523976d4ceecf1967e789696211162be8ad172e2bb36
+	b2sums = b34f447b1cf74110c97404fe815329cf84ae8ff798766eefc0f4e451cf52211e5745463c3d99209eafa8d3e1bc02ca66b5e526c04773ec5a21b626b428942f1c
+
+pkgname = mimalloc

--- a/extra/mimalloc/.nvchecker.toml
+++ b/extra/mimalloc/.nvchecker.toml
@@ -1,0 +1,4 @@
+[mimalloc]
+source = "git"
+git = "https://github.com/microsoft/mimalloc.git"
+prefix = "v"

--- a/extra/mimalloc/PKGBUILD
+++ b/extra/mimalloc/PKGBUILD
@@ -1,0 +1,54 @@
+# Maintainer: George Rawlinson <grawlinson@archlinux.org>
+# Contributor: René Wagner < rwagner at rw-net dot de >
+# Contributor: Diab Neiroukh <lazerl0rd@thezest.dev>
+
+# ALARM: SandaruKasa <sandarukasa plus archarm at ya dot ru>
+#  - set `MI_NO_OPT_ARCH` to fix https://github.com/microsoft/mimalloc/issues/1095
+
+pkgname=mimalloc
+pkgver=2.2.3
+pkgrel=1
+pkgdesc='General-purpose allocator with excellent performance characteristics'
+arch=('x86_64')
+url='https://github.com/microsoft/mimalloc'
+license=('MIT')
+depends=('glibc')
+makedepends=('git' 'cmake')
+source=(
+  "$pkgname::git+$url#tag=v$pkgver"
+  'remove-staticlib-refs.patch'
+)
+sha512sums=('69917fdee99f818e653e3cdb6ae3ad4c3131d715ec7752972ea28b0a801d077e30d6202f9c13e2114050b67553ea9c758fe0311ba3c2359f62f67501b53cd3f7'
+            'e8a32f066f269d449a765ddc54c192ce7b615e034753b1ffdc66153374e9b7f1973ebc7acf45a90f8ccf05962708f9288e4c5f3819abfe2c909530152e24437a')
+b2sums=('9fba0e21b5c6f87c562c40d1c0028318aeb114ce3e59fd055496769da1b2d35b3564b029db5260fca601523976d4ceecf1967e789696211162be8ad172e2bb36'
+        'b34f447b1cf74110c97404fe815329cf84ae8ff798766eefc0f4e451cf52211e5745463c3d99209eafa8d3e1bc02ca66b5e526c04773ec5a21b626b428942f1c')
+
+build() {
+  cmake \
+    -B build \
+    -S "$pkgname" \
+    -D CMAKE_INSTALL_PREFIX=/usr \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D MI_NO_OPT_ARCH=ON \
+    -D MI_BUILD_OBJECT=OFF \
+    -D MI_INSTALL_TOPLEVEL=ON
+
+  cmake --build build
+}
+
+check() {
+  cd build
+
+  ctest --output-on-failure
+}
+
+package() {
+  DESTDIR="$pkgdir" cmake --install build
+
+  pushd "$pkgdir/usr/lib/cmake/mimalloc"
+  patch -p1 -i "$srcdir/remove-staticlib-refs.patch"
+  popd
+
+  # license
+  install -vDm644 -t "$pkgdir/usr/share/licenses/$pkgname" "$pkgname/LICENSE"
+}

--- a/extra/mimalloc/remove-staticlib-refs.patch
+++ b/extra/mimalloc/remove-staticlib-refs.patch
@@ -1,0 +1,44 @@
+--- a/mimalloc-release.cmake
++++ b/mimalloc-release.cmake
+@@ -15,15 +15,5 @@ set_target_properties(mimalloc PROPERTIES
+ list(APPEND _cmake_import_check_targets mimalloc )
+ list(APPEND _cmake_import_check_files_for_mimalloc "${_IMPORT_PREFIX}/lib/libmimalloc.so.2.2" )
+ 
+-# Import target "mimalloc-static" for configuration "Release"
+-set_property(TARGET mimalloc-static APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+-set_target_properties(mimalloc-static PROPERTIES
+-  IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "C"
+-  IMPORTED_LOCATION_RELEASE "${_IMPORT_PREFIX}/lib/libmimalloc.a"
+-  )
+-
+-list(APPEND _cmake_import_check_targets mimalloc-static )
+-list(APPEND _cmake_import_check_files_for_mimalloc-static "${_IMPORT_PREFIX}/lib/libmimalloc.a" )
+-
+ # Commands beyond this point should not need to know the version.
+ set(CMAKE_IMPORT_FILE_VERSION)
+--- a/mimalloc.cmake
++++ b/mimalloc.cmake
+@@ -19,7 +19,7 @@ set(CMAKE_IMPORT_FILE_VERSION 1)
+ set(_cmake_targets_defined "")
+ set(_cmake_targets_not_defined "")
+ set(_cmake_expected_targets "")
+-foreach(_cmake_expected_target IN ITEMS mimalloc mimalloc-static)
++foreach(_cmake_expected_target IN ITEMS mimalloc)
+   list(APPEND _cmake_expected_targets "${_cmake_expected_target}")
+   if(TARGET "${_cmake_expected_target}")
+     list(APPEND _cmake_targets_defined "${_cmake_expected_target}")
+@@ -71,14 +71,6 @@ set_target_properties(mimalloc PROPERTIES
+   INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
+ )
+ 
+-# Create imported target mimalloc-static
+-add_library(mimalloc-static STATIC IMPORTED)
+-
+-set_target_properties(mimalloc-static PROPERTIES
+-  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
+-  INTERFACE_LINK_LIBRARIES "\$<LINK_ONLY:pthread>;\$<LINK_ONLY:rt>;\$<LINK_ONLY:atomic>"
+-)
+-
+ # Load information for each installed configuration.
+ file(GLOB _cmake_config_files "${CMAKE_CURRENT_LIST_DIR}/mimalloc-*.cmake")
+ foreach(_cmake_config_file IN LISTS _cmake_config_files)


### PR DESCRIPTION
To fix https://github.com/microsoft/mimalloc/issues/1095

```diff
$ paru -G mimalloc && diff -ru mimalloc ArchArmPKGBUILDs/extra/mimalloc
 (1/1) downloading: mimalloc
Only in mimalloc: .git
diff '--color=auto' -ru mimalloc/PKGBUILD ArchArmPKGBUILDs/extra/mimalloc/PKGBUILD
--- mimalloc/PKGBUILD   2025-06-10 03:45:20.942014741 +0300
+++ ArchArmPKGBUILDs/extra/mimalloc/PKGBUILD    2025-06-10 03:42:24.469200200 +0300
@@ -2,6 +2,9 @@
 # Contributor: René Wagner < rwagner at rw-net dot de >
 # Contributor: Diab Neiroukh <lazerl0rd@thezest.dev>
 
+# ALARM: SandaruKasa <sandarukasa plus archarm at ya dot ru>
+#  - set `MI_NO_OPT_ARCH` to fix https://github.com/microsoft/mimalloc/issues/1095
+
 pkgname=mimalloc
 pkgver=2.2.3
 pkgrel=1
@@ -26,6 +29,7 @@
     -S "$pkgname" \
     -D CMAKE_INSTALL_PREFIX=/usr \
     -D CMAKE_BUILD_TYPE=Release \
+    -D MI_NO_OPT_ARCH=ON \
     -D MI_BUILD_OBJECT=OFF \
     -D MI_INSTALL_TOPLEVEL=ON
```