### PR TITLE
core/pacman: fix $CFLAGS

### DIFF
--- a/core/pacman/PKGBUILD
+++ b/core/pacman/PKGBUILD
@@ -152,7 +152,7 @@ package() {
     aarch64)
       mycarch="aarch64"
       mychost="aarch64-unknown-linux-gnu"
-      myflags="-march=armv8-a "
+      myflags="-march=armv8-a -mno-omit-leaf-frame-pointer "
       ;;
   esac
 

--- a/core/pacman/makepkg.conf
+++ b/core/pacman/makepkg.conf
@@ -45,7 +45,7 @@ CPPFLAGS=""
 CFLAGS="@CARCHFLAGS@-O2 -pipe -fstack-protector-strong -fno-plt -fexceptions \
         -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security \
         -fstack-clash-protection \
-        -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
+        -fno-omit-frame-pointer"
 CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS"
 LDFLAGS="-Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now \
          -Wl,-z,pack-relative-relocs"


### PR DESCRIPTION
The `-mno-omit-leaf-frame-pointer` flag isn't valid on ARMv7.

Testing done implicitly by nature of the fact that I have a patch for a different `PKGBUILD` to _remove_ this flag from `$CFLAGS` and `$CXXFLAGS` to resolve an error from `gcc`.