### PR TITLE
[uboot-rock64] add variants for Rock64 V2 and SPI booting

### DIFF
--- a/alarm/uboot-rock64/0000-rock64V2-lpddr3-1333.patch
+++ b/alarm/uboot-rock64/0000-rock64V2-lpddr3-1333.patch
@@ -1,0 +1,13 @@
+diff --git a/arch/arm/dts/rk3328-sdram-lpddr3-1600.dtsi b/arch/arm/dts/rk3328-sdram-lpddr3-1600.dtsi
+index 07f27b2b7ba..0d7c62cade5 100644
+--- a/arch/arm/dts/rk3328-sdram-lpddr3-1600.dtsi
++++ b/arch/arm/dts/rk3328-sdram-lpddr3-1600.dtsi
+@@ -26,7 +26,7 @@
+ 		0x00000432
+ 		0x000000ff
+ 
+-		800
++		667
+ 		6
+ 		1
+ 		0

--- a/alarm/uboot-rock64/0001-store-env-in-spi-flash.patch
+++ b/alarm/uboot-rock64/0001-store-env-in-spi-flash.patch
@@ -1,0 +1,15 @@
+diff --git a/configs/rock64-rk3328_defconfig b/configs/rock64-rk3328_defconfig
+index 12cdf2e9e21..ed3ecd17b2e 100644
+--- a/configs/rock64-rk3328_defconfig
++++ b/configs/rock64-rk3328_defconfig
+@@ -44,9 +44,8 @@ CONFIG_SPL_OF_CONTROL=y
+ CONFIG_TPL_OF_CONTROL=y
+ CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
+ CONFIG_TPL_OF_PLATDATA=y
+-CONFIG_ENV_IS_IN_MMC=y
++CONFIG_ENV_IS_IN_SPI_FLASH=y
+ CONFIG_ENV_RELOC_GD_ENV_ADDR=y
+-CONFIG_ENV_MMC_DEVICE_INDEX=1
+ CONFIG_TPL_DM=y
+ CONFIG_SPL_DM_SEQ_ALIAS=y
+ CONFIG_REGMAP=y

--- a/alarm/uboot-rock64/PKGBUILD
+++ b/alarm/uboot-rock64/PKGBUILD
@@ -3,24 +3,31 @@
 
 buildarch=8
 
-pkgname=uboot-rock64
+pkgname=('uboot-rock64'
+         'uboot-rock64-spi'
+         'uboot-rock64V2'
+         'uboot-rock64V2-spi')
 pkgver=2025.10
-pkgrel=1
+pkgrel=2
 pkgdesc="U-Boot for Rock64"
 arch=('aarch64')
 url='http://www.denx.de/wiki/U-Boot/WebHome'
 license=('GPL')
 backup=('boot/boot.txt' 'boot/boot.scr')
-makedepends=('bc' 'git' 'python' 'python-setuptools' 'python-pyelftools' 'swig' 'dtc' 'uboot-tools')
-install=${pkgname}.install
+depends=('mtd-utils')
+makedepends=('bc' 'git' 'python' 'python-setuptools' 'python-pyelftools' 'swig' 'dtc')
 source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
         "https://github.com/ARM-software/arm-trusted-firmware/archive/v2.14.0.tar.gz"
         'boot.txt'
