### PR TITLE
core/pacman move -mno-omit-leaf-frame-pointer flags to arch specific

### DIFF
--- a/core/pacman/PKGBUILD
+++ b/core/pacman/PKGBUILD
@@ -69,7 +69,7 @@ sha256sums=('06d082c3ce6f0811ca728515aa82d69d372800bd3ada99f5c445ef9429b6e3a6'
             'b36c4975286f8dea0fc3c64abf52706c31cb6d6e2c05a4983834b5417e23e802'
             '7ea05a9457f3b6b1edd9dc82f8a1231b0b9048e8c0a7e75fb99abb330a304234'
             'bc9fd787580f5c00c48cbab0efd8cc24fd7d33cccb8e17541528f757d729a462'
-            '1fae8471726bbda9521ce4d54f9fc646751d450cc4c9e6ebcae5eaeaf4909efe'
+            'd28e0630ae3e8cd84aa10be710104c120f1085fcb0cbdbc1e9c5de60f0cd5adb'
             'c8760d7ebb6c9817d508c691c67084be251cd9c8811ee1ccf92c1278bad74c1c'
             '3d7579f4fa52ef512dc82187c010f273aa45e6e8349f8fda9839f808c7dae042')
 
@@ -152,7 +152,7 @@ package() {
     aarch64)
       mycarch="aarch64"
       mychost="aarch64-unknown-linux-gnu"
-      myflags="-march=armv8-a "
+      myflags="-march=armv8-a -mno-omit-leaf-frame-pointer "
       ;;
   esac
 

--- a/core/pacman/makepkg.conf
+++ b/core/pacman/makepkg.conf
@@ -45,7 +45,7 @@ CPPFLAGS=""
 CFLAGS="@CARCHFLAGS@-O2 -pipe -fstack-protector-strong -fno-plt -fexceptions \
         -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security \
         -fstack-clash-protection \
-        -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
+        -fno-omit-frame-pointer"
 CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS"
 LDFLAGS="-Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now \
          -Wl,-z,pack-relative-relocs"


### PR DESCRIPTION
-mno-omit-leaf-frame-pointer is aarch64 specific, using this flag in armv7 will break compilation of everything with gcc and result will error

cc: error: unrecognized command-line option
‘-mno-omit-leaf-frame-pointer’; did you mean ‘-fno-omit-frame-pointer’?

References:
https://gcc.gnu.org/onlinedocs/gcc-15.2.0/gcc/AArch64-Function-Attributes.html#index-omit-leaf-frame-pointer-function-attribute_002c-AArch64 https://gcc.gnu.org/onlinedocs/gcc-15.2.0/gcc/ARM-Function-Attributes.html

in case things gets lost in the way here i am pinging @graysky2 @kmihelich 