### PR TITLE
extra/pixman: use neon for aarch64

### DIFF
--- a/extra/pixman/PKGBUILD
+++ b/extra/pixman/PKGBUILD
@@ -25,7 +25,7 @@ build() {
     -D vmx=disabled \
     -D arm-simd=disabled \
     -D neon=disabled \
-    -D a64-neon=disabled \
+    -D a64-neon=$([[ $CARCH == aarch64 ]] && echo enabled || echo disabled) \
     -D rvv=disabled \
     -D mmx=disabled \
     -D sse2=disabled \


### PR DESCRIPTION
I've been testing this change with my sway/wlroots setup on an aarch64 device. Debian already enables NEON for arm64.