-        'mkscr')
+        'mkscr'
+        '0000-rock64V2-lpddr3-1333.patch'
+        '0001-store-env-in-spi-flash.patch')
 sha256sums=('b4f032848e56cc8f213ad59f9132c084dbbb632bc29176d024e58220e0efdf4a'
             'd44936677a63c5216ffc151ae7711d458c992ef159a9df271fd9429f0a1cb5e5'
-            'd0de25353f38dd633b63d7f547f0eaffe967bcd5d8c43b17897fb1c3d1f918fa'
-	    'a4fc8b6b92bc364d6542670d294aa618a8501fb8729f415cc0a3eed776ef0c8e')
+            '28d98741349f0898d6c1f76fcd20b7536cf107ad3bdaf19bd4952bb62ffbf812'
+            'a4fc8b6b92bc364d6542670d294aa618a8501fb8729f415cc0a3eed776ef0c8e'
+            'f3b0da1c910865da896d8a66673cdb93b8787797be3cf168f9442f4d9e10cf75'
+            '542ff9bed704399cc79509bf98dba92ed0548bd14b967a92ede5c2ff517ee37b')
 
 prepare() {
   export CC=cc
@@ -39,20 +46,41 @@ prepare() {
   cd ${srcdir}/u-boot-${pkgver}/configs
   echo 'CONFIG_IDENT_STRING=" Arch Linux ARM"' >> rock64-rk3328_defconfig
 
+  for i in ${pkgname[@]}; do
+    cp -r ${srcdir}/u-boot-${pkgver} ${srcdir}/u-boot-${i:6}
+  done
+
+  cd ${srcdir}/u-boot-rock64-spi
+  patch -p1 < ../0001-store-env-in-spi-flash.patch
+
+  cd ${srcdir}/u-boot-rock64V2
+  patch -p1 < ../0000-rock64V2-lpddr3-1333.patch
+
+  cd ${srcdir}/u-boot-rock64V2-spi
+  patch -p1 < ../0000-rock64V2-lpddr3-1333.patch
+  patch -p1 < ../0001-store-env-in-spi-flash.patch
+
+  rm -r ${srcdir}/u-boot-${pkgver}
+
 }
 
 build() {
-  cd ${srcdir}/u-boot-${pkgver}
+  unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
 
-  unset CLFAGS CXXFLAGS CPPFLAGS LDFLAGS
+  for i in ${pkgname[@]}; do
+    cd ${srcdir}/u-boot-${i:6}
+    make rock64-rk3328_defconfig
+    make EXTRAVERSION=-${pkgrel}
+    make EXTRAVERSION=-${pkgrel} u-boot.itb
+  done
 
-  make rock64-rk3328_defconfig
-  make EXTRAVERSION=-${pkgrel}
-  make EXTRAVERSION=-${pkgrel} u-boot.itb
+  tools/mkimage -A arm -O linux -T script -C none -n "U-Boot boot script" -d ../boot.txt ../boot.scr
 }
 
-package() {
-  cd u-boot-${pkgver}
+package_uboot-rock64() {
+  install=${pkgname}.install
+  
+  cd u-boot-${pkgname:6}
 
   mkdir -p "${pkgdir}/boot"
 
@@ -61,6 +89,53 @@ package() {
 
   cp ./u-boot.itb "${pkgdir}/boot/u-boot.itb"
 
-  tools/mkimage -A arm -O linux -T script -C none -n "U-Boot boot script" -d ../boot.txt "${pkgdir}/boot/boot.scr"
-  cp ../{boot.txt,mkscr} "${pkgdir}"/boot
+  cp ../{boot.txt,boot.scr,mkscr} "${pkgdir}"/boot
+}
+
+package_uboot-rock64-spi() {
+  pkgdesc="U-Boot for Rock64 (SPI flash)"
+  install=${pkgname}.install
+  provides=('uboot-rock64')
+  conflicts=('uboot-rock64')
+
+  cd u-boot-${pkgname:6}
+
+  mkdir -p "${pkgdir}/boot"
+
+  cp ./u-boot-rockchip-spi.bin "${pkgdir}/boot/u-boot-rockchip-spi.bin"
+
+  cp ../{boot.txt,boot.scr,mkscr} "${pkgdir}"/boot
+}
+
+package_uboot-rock64V2() {
+  pkgdesc="U-Boot for Rock64 V2"
+  install=${pkgbase}.install
+  provides=('uboot-rock64')
+  conflicts=('uboot-rock64')
+
+  cd u-boot-${pkgname:6}
+
+  mkdir -p "${pkgdir}/boot"
+
+  tools/mkimage -n rk3328 -T rksd -d ./tpl/u-boot-tpl.bin "${pkgdir}/boot/rksd_loader.img"
+  cat ./spl/u-boot-spl.bin >> "${pkgdir}/boot/rksd_loader.img"
+
+  cp ./u-boot.itb "${pkgdir}/boot/u-boot.itb"
+
+  cp ../{boot.txt,boot.scr,mkscr} "${pkgdir}"/boot
+}
+
+package_uboot-rock64V2-spi() {
+  pkgdesc="U-Boot for Rock64 V2 (SPI flash)"
+  install=${pkgbase}-spi.install
+  provides=('uboot-rock64')
+  conflicts=('uboot-rock64')
+
+  cd u-boot-${pkgname:6}
+
+  mkdir -p "${pkgdir}/boot"
+
+  cp ./u-boot-rockchip-spi.bin "${pkgdir}/boot/u-boot-rockchip-spi.bin"
+
+  cp ../{boot.txt,boot.scr,mkscr} "${pkgdir}"/boot
 }

--- a/alarm/uboot-rock64/PKGBUILD
+++ b/alarm/uboot-rock64/PKGBUILD
@@ -4,30 +4,37 @@
 buildarch=8
 
 pkgname=uboot-rock64
-pkgver=2020.07
+pkgver=2025.10
 pkgrel=1
 pkgdesc="U-Boot for Rock64"
 arch=('aarch64')
 url='http://www.denx.de/wiki/U-Boot/WebHome'
 license=('GPL')
 backup=('boot/boot.txt' 'boot/boot.scr')
-makedepends=('bc' 'git' 'python' 'swig' 'dtc' 'uboot-tools')
+makedepends=('bc' 'git' 'python' 'python-setuptools' 'python-pyelftools' 'swig' 'dtc' 'uboot-tools')
 install=${pkgname}.install
 source=("ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2"
-        "https://github.com/ARM-software/arm-trusted-firmware/archive/v2.3.tar.gz"
+        "https://github.com/ARM-software/arm-trusted-firmware/archive/v2.14.0.tar.gz"
         'boot.txt'
         'mkscr')
-md5sums=('86e51eeccd15e658ad1df943a0edf622'
-         '06ad72bdf63b922a3f3865d81f5d9ad2'
-         'c926f318d8fa7a5c89108331cbd3f8e2'
-         '021623a04afd29ac3f368977140cfbfd')
+sha256sums=('b4f032848e56cc8f213ad59f9132c084dbbb632bc29176d024e58220e0efdf4a'
+            'd44936677a63c5216ffc151ae7711d458c992ef159a9df271fd9429f0a1cb5e5'
+            'd0de25353f38dd633b63d7f547f0eaffe967bcd5d8c43b17897fb1c3d1f918fa'
+	    'a4fc8b6b92bc364d6542670d294aa618a8501fb8729f415cc0a3eed776ef0c8e')
 
 prepare() {
-  cd ${srcdir}/arm-trusted-firmware-2.3
-  make PLAT=rk3328 all
+  export CC=cc
+  export LD=cc
+  export AS=cc
+  export OC=objcopy
+  export OD=objdump
+
+  cd ${srcdir}/arm-trusted-firmware-2.14.0
+  make PLAT=rk3328 bl31
 
   cd ${srcdir}/u-boot-${pkgver}
-  cp ../arm-trusted-firmware-2.3/build/rk3328/release/bl31/bl31.elf ./bl31.elf
+  cp ../arm-trusted-firmware-2.14.0/build/rk3328/release/bl31/bl31.elf ./bl31.elf
+  export BL31=./bl31.elf
 
   cd ${srcdir}/u-boot-${pkgver}/configs
   echo 'CONFIG_IDENT_STRING=" Arch Linux ARM"' >> rock64-rk3328_defconfig

--- a/alarm/uboot-rock64/uboot-rock64-spi.install
+++ b/alarm/uboot-rock64/uboot-rock64-spi.install
@@ -1,0 +1,24 @@
+flash_uboot() {
+  echo "A new U-Boot version needs to be flashed onto /dev/mtd0."
+  echo "Do you want to do this now? [y|N]"
+  read -r shouldwe
+  if [[ $shouldwe =~ ^([yY][eE][sS]|[yY])$ ]]; then
+    flash_erase /dev/mtd0 0 0
+    nandwrite -p /dev/mtd0 /boot/u-boot-rockchip-spi.bin
+  else
+    echo "You can do this later by running:"
+    echo "# flash_erase /dev/mtd0 0 0"
+    echo "# nandwrite -p /dev/mtd0 /boot/u-boot-rockchip-spi.bin"
+  fi
+}
+
+## arg 1:  the new package version
+post_install() {
+  flash_uboot
+}
+
+## arg 1:  the new package version
+## arg 2:  the old package version
+post_upgrade() {
+  flash_uboot
+}


### PR DESCRIPTION
**changes**
add 3 additional sub-packages to `uboot-rock64`:

- `uboot-rock64-spi`: patches U-Boot to store its environment variables in SPI flash, allowing for the use of an eMMC/SD card with a single partition occupying the entire space without any loss of functionality. A new flashing script has been added to write it to `/dev/mtd0` (this is the reason for the new dependency on `mtd-utils`)

- `uboot-rock64V2`: underclocks the DRAM to 667MHz (1333 MT/s) for superior stability on Rock64 V2 hardware. The 786MHz underclock used by Armbian wasn't stable on my board, but 667MHz has been rock solid.

- `uboot-rock64V2-spi`: a combination of the above two packages

**reason**
improving the somewhat mediocre support for the Rock64

**additional comment**
I decided to rebase on top of #2161, hope that isn't an issue