### PR TITLE
add alarm/firmware-ap6611s

### DIFF
--- a/alarm/firmware-ap6611s/PKGBUILD
+++ b/alarm/firmware-ap6611s/PKGBUILD
@@ -1,0 +1,19 @@
+# Maintainer: Jimmy Hon <honyuenkwun@gmail.com>
+
+buildarch=4
+
+pkgname=firmware-ap6611s
+pkgver=1.0
+pkgrel=1
+pkgdesc="Firmware for the AP6611s in the Orange Pi 5 Max/Ultra"
+url="https://github.com/orangepi-xunlong/firmware"
+arch=('aarch64')
+source=("https://raw.githubusercontent.com/orangepi-xunlong/firmware/refs/heads/master/SYN43711A0.hcd")
+sha256sums=('e9bfbf89f671771cde86525fcffa920cddce4cdc656815ba9b0c5f3750d0fac1')
+
+package() {
+  mkdir -p "${pkgdir}/usr/lib/firmware/brcm"
+  cp SYN43711A0.hcd "${pkgdir}/usr/lib/firmware/brcm/"
+  ln -s SYN43711A0.hcd "${pkgdir}/usr/lib/firmware/brcm/BCM.xunlong,orangepi-5-max.hcd"
+  ln -s SYN43711A0.hcd "${pkgdir}/usr/lib/firmware/brcm/BCM.xunlong,orangepi-5-ultra.hcd"
+}


### PR DESCRIPTION
Bluetooth firmware for AP6611s on the Orange Pi 5 Max/Ultra