### PR TITLE
add aur/qbootctl and alarm/qcom-adreno-opencl-bin

### DIFF
--- a/alarm/qcom-adreno-opencl-bin/PKGBUILD
+++ b/alarm/qcom-adreno-opencl-bin/PKGBUILD
@@ -1,0 +1,86 @@
+# Maintainer: Xilin Wu <sophon@radxa.com>
+# Upstream: Qualcomm Adreno GPU OpenCL prebuilt binaries
+# Sources:
+#   armv8a    – generic Adreno prebuilt (gfx-adreno.le.0.0)
+#   qcm6490   – SPF platform prebuilt  (qualcomm-linux-spf-1-0)
+
+pkgname=qcom-adreno-opencl-bin
+pkgver=1.855.2
+pkgrel=2
+pkgdesc="Qualcomm Adreno GPU OpenCL driver (prebuilt binary)"
+arch=('aarch64')
+url="https://softwarecenter.qualcomm.com"
+license=('LicenseRef-Qualcomm-EULA')
+depends=('qcom-libdmabufheap' 'glib2' 'zlib')
+makedepends=('patchelf')
+provides=('opencl-driver' 'opencl-icd-loader' 'ocl-icd')
+conflicts=('ocl-icd')
+options=('!strip')
+
+_armv8_datestamp=260304
+_qcm6490_datestamp=251215
+_spfrel=r1.0_00114.0
+
+source=("https://qartifactory-edge.qualcomm.com/artifactory/qsc_releases/software/chip/component/gfx-adreno.le.0.0/${_armv8_datestamp}/prebuilt_yocto/qcom-adreno_${pkgver}_armv8a.tar.gz"
+        "https://softwarecenter.qualcomm.com/nexus/generic/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/${_spfrel}/le-qclinux-1-0-r1/apps_proc/prebuilt_HY22/qcom-adreno/${_qcm6490_datestamp}/qcom-adreno_1.838.3_qcm6490.tar.gz")
+sha256sums=('825574743eecfeaef93201843a27f3b6cdebfae151a70846610da55cd467a7f2'
+            '3d55e1ef9f33b3fad2b9245c04169b540cfb73b7b1a1b5028f00d16ec8848874')
+noextract=("qcom-adreno_${pkgver}_armv8a.tar.gz"
+           "qcom-adreno_1.838.3_qcm6490.tar.gz")
+
+prepare() {
+  mkdir -p armv8 qcm6490
+  tar xzf "$srcdir/qcom-adreno_${pkgver}_armv8a.tar.gz"  -C armv8
+  tar xzf "$srcdir/qcom-adreno_1.838.3_qcm6490.tar.gz"   -C qcm6490
+}
+
+package() {
+  local _armv8="$srcdir/armv8"
+  local _qcm6490="$srcdir/qcm6490"
+
+  install -dm755 "$pkgdir/usr/lib"
+
+  install -Dm644 "$_armv8/usr/include/CL/cl_ext_qcom.h" \
+    "$pkgdir/usr/include/CL/cl_ext_qcom.h"
+
+  install -Dm644 "$_qcm6490/usr/lib/pkgconfig/opencl.pc" \
+    "$pkgdir/usr/lib/pkgconfig/OpenCL.pc"
+
+  install -Dm644 "$_qcm6490/usr/lib/pkgconfig/adreno_utils.pc" \
+    "$pkgdir/usr/lib/pkgconfig/adreno_utils.pc"
+
+  # LLVM backends
+  for _lib in libllvm-qcom.so.1 libllvm-glnext.so.1 libllvm-qgl.so.1; do
+    install -Dm755 "$_armv8/usr/lib/$_lib" "$pkgdir/usr/lib/$_lib"
+  done
+
+  # GPU support libraries
+  for _lib in libgsl.so.1 libadreno_utils.so.1 libCB.so.1 \
+              libq3dtools_adreno.so.1 libq3dtools_esx.so.1; do
+    install -Dm755 "$_armv8/usr/lib/$_lib" "$pkgdir/usr/lib/$_lib"
+  done
+
+  # Install Qualcomm's OpenCL loader from qcm6490 tarball, renamed to
+  # avoid conflict with the system ocl-icd (which owns libOpenCL.so).
+  install -Dm755 "$_qcm6490/usr/lib/libOpenCL.so.1" \
+    "$pkgdir/usr/lib/libOpenCL.so.1"
+  ln -s "libOpenCL.so.1" "$pkgdir/usr/lib/libOpenCL.so"
+
+  # Install Adreno OpenCL ICD driver and patch its dependency on the
+  # renamed loader.
+  install -Dm755 "$_armv8/usr/lib/libOpenCL_adreno.so.1" \
+    "$pkgdir/usr/lib/libOpenCL_adreno.so.1"
+  # patchelf --replace-needed libOpenCL.so.1 libOpenCL_qcom.so.1 \
+  #   "$pkgdir/usr/lib/libOpenCL_adreno.so.1"
+
+  install -Dm644 "$_armv8/etc/OpenCL/vendors/adrenocl.icd" \
+    "$pkgdir/etc/OpenCL/vendors/adrenocl.icd"
+
+  install -Dm644 "$_armv8/etc/profile.d/qcom-adreno-cl.sh" \
+    "$pkgdir/etc/profile.d/qcom-adreno-cl.sh"
+  install -Dm644 "$_armv8/etc/environment.d/qcom-adreno-cl.conf" \
+    "$pkgdir/etc/environment.d/qcom-adreno-cl.conf"
+
+  install -Dm644 "$_armv8/NOTICE" \
+    "$pkgdir/usr/share/licenses/$pkgname/NOTICE"
+}

