### PR TITLE
added alarm/stubble-git

### DIFF
--- a/alarm/stubble-git/PKGBUILD
+++ b/alarm/stubble-git/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Abel Vesa <abelvesa@gmail.com>
+
+pkgname=stubble-git
+pkgver=9.2.g765b1f3
+_pkgver=9.0
+pkgrel=1
+pkgdesc="Minimal UEFI kernel boot stub for selecting machine specific devicetree blobs"
+arch=('aarch64')
+license=('LGPL-2.1-only')
+depends=('python-pyelftools' 'systemd-ukify')
+makedepends=('git')
+source=("git+https://github.com/ubuntu/stubble.git")
+sha512sums=('SKIP')
+options=(!buildflags)
+provides=('stubble')
+conflicts=('stubble')
+
+pkgver() {
+	cd "$srcdir/stubble"
+
+	git describe --tags --long --always | sed 's/^v//;s/-/./g'
+}
+
+build() {
+	cd "$srcdir/stubble"
+
+	make -j$(nproc)
+}
+
+package() {
+	cd "$srcdir/stubble"
+
+	make DESTDIR="$pkgdir" PREFIX=/usr install
+}


### PR DESCRIPTION
Stubble is a minimal UEFI kernel boot stub that generates hwids of the 
running machine derived from smbios, compares them to an embedded 
lookup table in the .hwids section of the kernel image, and then selects
the machine specific devicetree blob from the .dtbauto section of the
same kernel image.