### PR TITLE
added extra/refind, an EFI boot manager

### DIFF
--- a/extra/refind/.SRCINFO
+++ b/extra/refind/.SRCINFO
@@ -1,0 +1,40 @@
+pkgbase = refind
+	pkgdesc = An EFI boot manager
+	pkgver = 0.14.2
+	pkgrel = 2
+	url = https://www.rodsbooks.com/refind/
+	arch = aarch64
+	makedepends = bash
+	makedepends = dosfstools
+	makedepends = efibootmgr
+	makedepends = gnu-efi>=3.0.17
+	source = https://sourceforge.net/projects/refind/files/0.14.2/refind-src-0.14.2.tar.gz
+	source = Make.common_remove-CC-prefix.patch
+	sha512sums = 76a52ed422ab3d431e6530fae4d13a51e8ed100568d4290207aaee87a84700b077bb79c4f4917027f5286de422954e1872fca288252ec756072d6c075b102e1e
+	sha512sums = 54d06d82bb7451bf06e54ceea31a06ab1d96748cf2aebbc638210dca8b72a19c576708a9f5ae606417ebf1a5633c5da06e85da330785e9d915997364c348e4d9
+	b2sums = 987acb29d4d81c01db245cd8e1c9761072e34cf3dfaa3e4fa77e549ee2c1dc4c3f8cbd9218f42e4eb77478df3453095dba8b36324c289c6a10b81f1ecb202743
+	b2sums = b94699983dbf28c44647c50e9f2c94a9a73315e835c44fb5dec7096432a20aa4a095feaf4ac6de991438cc7be0d0d0faa306c261451b5dc443bae5428b20cd30
+
+pkgname = refind
+	license = BSD-2-Clause
+	license = CC-BY-SA-3.0
+	license = CC-BY-SA-4.0
+	license = GPL-2.0-only
+	license = GPL-2.0-or-later
+	license = GPL-3.0-or-later
+	license = LGPL-2.1-or-later
+	license = LGPL-3.0-or-later OR CC-BY-SA-3.0
+	depends = bash
+	depends = dosfstools
+	depends = efibootmgr
+	optdepends = gptfdisk: for finding non-vfat ESP with refind-install
+	optdepends = imagemagick: for refind-mkfont
+	optdepends = openssl: for generating local certificates with refind-install
+	optdepends = python: for refind-mkdefault
+	optdepends = refind-docs: for HTML documentation
+	optdepends = sbsigntools: for EFI binary signing with refind-install
+	optdepends = sudo: for privilege elevation in refind-install and refind-mkdefault
+
+pkgname = refind-docs
+	pkgdesc = An EFI boot manager - documentation
+	license = FDL-1.3-or-later

--- a/extra/refind/Make.common_remove-CC-prefix.patch
+++ b/extra/refind/Make.common_remove-CC-prefix.patch
@@ -1,0 +1,30 @@
+--- Make.common	2024-04-07 00:18:25.000000000 +0300
++++ /dev/shm/Make.common	2025-06-22 21:24:08.982974956 +0300
+@@ -39,7 +39,7 @@
+ # version or later and compiling for ARM64; but set it to "n" if using an
+ # earlier version of GNU-EFI on ARM64. This option has no effect on IA32/x86
+ # or X64/AMD64/x86-64 systems.
+-GNUEFI_ARM64_TARGET_SUPPORT ?= n
++GNUEFI_ARM64_TARGET_SUPPORT ?= y
+ 
+ HOSTARCH        = $(shell uname -m | sed s,i[3456789]86,ia32,)
+ ARCH            ?= $(HOSTARCH)
+@@ -54,12 +54,12 @@
+ GENFW           = $(TIANOBASE)/BaseTools/Source/C/bin/GenFw
+ prefix          = /usr/bin/
+ ifeq ($(ARCH),aarch64)
+-  CC            = $(prefix)aarch64-linux-gnu-gcc
+-  AS            = $(prefix)aarch64-linux-gnu-as
+-  LD            = $(prefix)aarch64-linux-gnu-ld
+-  AR            = $(prefix)aarch64-linux-gnu-ar
+-  RANLIB        = $(prefix)aarch64-linux-gnu-ranlib
+-  OBJCOPY       = $(prefix)aarch64-linux-gnu-objcopy
++  CC            = $(prefix)gcc
++  AS            = $(prefix)as
++  LD            = $(prefix)ld
++  AR            = $(prefix)ar
++  RANLIB        = $(prefix)ranlib
++  OBJCOPY       = $(prefix)objcopy
+ else
+   CC            = $(prefix)gcc
+   AS            = $(prefix)as