--- a/alarm/qcom-libdmabufheap/0001-libdmabufheap-Update-generated-libs-version.patch
+++ b/alarm/qcom-libdmabufheap/0001-libdmabufheap-Update-generated-libs-version.patch
@@ -1,0 +1,52 @@
+####################################################################################################
+This patch file is from Qualcomm Technologies, Inc. and is provided under the following license:
+
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+####################################################################################################
+From dcfa3177ae6bdd8911ddca570625ad14f1dc9589 Mon Sep 17 00:00:00 2001
+From: Stilyan Uzunov <suzunov@qti.qualcomm.com>
+Date: Thu, 22 May 2025 15:13:43 +0300
+Subject: [PATCH] libdmabufheap: Update generated libs version
+
+- Update generated libdmabufheap libs to match pkg-config version.
+
+Upstream-Status: Pending
+Signed-off-by: Stilyan Uzunov <suzunov@qti.qualcomm.com>
+---
+ Makefile.am  | 2 +-
+ configure.ac | 3 +--
+ 2 files changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 211dc58..d587e03 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -21,7 +21,7 @@ if USE_ION
+ libdmabufheap_la_CPPFLAGS +=  -DUSE_ION
+ endif
+ libdmabufheap_la_CPPFLAGS +=  @LIBION_CFLAGS@
+-libdmabufheap_la_LDFLAGS :=  @LIBION_LIBS@
++libdmabufheap_la_LDFLAGS :=  @LIBION_LIBS@ -version-info $(subst .,:, $(PACKAGE_VERSION))
+ 
+ # Export headers
+ dmabufheap_includedir=$(includedir)/BufferAllocator
+diff --git a/configure.ac b/configure.ac
+index f96dd56..806b6be 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1,5 +1,5 @@
+ AC_PREREQ(2.61)
+-AC_INIT([libdmabufheap],1.0.0)
++AC_INIT([libdmabufheap],0.0.0)
+ AM_INIT_AUTOMAKE([-Wall gnu foreign])
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_HEADERS([config.h])
+@@ -40,4 +40,3 @@ AC_CONFIG_FILES([ \
+     libdmabufheap.pc
+ ])
+ AC_OUTPUT
+-
+-- 
+2.43.0
+

