### PR TITLE
alarm/uboot-sunxi to 2025.10-1

### DIFF
--- a/alarm/uboot-sunxi/PKGBUILD
+++ b/alarm/uboot-sunxi/PKGBUILD
@@ -17,8 +17,8 @@ pkgname=('uboot-a10-olinuxino-lime'
          'uboot-pcduino'
          'uboot-pcduino3'
          'uboot-pcduino3-nano')
-pkgver=2024.07
-pkgrel=2
+pkgver=2025.10
+pkgrel=1
 arch=('armv7h')
 url="http://git.denx.de/u-boot.git/"
 license=('GPL')
@@ -27,7 +27,7 @@ backup=(boot/boot.txt boot/boot.scr)
 source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
         'boot.txt'
         'mkscr')
-sha256sums=('f591da9ab90ef3d6b3d173766d0ddff90c4ed7330680897486117df390d83c8f'
+sha256sums=('b4f032848e56cc8f213ad59f9132c084dbbb632bc29176d024e58220e0efdf4a'
             '24ca87bc2941bc5c6230e9004c0305fa63c5c007160bd438d296691bd979f27a'
             'a4fc8b6b92bc364d6542670d294aa618a8501fb8729f415cc0a3eed776ef0c8e')
 


### PR DESCRIPTION
This u-boot version includes commit 7161a5f68 "sunxi: Enable SPL/SPI boot for OLinuXino Lime2". Writing to the flash[1], however, requires building sunxi-tools from source, as v1.4.2 is too old. To enter FEL mode, press the recovery button while connecting to a computer with mini-USB. The recovery button is the one closest to the HDMI port.

I tested with both SD and SPI flash. I did not test network boot, but u-boot was able to detect when the Ethernet cable was plugged in. A USB keyboard also worked.

1. https://linux-sunxi.org/Bootable_SPI_flash#Using_the_sunxi-fel_tool

Run-tested: A20-OLinuXino-LIME2

----

CC @linkmauve