### PR TITLE
linux-aarch64: install vmlinuz and pkgbase into the modules directory

### DIFF
--- a/core/linux-aarch64/PKGBUILD
+++ b/core/linux-aarch64/PKGBUILD
@@ -96,6 +96,13 @@ _package() {
   install -Dm644 arch/arm64/boot/Image{,.gz} -t "${pkgdir}/boot"
   make INSTALL_DTBS_PATH="${pkgdir}/boot/dtbs" dtbs_install
 
+  # systemd expects to find the kernel here to allow hibernation, and the
+  # mkinitcpio pacman hook triggers on usr/lib/modules/*/vmlinuz.
+  install -Dm644 arch/arm64/boot/Image "$modulesdir/vmlinuz"
+
+  # Used by mkinitcpio to name the kernel
+  echo "$pkgbase" | install -Dm644 /dev/stdin "$modulesdir/pkgbase"
+
   echo "Installing modules..."
   make INSTALL_MOD_PATH="$pkgdir/usr" INSTALL_MOD_STRIP=1 DEPMOD=/doesnt/exist modules_install
 


### PR DESCRIPTION
`linux-rpi` in this repository already installs `pkgbase`; this brings `linux-aarch64` in line
with it, and adds the `vmlinuz` file that goes with it.

Arch's `linux` package installs both into `usr/lib/modules/<version>/`:

```bash
install -Dm644 "$(make -s image_name)" "$modulesdir/vmlinuz"
echo "$pkgbase" | install -Dm644 /dev/stdin "$modulesdir/pkgbase"
```

## Why this should be merged

mkinitcpio's pacman hook depends on both files:

- `/usr/share/libalpm/hooks/90-mkinitcpio-install.hook` triggers on `usr/lib/modules/*/vmlinuz`
- `/usr/share/libalpm/scripts/mkinitcpio` then reads the sibling `pkgbase` to learn the kernel
  name (`read -r pkgbase < "${line%/vmlinuz}/pkgbase"`)

With neither present the hook never fires, so **installing or upgrading `linux-aarch64`
generates no initramfs at all**, and bootloader integrations that discover kernels this way find
nothing.

The failure is silent — nothing is logged and the transaction succeeds. The observable result is
an installed system with no initramfs, no unified kernel image, and a bootloader configuration
containing no entries.

The image installed is the same file already going to `/boot`: `arch/arm64/boot/Image`, which is
what `make -s image_name` resolves to here. `pkgrel` incremented per CONTRIBUTING.md.

## Verification

Traced on 7.2-1 by staging both files into a pacstrapped root and invoking the hook script the
way pacman does:

```
$ cd / && echo "usr/lib/modules/$KV/vmlinuz" | /usr/share/libalpm/scripts/mkinitcpio install
==> Initcpio image generation successful
==> Creating unified kernel image: '.../linux-aarch64.efi'
==> Unified kernel image generation successful
    Updated: /boot/limine.conf
```

Without them, `bash -x` shows the script reaching `read -r pkgbase` and `continue`ing, having
done nothing.

Separately, a fresh `pacstrap` of `base linux-aarch64 mkinitcpio mkinitcpio-archiso` yields
`/boot` containing only `Image`, `Image.gz` and `dtbs` — no initramfs. Installing a package that
provides just these two files causes the hook to fire and produce
`/boot/initramfs-linux.img`.

A clean-chroot package build on aarch64 hardware is in progress; I will report the result here
rather than claim it before it finishes.
