### PR TITLE
extra/chromium: Install `chromedriver` again, like Arch still does

### DIFF
--- a/extra/chromium/PKGBUILD
+++ b/extra/chromium/PKGBUILD
@@ -365,6 +365,7 @@ package() {
   cd ../chromium-$pkgver
 
   install -Dv out/Release/chrome "$pkgdir/usr/lib/chromium/chromium"
+  install -Dv out/Release/chromedriver.unstripped "$pkgdir/usr/bin/chromedriver"
   install -Dvm4755 out/Release/chrome_sandbox "$pkgdir/usr/lib/chromium/chrome-sandbox"
 
   install -Dvm644 chrome/installer/linux/common/desktop.template \


### PR DESCRIPTION
I am 99,9% sure this is a flaw in the chromium `PKGBUILD`:

The Arch chromium `PKGBUILD` does install the `chromedriver` binary: https://gitlab.archlinux.org/archlinux/packaging/packages/chromium/-/blob/4a9d37d333c4067d092c1f720c6ed0333244aaad/PKGBUILD#L272

**I am pretty sure the removal of that `chromedriver` binary in ALARM was a mistake.**

When Arch upgraded chromium to 98.0.4758.80, despite removing a soft link regarding chromedriver, the unstripped binary was installed instead (line 222): https://gitlab.archlinux.org/archlinux/packaging/packages/chromium/-/commit/4626d4568994767ff668c3c545132f04c7df54ea
When ALARM synced those changes in 23d682ac4253bc8341949e101a636495a82ee07f that `install` line was overlooked - **despite building it(!)**, see line 260.