### PR TITLE
alarm/uboot-odroid-c2-mainline to 2025.07-1

### DIFF
--- a/alarm/uboot-odroid-c2-mainline/PKGBUILD
+++ b/alarm/uboot-odroid-c2-mainline/PKGBUILD
@@ -4,7 +4,7 @@
 buildarch=8
 
 pkgname=uboot-odroid-c2-mainline
-pkgver=2019.07
+pkgver=2025.07
 pkgrel=1
 pkgdesc="Mainline U-Boot for ODROID-C2"
 arch=('aarch64')
@@ -19,7 +19,7 @@ source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver/rc/-rc}.tar.bz2"
         'sd_fusing.sh'
         'boot.txt'
         'mkscr')
-md5sums=('73434338536c7500b4302bd0a02921ed'
+md5sums=('71570f5e1b5a81dd67e3082fb269f07d'
          '11a49bb7e9825b05fb555ba6f2aca736'
          'c1222a54697dc5025f059024d41b9659'
          '4258258571f02d00d4b38d03b563dc2b'


### PR DESCRIPTION
Improves GPT compatibility with bootefi. Fixes:

```
alloc_read_gpt_entries: ERROR: Can't allocate 0X4000 bytes for GPT Entries
GPT: Failed to allocate memory for PTE
```

Tested by booting from SD and eMMC.

------

This is dependent on the meson-tools rebuild in #2137.