### PR TITLE
qt6-base-headless: fix package() failure and clean up patches

### DIFF
--- a/aur/qt6-base-headless/PKGBUILD
+++ b/aur/qt6-base-headless/PKGBUILD
@@ -13,7 +13,7 @@
 
 pkgname=qt6-base-headless
 pkgver=6.11.0
-pkgrel=1
+pkgrel=1.1
 arch=(x86_64)
 url='https://www.qt.io'
 license=(GPL-3.0-only
@@ -53,7 +53,6 @@ sha256sums=('2223c075e95d86f8dbf6395b025a74d996c418f094453c903290e3c2663fbed2'
 prepare() {
   patch -d $_pkgfn -p1 < qt6-base-cflags.patch # Use system CFLAGS
   patch -d $_pkgfn -p1 < qt6-base-nostrip.patch # Don't strip binaries with qmake
-  git -C $_pkgfn cherry-pick -n a374ab6ce9f01f1f559403ec377cde990a689890 # Fix yakuake
 }
 
 build() {
@@ -98,11 +97,4 @@ package() {
   DESTDIR="$pkgdir" cmake --install build
 
   install -Dm644 $_pkgfn/LICENSES/* -t "$pkgdir"/usr/share/licenses/$pkgbase
-
-# Install symlinks for user-facing tools
-  cd "$pkgdir"
-  mkdir usr/bin
-  while read _line; do
-    ln -s $_line
-  done < "$srcdir"/build/user_facing_tool_links.txt
 }


### PR DESCRIPTION
Fix build failure caused by mkdir usr/bin, which now conflicts with cmake --install creating the directory.

Remove obsolete user-facing tool symlink step and drop outdated yakuake cherry-pick to align with AUR packaging.

Refs:
https://aur.archlinux.org/cgit/aur.git/commit/?h=qt6-base-headless&id=bd1273c5a146acf4916decacfc0b393aeb369050 https://aur.archlinux.org/cgit/aur.git/commit/?h=qt6-base-headless&id=912089a0b97270ffc6abb1e0cbf95837b52f529a