### PR TITLE
uboot-raspberrypi: move load addresses clear of the kernel (linux-aarch64 7.2.4 no longer fits)

### DIFF
--- a/alarm/uboot-raspberrypi/0001-rpi-increase-space-for-kernel.patch
+++ b/alarm/uboot-raspberrypi/0001-rpi-increase-space-for-kernel.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] rpi: increase space for kernel
 
 Signed-off-by: Kevin Mihelich <kevin@archlinuxarm.org>
 ---
- board/raspberrypi/rpi/rpi.env | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
+ board/raspberrypi/rpi/rpi.env | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/board/raspberrypi/rpi/rpi.env b/board/raspberrypi/rpi/rpi.env
 index 3022828..836c510 100644
@@ -15,15 +15,16 @@ index 3022828..836c510 100644
 @@ -69,9 +69,9 @@ fdt_high=ffffffff
  initrd_high=ffffffff
  #endif
- kernel_addr_r=0x00080000
+-kernel_addr_r=0x00080000
 -scriptaddr=0x02400000
 -pxefile_addr_r=0x02500000
 -fdt_addr_r=0x02600000
 -ramdisk_addr_r=0x02700000
++kernel_addr_r=0x04000000
 +scriptaddr=0x02C00000
 +pxefile_addr_r=0x02D00000
-+fdt_addr_r=0x03000000
-+ramdisk_addr_r=0x03100000
++fdt_addr_r=0x0A000000
++ramdisk_addr_r=0x0C000000
 
  boot_targets=mmc usb pxe dhcp
 --

--- a/alarm/uboot-raspberrypi/PKGBUILD
+++ b/alarm/uboot-raspberrypi/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=uboot-raspberrypi
 pkgver=2025.01
-pkgrel=1
+pkgrel=2
 pkgdesc="U-Boot for Raspberry Pi"
 arch=('armv7h' 'aarch64')
 url='https://docs.u-boot.org/en/latest'
@@ -84,7 +84,7 @@ md5sums=('eae6d6ed62c30dd516e6f46b272553e8'
          '8036ecf8bdc3e174ed6dcc6d1711716f'
          '051a6d4fa0c903c7d39ad530c1796f3e'
          'eff27a37a8e4a96fe660970b07a37b2c'
-         '636c8ac2098ebf0acdc2ff15430edf0d'
+         '8f29b30a9d5850b9e77e20ee428185ee'
          'a63d6cde8e45c00075e0df23ff71a0f4'
          'f8ad4508b9734e9e13aedb9f7419d7a3'
          'be8abe44b86d63428d7ac3acc64ee3bf'


### PR DESCRIPTION
Issues are disabled on this repo, so the bug report and the proposed fix are both here.

## Problem

`linux-aarch64` 7.2.4-1 ships a 48.3 MiB `Image`. Loaded at the packaged `kernel_addr_r` of `0x00080000` it spans up to `0x030D4A00`, which runs over both `scriptaddr` (`0x02C00000`) and `fdt_addr_r` (`0x03000000`). `boot.scr` then loads the DTB into the tail of the kernel it just loaded, and the board does not boot.

Load addresses currently produced by `0001-rpi-increase-space-for-kernel.patch`, read back from the installed `kernel8.img`:

```
kernel_addr_r  = 0x00080000    (  0.5 MiB)
scriptaddr     = 0x02C00000    ( 44   MiB)
pxefile_addr_r = 0x02D00000    ( 45   MiB)
fdt_addr_r     = 0x03000000    ( 48   MiB)
ramdisk_addr_r = 0x03100000    ( 49   MiB)
```

Kernel `Image` sizes, from the packages in `/var/cache/pacman/pkg`:

| package | Image size | occupies from `kernel_addr_r` | verdict |
|---|---|---|---|
| linux-aarch64 7.2-2 | 44444160 B (42.4 MiB) | 0x00080000 – 0x02A60000 | fits |
| linux-aarch64 7.2.3-2 | 44509696 B (42.4 MiB) | 0x00080000 – 0x02A70000 | fits |
| **linux-aarch64 7.2.4-1** | **50678272 B (48.3 MiB)** | **0x00080000 – 0x030D4A00** | **overruns `scriptaddr` and `fdt_addr_r`** |

The ceiling is `scriptaddr - kernel_addr_r` = `0x02C00000 - 0x00080000` = 45613056 B = **43.5 MiB**. 7.2.4-1 exceeds it by 4.8 MiB. 7.2.3-2 cleared it by about 1 MiB, so this should reproduce on any aarch64 RPi install that upgrades past 7.2.3-2 and boots via the packaged `boot.scr`.

Worth noting `ramdisk_addr_r` (`0x03100000`) currently sits only 177664 bytes above the end of the 7.2.4 kernel, so the initramfs load is next in line regardless.

## Why not another 8 MiB bump

This is the second lap. `0001-rpi-increase-space-for-kernel.patch` already moved everything except the kernel up by 8 MiB (`scriptaddr` `0x02400000` → `0x02C00000`) to absorb the 2023 arm64 kernel growth that also broke Debian's `u-boot-rpi` (Debian #1033301). That headroom is now spent, and another fixed bump just schedules lap three.

## This PR

Moves the kernel to `0x04000000` and the DTB and ramdisk above it, leaving `scriptaddr` and `pxefile_addr_r` where they are:

```
kernel_addr_r=0x04000000
scriptaddr=0x02C00000       (unchanged, now permanently below the kernel)
pxefile_addr_r=0x02D00000   (unchanged, likewise)
fdt_addr_r=0x0A000000
ramdisk_addr_r=0x0C000000
```

That gives 96 MiB of kernel headroom instead of 43.5 MiB, and puts the script and pxefile buffers below the kernel where kernel growth cannot reach them at all. Everything stays far inside the ~700 MB lowmem window that `rpi.env`'s own comment describes, and the lowest-RAM board supported here (Pi Zero 2 W, 512 MB) has plenty of room.

`pkgrel` bumped to 2 and the patch md5sum updated.

## Testing

Confirmed on a Raspberry Pi 4 Model B Rev 1.4 (8 GB) running `linux-aarch64` 7.2.4-1:

- stock addresses: does not boot
- with **exactly the values in this patch** applied via `setenv` in `/boot/boot.txt` + `./mkscr`: boots normally, currently up and running 7.2.4-1

The patch also applies cleanly to u-boot v2025.01.

To be clear about what I have **not** tested: I overrode the addresses from `boot.txt` rather than rebuilding the package, so the relocated `scriptaddr`/`pxefile_addr_r` path in a rebuilt U-Boot binary is untested, as is the `armv7h` build and every board other than the Pi 4B. Fresh eyes on those would be welcome.

## Alternative shape

If you would rather keep `kernel_addr_r` at `0x00080000` and stay closer to upstream, moving the other four to `0x08000000`+ achieves the same decoupling with a smaller conceptual delta. I picked the layout above because it is the one I could actually boot-test. Happy to reshape this however you prefer, including re-authoring the patch header rather than editing Kevin's in place.

## Environment

- Raspberry Pi 4 Model B Rev 1.4, 8 GB (`MemTotal: 7971284 kB`)
- uboot-raspberrypi 2025.01-1
- linux-aarch64 7.2.4-1 (broken), 7.2.3-2 (last working)
- Boot chain: RPi firmware → `kernel8.img` (U-Boot) → `boot.scr` → `Image` + `dtbs/broadcom/bcm2711-rpi-4-b.dtb` + `initramfs-linux.img`
