### PR TITLE
Drop base groups

### DIFF
--- a/core/archlinuxarm-keyring/PKGBUILD
+++ b/core/archlinuxarm-keyring/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=archlinuxarm-keyring
 pkgver=20240419
-pkgrel=1
+pkgrel=2
 pkgdesc='Arch Linux ARM PGP keyring'
 arch=('any')
 url='http://archlinuxarm.org'
 license=('GPL')
-groups=('base-devel')
 install="${pkgname}.install"
 depends=('pacman')
 source=('archlinuxarm'{.gpg,-trusted,-revoked})

--- a/core/pacman-mirrorlist/PKGBUILD
+++ b/core/pacman-mirrorlist/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=pacman-mirrorlist
 pkgver=20251026
-pkgrel=1
+pkgrel=2
 pkgdesc="Arch Linux ARM mirror list for use by pacman"
 arch=('any')
 url="https://www.archlinuxarm.org/about/mirrors"
 license=('GPL')
-groups=('base')
 backup=(etc/pacman.d/mirrorlist)
 source=(mirrorlist)
 md5sums=('b19510dc6a32fe6b58b545f63ba06703')


### PR DESCRIPTION
Note: I don't know how the main image is built (`ArchLinuxARM-aarch64-latest.tar.gz` typically) so maybe this requires changes elsewhere to make sure the dependencies are appropriately pulled.