### PR TITLE
alarm/meson-tools to r32.0a02e2d-2

### DIFF
--- a/alarm/meson-tools/PKGBUILD
+++ b/alarm/meson-tools/PKGBUILD
@@ -4,7 +4,7 @@ buildarch=8
 
 pkgname=meson-tools
 pkgver=r32.0a02e2d
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 pkgdesc="Amlogic Meson tools"
 url="https://github.com/afaerber/meson-tools"


### PR DESCRIPTION
Rebuild for libcrypto.so soname bump. Fixes failure when building uboot-odroid-c2-mainline:

```
amlbootsig: error while loading shared libraries: libcrypto.so.1.1: cannot open shared object file: No such file or directory
```