### PR TITLE
alarm/wiringpi to 3.18

### DIFF
--- a/alarm/wiringpi/PKGBUILD
+++ b/alarm/wiringpi/PKGBUILD
@@ -3,29 +3,23 @@
 
 pkgname=wiringpi
 _pkgname=WiringPi
-pkgver=181.1ad03dd
+epoch=1
+pkgver=3.18
 pkgrel=1
 pkgdesc='GPIO Interface library for the Raspberry Pi'
 arch=('armv7h' 'aarch64')
-makedepends=('git')
 license=('LGPL3')
 url='https://github.com/WiringPi/WiringPi.git'
-source=("git+https://github.com/WiringPi/WiringPi.git")
+source=("$_pkgname-$pkgver.tar.gz::https://github.com/WiringPi/WiringPi/archive/$pkgver.tar.gz")
 md5sums=('SKIP')
 
-pkgver() {
-  cd ${_pkgname}
-  echo $(git rev-list --count master).$(git rev-parse --short master)
-}
-
 prepare() {
-  cd ${_pkgname}
-  sed -i 's|/usr/local/bin/gpio|/usr/bin/gpio|' wiringPi/wiringPi.c
-  VERSION=$(cat VERSION)
+  mv ${_pkgname}-${pkgver} ${_pkgname}
 }
 
 build() {
   cd ${_pkgname}
+  VERSION=$(cat VERSION)
 
   make -C wiringPi all
   make -C devLib all INCLUDE+="-I${srcdir}/${_pkgname}/wiringPi"
@@ -39,6 +33,7 @@ build() {
 
 package(){
   cd ${_pkgname}
+  VERSION=$(cat VERSION)
 
   make LDCONFIG= PREFIX= DESTDIR="${pkgdir}/usr" -C wiringPi install
   make LDCONFIG= PREFIX= DESTDIR="${pkgdir}/usr" -C devLib install
@@ -46,4 +41,8 @@ package(){
   make PREFIX= DESTDIR="${pkgdir}/usr" WIRINGPI_SUID=1 -C gpio install
   install -m0755 wiringPiD/wiringpid "${pkgdir}/usr/bin"
   install -Dm644 COPYING.LESSER "$pkgdir/usr/share/licenses/$pkgname/COPYING.LESSER"
+
+  # Upstream's "make install" generates broken symlinks
+  ln -sf "libwiringPi.so.${VERSION}" "$pkgdir/usr/lib/libwiringPi.so"
+  ln -sf "libwiringPiDev.so.${VERSION}" "$pkgdir/usr/lib/libwiringPiDev.so"
 }


### PR DESCRIPTION
Upstream has started making versioned releases.

Also fixed broken symlinks.