--- a/extra/refind/PKGBUILD
+++ b/extra/refind/PKGBUILD
@@ -1,0 +1,116 @@
+# Maintainer: David Runge <dvzrv@archlinux.org>
+
+# ALARM: Aleksej Kovura <alarm-pkgs-77c3 at mekboy dot ru>
+# - rEFInd supports only for ARM64 so buildarch=8
+# - gnu-efi>=3.0.17 to make sure GNUEFI_ARM64_TARGET_SUPPORT ?= y works
+# - (patch) Disable cross-compilation on aarch64
+# - (patch) GNUEFI_ARM64_TARGET_SUPPORT ?= y in Makefile for ARM64
+
+pkgbase=refind
+pkgname=(refind refind-docs)
+pkgver=0.14.2
+pkgrel=2
+pkgdesc="An EFI boot manager"
+arch=(aarch64) # we build architecture-specific EFI binaries
+_arch='aarch64'
+buildarch=8
+url="https://www.rodsbooks.com/refind/"
+makedepends=(
+  bash
+  dosfstools
+  efibootmgr
+  'gnu-efi>=3.0.17'
+)
+source=(https://sourceforge.net/projects/refind/files/$pkgver/$pkgname-src-$pkgver.tar.gz
+  Make.common_remove-CC-prefix.patch)
+sha512sums=('76a52ed422ab3d431e6530fae4d13a51e8ed100568d4290207aaee87a84700b077bb79c4f4917027f5286de422954e1872fca288252ec756072d6c075b102e1e'
+            '54d06d82bb7451bf06e54ceea31a06ab1d96748cf2aebbc638210dca8b72a19c576708a9f5ae606417ebf1a5633c5da06e85da330785e9d915997364c348e4d9')
+b2sums=('987acb29d4d81c01db245cd8e1c9761072e34cf3dfaa3e4fa77e549ee2c1dc4c3f8cbd9218f42e4eb77478df3453095dba8b36324c289c6a10b81f1ecb202743'
+        'b94699983dbf28c44647c50e9f2c94a9a73315e835c44fb5dec7096432a20aa4a095feaf4ac6de991438cc7be0d0d0faa306c261451b5dc443bae5428b20cd30')
+
+prepare() {
+  cd $pkgbase-$pkgver
+  patch Make.common ../Make.common_remove-CC-prefix.patch
+  # remove the path prefix from the css reference, so that the css can live
+  # in the same directory
+  sed -e 's|../Styles/||g' -i docs/$pkgbase/*.html
+  # hardcode RefindDir, so that refind-install can find refind_aa64.efi
+  sed -e 's|RefindDir=\"\$ThisDir/refind\"|RefindDir="/usr/share/refind/"|g' -i refind-install
+  # add vendor line to the sbat file
+  printf 'refind.%s,%s,%s,refind,%s,%s\n' 'arch' '1' 'Arch Linux' "${epoch:+${epoch}:}${pkgver}-${pkgrel}" 'https://archlinux.org/packages/?q=refind' >> refind-sbat.csv
+}
+
+build() {
+  cd $pkgname-$pkgver
+  make
+  make gptsync
+  make fs
+}
+
+package_refind() {
+  license=(
+    BSD-2-Clause
+    CC-BY-SA-3.0
+    CC-BY-SA-4.0
+    GPL-2.0-only
+    GPL-2.0-or-later
+    GPL-3.0-or-later
+    LGPL-2.1-or-later
+    'LGPL-3.0-or-later OR CC-BY-SA-3.0'
+  )
+  depends=(
+    bash
+    dosfstools
+    efibootmgr
+  )
+  optdepends=(
+    'gptfdisk: for finding non-vfat ESP with refind-install'
+    'imagemagick: for refind-mkfont'
+    'openssl: for generating local certificates with refind-install'
+    'python: for refind-mkdefault'
+    'refind-docs: for HTML documentation'
+    'sbsigntools: for EFI binary signing with refind-install'
+    'sudo: for privilege elevation in refind-install and refind-mkdefault'
+  )
+
+  cd $pkgbase-$pkgver
+  # NOTE: the install target calls refind-install, therefore we install things
+  # manually
+  # efi binaries
+  install -vDm 644 refind/*.efi -t "$pkgdir/usr/share/$pkgname/"
+  install -vDm 644 drivers_*/*.efi -t "$pkgdir/usr/share/refind/drivers_$_arch/"
+  install -vDm 644 gptsync/*.efi -t "$pkgdir/usr/share/$pkgname/tools_$_arch/"
+  # sample config
+  install -vDm 644 $pkgname.conf-sample -t "$pkgdir/usr/share/$pkgname/"
+  # keys
+  install -vDm 644 keys/*{cer,crt} -t "$pkgdir/usr/share/$pkgname/keys/"
+  # keysdir
+  install -vdm 700 "$pkgdir/etc/refind.d/keys"
+  # fonts
+  install -vDm 644 fonts/*.png -t "$pkgdir/usr/share/$pkgname/fonts/"
+  # icons
+  install -vDm 644 icons/*.png -t "$pkgdir/usr/share/$pkgname/icons"
+  install -vDm 644 icons/svg/*.svg -t "$pkgdir/usr/share/$pkgname/icons/svg/"
+  # scripts
+  install -vDm 755 {refind-{install,mkdefault,sb-healthcheck},mkrlconf,mvrefind} -t "$pkgdir/usr/bin/"
+  install -vDm 755 fonts/mkfont.sh "$pkgdir/usr/bin/$pkgname-mkfont"
+  # man pages
+  install -vDm 644 docs/man/*.8 -t "$pkgdir/usr/share/man/man8/"
+  # docs
+  install -vDm 644 {CREDITS,NEWS,README}.txt -t "$pkgdir/usr/share/doc/$pkgname/"
+  install -vDm 644 fonts/README.txt "$pkgdir/usr/share/doc/$pkgname/README.$pkgname-mkfont.txt"
+  install -vDm 644 icons/README "$pkgdir/usr/share/doc/$pkgname/README.icons.txt"
+  install -vDm 644 keys/README.txt "$pkgdir/usr/share/doc/$pkgname/README.keys.txt"
+  # license
+  install -vDm 644 LICENSE.txt -t "$pkgdir/usr/share/licenses/$pkgname/"
+}
+
+package_refind-docs() {
+  pkgdesc+=" - documentation"
+  license=(FDL-1.3-or-later)
+
+  cd $pkgbase-$pkgver
+  install -vDm 644 docs/$pkgbase/*.{html,png,svg,txt} -t "$pkgdir/usr/share/doc/$pkgbase/html/"
+  install -vDm 644 docs/Styles/*.css -t "$pkgdir/usr/share/doc/$pkgbase/html/"
+  install -vDm 644 images/$pkgbase-banner.{png,svg} -t "$pkgdir/usr/share/doc/$pkgbase/html/"
+}


### PR DESCRIPTION
rEFInd package to make multi-booting on UEFI-enabled platforms more convenient/presentable.
Built, installed and tested on aarch64 HW, it works.
Builds fine in a clean chroot (aarch64 only as that's what rEFInd supports).