### PR TITLE
alarm/uboot-rock64 to 2025.10-1

### DIFF
--- a/alarm/uboot-rock64/PKGBUILD
+++ b/alarm/uboot-rock64/PKGBUILD
@@ -4,30 +4,37 @@
 buildarch=8
 
 pkgname=uboot-rock64
-pkgver=2020.07
+pkgver=2025.10
 pkgrel=1
 pkgdesc="U-Boot for Rock64"
 arch=('aarch64')
 url='http://www.denx.de/wiki/U-Boot/WebHome'
 license=('GPL')
 backup=('boot/boot.txt' 'boot/boot.scr')
-makedepends=('bc' 'git' 'python' 'swig' 'dtc' 'uboot-tools')
+makedepends=('bc' 'git' 'python' 'python-setuptools' 'python-pyelftools' 'swig' 'dtc' 'uboot-tools')
 install=${pkgname}.install
 source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
-        "https://github.com/ARM-software/arm-trusted-firmware/archive/v2.3.tar.gz"
+        "https://github.com/ARM-software/arm-trusted-firmware/archive/v2.14.0.tar.gz"
         'boot.txt'
         'mkscr')
-md5sums=('86e51eeccd15e658ad1df943a0edf622'
-         '06ad72bdf63b922a3f3865d81f5d9ad2'
-         'c926f318d8fa7a5c89108331cbd3f8e2'
-         '021623a04afd29ac3f368977140cfbfd')
+sha256sums=('b4f032848e56cc8f213ad59f9132c084dbbb632bc29176d024e58220e0efdf4a'
+            'd44936677a63c5216ffc151ae7711d458c992ef159a9df271fd9429f0a1cb5e5'
+            '28d98741349f0898d6c1f76fcd20b7536cf107ad3bdaf19bd4952bb62ffbf812'
+	    'a4fc8b6b92bc364d6542670d294aa618a8501fb8729f415cc0a3eed776ef0c8e')
 
 prepare() {
-  cd ${srcdir}/arm-trusted-firmware-2.3
-  make PLAT=rk3328 all
+  export CC=cc
+  export LD=cc
+  export AS=cc
+  export OC=objcopy
+  export OD=objdump
+
+  cd ${srcdir}/arm-trusted-firmware-2.14.0
+  make PLAT=rk3328 bl31
 
   cd ${srcdir}/u-boot-${pkgver}
-  cp ../arm-trusted-firmware-2.3/build/rk3328/release/bl31/bl31.elf ./bl31.elf
+  cp ../arm-trusted-firmware-2.14.0/build/rk3328/release/bl31/bl31.elf ./bl31.elf
+  export BL31=./bl31.elf
 
   cd ${srcdir}/u-boot-${pkgver}/configs
   echo 'CONFIG_IDENT_STRING=" Arch Linux ARM"' >> rock64-rk3328_defconfig


### PR DESCRIPTION
**changes**
update uboot to mainline 2025-10
update ARM-Trusted-Firmware Source to 2.14.0

**resaon**
update to latest upstream versions

**additional comment**
The wiki is also pretty outdated with instructions for the old bootloader and the old boot.scr file.


At this point I guess nobody with the memory frequency issue is left or already knows how to mitigate it

In U-boot
`sed -i 's/800/600/g' arch/arm/dts/rk3328-sdram-lpddr3-1600.dtsi`
You could also use the *666.dtsi file instead, but lose even more performance.