--- a/alarm/qcom-libdmabufheap/PKGBUILD
+++ b/alarm/qcom-libdmabufheap/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Xilin Wu <sophon@radxa.com>
+# Upstream: https://git.codelinaro.org/clo/le/platform/system/memory/libdmabufheap
+
+pkgname=qcom-libdmabufheap
+pkgver=1.1.0
+pkgrel=2
+pkgdesc="Qualcomm dmabuf heap allocator library (originated from Android)"
+arch=('aarch64')
+url="https://git.codelinaro.org/clo/le/platform/system/memory/libdmabufheap"
+license=('BSD-3-Clause-Clear')
+depends=('glibc')
+makedepends=('git' 'autoconf' 'automake' 'libtool' 'pkg-config' 'linux-api-headers')
+install=qcom-libdmabufheap.install
+source=("git+https://gitea.classfun.cn:4443/mirrors/libdmabufheap.git#commit=42ee7943f7ea71588dea3a507fd0e13b7230e472"
+        "0001-libdmabufheap-Update-generated-libs-version.patch")
+sha256sums=('SKIP' 'SKIP')
+
+prepare() {
+  cd libdmabufheap
+  git reset --hard HEAD
+  git clean -fd
+  patch -Np1 -i "$srcdir/0001-libdmabufheap-Update-generated-libs-version.patch"
+  autoreconf -fi
+}
+
+build() {
+  cd libdmabufheap
+  ./configure \
+    --prefix=/usr \
+    --disable-static
+  make
+}
+
+package() {
+  cd libdmabufheap
+  make DESTDIR="$pkgdir" install
+
+  # udev rules for dma_heap device permissions
+  install -Dm644 scripts/udev-rules/99-dma-heap-permissions.rules \
+    "$pkgdir/usr/lib/udev/rules.d/99-dma-heap-permissions.rules"
+
+  # Remove libtool archives
+  rm -f "$pkgdir"/usr/lib/*.la "$pkgdir"/usr/lib/*.a
+}

--- a/alarm/qcom-libdmabufheap/qcom-libdmabufheap.install
+++ b/alarm/qcom-libdmabufheap/qcom-libdmabufheap.install
@@ -1,0 +1,15 @@
+post_install() {
+  systemd-sysusers
+  udevadm control --reload-rules
+  udevadm trigger --subsystem-match=dma_heap
+
+  echo ""
+  echo ">>> To use camera and fastrpc as a regular user, add yourself to the 'kmem' group:"
+  echo ">>>   sudo usermod -aG kmem \$USER"
+  echo ">>> Then log out and log back in for the change to take effect."
+  echo ""
+}
+
+post_upgrade() {
+  post_install
+}

--- a/aur/qbootctl/PKGBUILD
+++ b/aur/qbootctl/PKGBUILD
@@ -1,0 +1,41 @@
+# Maintainer: taotieren <admin@taotieren.com>
+
+pkgname=qbootctl
+pkgver=0.2.2
+pkgrel=1
+epoch=
+pkgdesc="Qualcomm bootctl HAL for Linux."
+arch=($CARCH)
+url="https://github.com/linux-msm/qbootctl"
+license=('GPL-3.0-or-later')
+groups=()
+depends=(glibc)
+makedepends=(
+    meson
+    ninja)
+checkdepends=()
+optdepends=()
+provides=(${pkgname})
+conflicts=(${pkgname})
+replaces=()
+backup=()
+options=()
+install=
+changelog=
+source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/${pkgver}.tar.gz")
+noextract=()
+sha256sums=('e66b361f86fac413f6a96974b4045a1fbc385f9eb6cee7fa8a26e0ca77c74a51')
+#validpgpkeys=()
+
+build() {
+    arch-meson ${pkgname}-${pkgver} build
+    ninja -C build
+}
+
+# check() {
+#     meson test -C ${srcdir}/build
+# }
+
+package() {
+    DESTDIR="${pkgdir}" ninja -C ${srcdir}/build install
+}


### PR DESCRIPTION
Qbootctl very important tool for switching A/B slots on Qualcomm SOCs in linux.

qcom-adreno-opencl-bin is proprietary Qualcomm OpenCL driver for Adreno GPUs